### PR TITLE
chore(actions): introduce new kubernetes image replace action + adjust docker build

### DIFF
--- a/build-docker-image/README.md
+++ b/build-docker-image/README.md
@@ -16,6 +16,7 @@ This composite GHA can be used in any non-public repository with a `Dockerfile` 
 | image_name        | Docker image name (*without* registry and Docker tag), e.g. `example/image` |
 | build_args        | Allows defining extra build-args, supply as list with \| (pipe bar) |
 | extra_tags        | Allows defining extra tags according to the [metadata action](https://github.com/docker/metadata-action), supply as list with \| (pipe bar) |
+| force_push        | Allows overwriting the image push behaviour, by setting to 'true' as input |
 
 For the above example inputs the resulting Docker image would be named `gcr.io/example/image`.
 

--- a/build-docker-image/README.md
+++ b/build-docker-image/README.md
@@ -14,10 +14,20 @@ This composite GHA can be used in any non-public repository with a `Dockerfile` 
 | registry_username | Username used for authenticating to registry host  |
 | registry_password | Password used for authenticating to registry host  |
 | image_name        | Docker image name (*without* registry and Docker tag), e.g. `example/image` |
+| build_args        | Allows defining extra build-args, supply as list with \| (pipe bar) |
+| extra_tags        | Allows defining extra tags according to the [metadata action](https://github.com/docker/metadata-action), supply as list with \| (pipe bar) |
 
 For the above example inputs the resulting Docker image would be named `gcr.io/example/image`.
 
 Please check out Camunda's [Github Actions Recipes](https://github.com/camunda/github-actions-recipes#secrets=) for how to retrieve secrets from Vault.
+
+### Outputs
+| Output name        | Description                                        |
+|--------------------|----------------------------------------------------|
+| image_digest       | The image digest (sha256) of the pushed image      |
+| image_metadata     | The json metadata object of the pushed image, according to the [docker-push action](https://github.com/docker/build-push-action). This can often not be set as additional output for other jobs within a workflow      |
+| images             | The "images.name" value from metadata. This is a comma separated string of image:tag |
+| pushed             | The decission whether the image was pushed or not, can be "true" or "false |
 
 ### Behavior
 

--- a/build-docker-image/action.yml
+++ b/build-docker-image/action.yml
@@ -22,6 +22,10 @@ inputs:
   extra_tags:
     description: Extra tags that the image should get
     required: false
+  force_push:
+    description: Allow overwriting the push behaviour by setting it to 'true'
+    required: false
+    default: 'false'
 
 outputs:
   image_digest:
@@ -82,7 +86,7 @@ runs:
     id: check-push
     shell: bash
     run: |
-      echo "SHOULD_WE_PUSH=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || startsWith(github.ref, 'refs/tags/') || endsWith(github.ref, '-push') }}" | tee -a "$GITHUB_ENV" "$GITHUB_OUTPUT"
+      echo "SHOULD_WE_PUSH=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || startsWith(github.ref, 'refs/tags/') || endsWith(github.ref, '-push') || inputs.force_push == 'true' }}" | tee -a "$GITHUB_ENV" "$GITHUB_OUTPUT"
 
   - name: Set up Docker Buildx
     uses: docker/setup-buildx-action@v2

--- a/build-docker-image/action.yml
+++ b/build-docker-image/action.yml
@@ -19,6 +19,23 @@ inputs:
   build_args:
     description: Docker build args to append to `docker build` command.
     required: false
+  extra_tags:
+    description: Extra tags that the image should get
+    required: false
+
+outputs:
+  image_digest:
+    description: The image digest (sha256)
+    value: ${{ steps.build-push.outputs.digest }}
+  image_metadata:
+    description:  The metedata output of the docker build and push action
+    value: ${{ steps.build-push.outputs.metadata }}
+  images: # metedata can often not be passed between jobs, therefore provide the image names on top
+    description: Comma separated string of images including their tags
+    value: ${{ steps.get-image-names.outputs.images }}
+  pushed:
+    description: The decision whether the image should be pushed or not
+    value: ${{ steps.check-push.outputs.SHOULD_WE_PUSH }}
 
 runs:
   using: composite
@@ -58,12 +75,14 @@ runs:
         type=ref,event=tag
         type=ref,event=pr
         type=raw,value=latest,enable={{is_default_branch}}
+        ${{ inputs.extra_tags }}
 
   # See README.md for explained cases when we push
   - name: Check whether we should push
+    id: check-push
     shell: bash
     run: |
-      echo "SHOULD_WE_PUSH=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || startsWith(github.ref, 'refs/tags/') || endsWith(github.ref, '-push') }}" >> "$GITHUB_ENV"
+      echo "SHOULD_WE_PUSH=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || startsWith(github.ref, 'refs/tags/') || endsWith(github.ref, '-push') }}" | tee -a "$GITHUB_ENV" "$GITHUB_OUTPUT"
 
   - name: Set up Docker Buildx
     uses: docker/setup-buildx-action@v2
@@ -80,6 +99,7 @@ runs:
       password: ${{ inputs.registry_password }}
 
   - name: Build and push Docker image
+    id: build-push
     uses: docker/build-push-action@v3
     with:
       context: .
@@ -87,3 +107,8 @@ runs:
       push: ${{ env.SHOULD_WE_PUSH }}
       tags: ${{ steps.meta.outputs.tags }}
       labels: ${{ steps.meta.outputs.labels }}
+  - id: get-image-names
+    shell: bash
+    run: |
+      imageNames=${{ fromJSON(steps.build-push.outputs.metadata)['image.name'] }}
+      echo "images=$imageNames" >> "$GITHUB_OUTPUT"

--- a/kubernetes-image-replace/README.md
+++ b/kubernetes-image-replace/README.md
@@ -1,0 +1,50 @@
+# kubernetes-image-replace
+
+This composite Github Action (GHA) can be used to replace the image of a specified container within a deployment or statefulset. Alternatively, if the image is already present, it will just restart the pod.
+
+## Usage
+
+For the credentials, please reach out to the Infrastructure team.
+Requirements for the usage of this action is to have kubectl installed and authenticated already.
+
+```yaml
+---
+name: Deploy new Image to Cluster
+
+on:
+    push:
+
+jobs:
+  replace-kubernetes-image:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Import Secrets
+      id: secrets
+      uses: hashicorp/vault-action@v2.5.0
+      with:
+        url: ${{ secrets.VAULT_ADDR }}
+        method: approle
+        roleId: ${{ secrets.VAULT_ROLE_ID }}
+        secretId: ${{ secrets.VAULT_SECRET_ID }}
+        exportEnv: false
+        secrets: |
+          secret/data/SOME_PATH GCP_AUTH_CREDS | GCP_CREDENTIALS;
+    - uses: azure/setup-kubectl@v3
+    - name: GCloud Auth
+      id: auth
+      uses: google-github-actions/auth@v1
+      with:
+        credentials_json: '${{ steps.secrets.outputs.GCP_CREDENTIALS }}'
+    - id: get-credentials
+      uses: 'google-github-actions/get-gke-credentials@v1'
+      with:
+        cluster_name: camunda-ci
+        location: europe-west1-b
+    - uses: camunda/infra-global-github-actions/kubernetes-image-replace@main
+      with:
+        app_name: alert-int-camunda-com
+        app_type: statefulset
+        container_name: alertmanager
+        image: prom/alertmanager:v0.25.0
+        namespace: monitoring
+```

--- a/kubernetes-image-replace/README.md
+++ b/kubernetes-image-replace/README.md
@@ -39,7 +39,7 @@ jobs:
       uses: 'google-github-actions/get-gke-credentials@v1'
       with:
         cluster_name: camunda-ci
-        location: europe-west1-b
+        location: europe-west1
     - uses: camunda/infra-global-github-actions/kubernetes-image-replace@main
       with:
         app_name: alert-int-camunda-com

--- a/kubernetes-image-replace/action.yml
+++ b/kubernetes-image-replace/action.yml
@@ -1,0 +1,43 @@
+name: Kubernetes Image Tag Replace
+description: Changes the image tag of a specified deployment / statefulset
+inputs:
+  app_name:
+    description: The name of the deployment / statefulset
+    required: true
+  app_type:
+    description: Whether it's a deployment or statefulset
+    default: 'deployment'
+    required: false
+  image:
+    description: Full image with tag
+    required: true
+  container_name:
+    description: Name of the container to replace the image of
+    required: true
+  namespace:
+    description: Kubernetes namespace that the app is running in
+    required: true
+
+runs:
+  using: "composite"
+
+  steps:
+  - name: Check for available tools
+    shell: bash
+    run: |
+      command -v kubectl >/dev/null 2>&1 || { echo >&2 "kubectl is not installed.  Aborting."; exit 1; }
+  - name: Update image of app
+    shell: bash
+    run: |
+      # if setting the same image tag as present, restart the pod otherwise set new tag
+      if (kubectl get ${{ inputs.app_type }} ${{ inputs.app_name }} -n ${{ inputs.namespace }} -o yaml | grep -q ${{ inputs.image }});
+      then
+        echo "Restarting existing pod due to same image"
+        kubectl rollout restart ${{ inputs.app_type }} ${{ inputs.app_name }} -n ${{ inputs.namespace }}
+      else
+        echo "Setting new image for defined app"
+        kubectl set image ${{ inputs.app_type }} ${{ inputs.app_name }} ${{ inputs.container_name }}=${{ inputs.image }} -n ${{ inputs.namespace }} --record
+      fi
+
+       # wait for deployment to have finished
+      kubectl rollout status -w ${{ inputs.app_type }} ${{ inputs.app_name }} -n ${{ inputs.namespace }}

--- a/kubernetes-image-replace/action.yml
+++ b/kubernetes-image-replace/action.yml
@@ -36,7 +36,7 @@ runs:
         kubectl rollout restart ${{ inputs.app_type }} ${{ inputs.app_name }} -n ${{ inputs.namespace }}
       else
         echo "Setting new image for defined app"
-        kubectl set image ${{ inputs.app_type }} ${{ inputs.app_name }} ${{ inputs.container_name }}=${{ inputs.image }} -n ${{ inputs.namespace }} --record
+        kubectl set image ${{ inputs.app_type }} ${{ inputs.app_name }} ${{ inputs.container_name }}=${{ inputs.image }} -n ${{ inputs.namespace }}
       fi
 
        # wait for deployment to have finished


### PR DESCRIPTION
related to https://github.com/camunda/team-infrastructure/issues/150

Adds several backward-compatible adjustments to the `build-docker-image` action.
E.g. allows setting `extra-tags` or exposure of outputs, so you can further use them for other actions.

Added also a `force_push` option, see example run: https://github.com/camunda/int-airtable-loader/actions/runs/4125315864/jobs/7125706871 . Reasoning is that not everyone follows the tagging schema and it can be useful to "force" an image push.

Additionally creates an action that allows settings the image of a container within a deployment or statefulset.

Example usage for both changes:
https://github.com/camunda/int-airtable-loader/actions/runs/4124077850/jobs/7122889524

Metadata is sadly often excluded in GitHub Actions if set as output between jobs since "they may contain secrets" ...
That's why I introduced the extra output of `images` as that contains all `image:tag` that were pushed.