### PR TITLE
chore(action): add branch sanitze action

### DIFF
--- a/sanitize-branch-name/README.md
+++ b/sanitize-branch-name/README.md
@@ -1,0 +1,34 @@
+# sanitize-branch-name
+
+This composite Github Action (GHA) is supposed to be used by other teams inside Camunda and mostly targeted at [preview environments](https://confluence.camunda.com/display/HAN/Preview+Environments). It's a highly opiniated function derived from its [groovy equivalent](https://github.com/camunda/jenkins-global-shared-library/blob/master/src/org/camunda/helper/GitUtilities.groovy#L4-L10).
+
+## Usage
+
+This composite GHA can be used in any repository.
+
+The resulting branch name will be converted to lowercase, remove `dependabot/` and `renovate/` and transform any non numeric and alphanumeric characters to `-`.
+
+### Inputs
+| Input name           | Description                                        |
+|----------------------|----------------------------------------------------|
+| branch               | the branch name to be sanitized |
+| max_length           | max length to cut the branch name at |
+
+### Workflow Example
+```yaml
+---
+name: example
+on: 
+  pull_request:
+jobs:
+  trigger-branch-deployment:
+    runs-on: ubuntu-latest
+
+    steps:
+      - id: sanitize
+        uses: camunda/infra-global-github-actions/sanitize-branch-name@main
+        with:
+          branch: ${{ github.head_ref }}
+          max_length: '50'
+      - run: echo ${{ steps.sanitize.outputs.branch_name }}
+```

--- a/sanitize-branch-name/action.yml
+++ b/sanitize-branch-name/action.yml
@@ -1,0 +1,33 @@
+---
+name: Sanitize Branch Name
+
+description: Sanitizes a branch name based on opiniated rules
+
+inputs:
+  branch:
+    description: 'Name of the branch'
+    required: true
+  max_length:
+    description: 'Max lenght where to cut the string at'
+    default: '0'
+outputs:
+  branch_name:
+    description: "Sanitized Branch Name"
+    value: ${{ steps.sanitize.outputs.branch_name }}
+
+runs:
+  using: composite
+  steps:
+  - name: Echo inputs
+    shell: bash
+    run: |
+      echo "Inputs"
+      echo "-----"
+      echo "Branch Name: ${{ inputs.branch }}"
+      echo "Max Length: ${{ inputs.max_length }}"
+
+  - name: Sanitize the branch name
+    id: sanitize
+    shell: bash
+    run: |
+      echo "::set-output name=branch_name::$(${{ github.action_path }}/sanitize.sh ${{ inputs.branch }} ${{ inputs.max_length }})"

--- a/sanitize-branch-name/sanitize.sh
+++ b/sanitize-branch-name/sanitize.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -eu
+
+# this function is derived from its groovy equivalent
+# https://github.com/camunda/jenkins-global-shared-library/blob/master/src/org/camunda/helper/GitUtilities.groovy#L4-L10
+
+# $1 = branch name
+# $2 = max length
+
+BRANCH=$(echo $1 | tr '[:upper:]' '[:lower:]') # make the branch input lowercase
+BRANCH=$(echo ${BRANCH//dependabot\//}) # removes all dependabot/ in a string
+BRANCH=$(echo ${BRANCH//renovate\//}) # removes all renovate/ in a string
+BRANCH=$(echo ${BRANCH//[^a-z0-9]/-}) # replaces anything not a-z0-9 with -
+MAX_LENGTH=$2
+
+if [[ $MAX_LENGTH -eq 0 ]];
+then
+    echo ${BRANCH}
+else
+    echo ${BRANCH:0:MAX_LENGTH}
+fi


### PR DESCRIPTION
based on the [global shared equivalent](https://github.com/camunda/jenkins-global-shared-library/blob/master/src/org/camunda/helper/GitUtilities.groovy#L4-L10).

removes `dependabot/`, `renovate/`,puts to lowercase, transforms anything not `a-z0-9` to `-` and cuts at a specified length or returns the whole string.

Decided for this approach as I will have to use it a couple of times in different repositories and don't intend to copy & paste it every time.

Test see here --> https://github.com/camunda/infra-test-3375/actions/runs/3043925402/jobs/4903735199

related to camunda/team-infrastructure#28