### PR TITLE
chore(sanitize): remove -deploy from branch names

### DIFF
--- a/sanitize-branch-name/sanitize.sh
+++ b/sanitize-branch-name/sanitize.sh
@@ -11,6 +11,7 @@ set -eu
 BRANCH=$(echo $1 | tr '[:upper:]' '[:lower:]') # make the branch input lowercase
 BRANCH=$(echo ${BRANCH//dependabot\//}) # removes all dependabot/ in a string
 BRANCH=$(echo ${BRANCH//renovate\//}) # removes all renovate/ in a string
+BRANCH=$(echo ${BRANCH/-deploy/}) # removes all -deploy in a string
 BRANCH=$(echo ${BRANCH//[^a-z0-9]/-}) # replaces anything not a-z0-9 with -
 MAX_LENGTH=$2
 


### PR DESCRIPTION
related to cawemo / web-modeler change.
Required as otherwise their branch names are too long, due to sticking to previous `-deploy` name.

related to camunda/team-infrastructure#28