### PR TITLE
Add a new 'configure-pull-request' composite GitHub action

### DIFF
--- a/configure-pull-request/README.md
+++ b/configure-pull-request/README.md
@@ -9,7 +9,7 @@ This composite GHA can be used in any repository and must be triggered on `pull_
 ### Inputs
 | Input name           | Description                                               |
 |----------------------|-----------------------------------------------------------|
-| github-token         | A GitHub personal access token with sufficient scope (*) |
+| github-token         | A GitHub access token with sufficient scope (*) |
 | labels               | Comma-separated list of labels to set |
 | project-url          | URL of a GitHub project to which to add the PR |
 | reviewers            | Comma-separated list of users to set as reviewers |
@@ -32,7 +32,7 @@ jobs:
     steps:
     - uses: camunda/infra-global-github-actions/configure-pull-request@main
       with:
-        github-token: ${{ secrets.MY_PAT }}
+        github-token: ${{ secrets.A_GITHUB_TOKEN }}
         labels: label-1,label-2
         project-url: https://github.com/orgs/camunda/projects/project-id/
         reviewers: user1,user2

--- a/configure-pull-request/README.md
+++ b/configure-pull-request/README.md
@@ -1,0 +1,40 @@
+# configure-pull-request
+
+This composite Github Action (GHA) is aimed to be used by Camunda teams for configuring basic parameters of a GitHub Pull Request like labels, project and reviewers.
+
+## Usage
+
+This composite GHA can be used in any repository and must be triggered on `pull_request` events.
+
+### Inputs
+| Input name           | Description                                               |
+|----------------------|-----------------------------------------------------------|
+| github-token         | A GitHub personal access token with sufficient scope (*) |
+| labels               | Comma-separated list of labels to set |
+| project-url          | URL of a GitHub project to which to add the PR |
+| reviewers            | Comma-separated list of users to set as reviewers |
+| team-reviewers       | Comma-separated list of teams to set as reviewers |
+
+(*) minimum scope required:
+- repo
+- admin:org/read:org (required if `team-reviewers` input is set)
+- project (required if `project-url` input is set)
+
+### Workflow Example
+```yaml
+---
+name: example
+on:
+  pull_request:
+jobs:
+  configure-pr:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: camunda/infra-global-github-actions/configure-pull-request@main
+      with:
+        github-token: ${{ secrets.MY_PAT }}
+        labels: label-1,label-2
+        project-url: https://github.com/orgs/camunda/projects/project-id/
+        reviewsers: user1,user2
+        team-reviewers: team1,team2
+```

--- a/configure-pull-request/README.md
+++ b/configure-pull-request/README.md
@@ -35,6 +35,6 @@ jobs:
         github-token: ${{ secrets.MY_PAT }}
         labels: label-1,label-2
         project-url: https://github.com/orgs/camunda/projects/project-id/
-        reviewsers: user1,user2
+        reviewers: user1,user2
         team-reviewers: team1,team2
 ```

--- a/configure-pull-request/action.yml
+++ b/configure-pull-request/action.yml
@@ -4,7 +4,7 @@ description: Sets the parameters of an existing Pull Request at once
 
 inputs:
   github-token:
-    description: A GitHub personal access token with write access to the project
+    description: A GitHub access token with write access to the project
     required: true
   labels:
     description: Comma-separated list of labels

--- a/configure-pull-request/action.yml
+++ b/configure-pull-request/action.yml
@@ -1,0 +1,49 @@
+name: Configure Pull Request
+
+description: Sets the parameters of an existing Pull Request at once
+
+inputs:
+  github-token:
+    description: A GitHub personal access token with write access to the project
+    required: true
+  labels:
+    description: Comma-separated list of labels
+    required: false
+  project-url:
+    description: URL of a GitHub project
+    required: false
+  reviewers:
+    description: Comma-separated list of users
+    required: false
+  team-reviewers:
+    description: Comma-separated list of teams
+    required: false
+
+runs:
+  using: composite
+  steps:
+  - name: Set labels
+    uses: buildsville/add-remove-label@v2.0.0
+    with:
+      labels: ${{ inputs.labels }}
+      token: ${{ inputs.github-token }}
+      type: add
+    if: ${{ inputs.labels != '' }}
+  - name: Set project
+    uses: actions/add-to-project@v0.4.0
+    with:
+      github-token: ${{ inputs.github-token }}
+      project-url: ${{ inputs.project-url }}
+    if: ${{ inputs.project-url != '' }}
+  - name: Set reviewers (users)
+    uses: dannysauer/actions-assigner@v2.0.1
+    with:
+      reviewers: ${{ inputs.reviewers }}
+      token: ${{ inputs.github-token }}
+    if: ${{ inputs.reviewers != '' }}
+  - name: Set reviewers (teams)
+    uses: dannysauer/actions-assigner@v2.0.1
+    with:
+      team-reviewers: ${{ inputs.team-reviewers }}
+      token: ${{ inputs.github-token }}
+    if: ${{ inputs.team-reviewers != '' }}

--- a/configure-pull-request/action.yml
+++ b/configure-pull-request/action.yml
@@ -23,27 +23,27 @@ runs:
   using: composite
   steps:
     - name: Set labels
+      if: ${{ inputs.labels != '' }}
       uses: buildsville/add-remove-label@eeae411a9be2e173f2420e1644514edbecc4e835 # pin@v2.0.0
       with:
         labels: ${{ inputs.labels }}
         token: ${{ inputs.github-token }}
         type: add
-      if: ${{ inputs.labels != '' }}
     - name: Set project
+      if: ${{ inputs.project-url != '' }}
       uses: actions/add-to-project@960fbad431afda394cfcf8743445e741acd19e85 # pin@v0.4.0
       with:
         github-token: ${{ inputs.github-token }}
         project-url: ${{ inputs.project-url }}
-      if: ${{ inputs.project-url != '' }}
     - name: Set reviewers (users)
+      if: ${{ inputs.reviewers != '' }}
       uses: dannysauer/actions-assigner@ca2ca780928294ee5126986cc31db6c2ee7d69b0 # pin@v2.0.1
       with:
         reviewers: ${{ inputs.reviewers }}
         token: ${{ inputs.github-token }}
-      if: ${{ inputs.reviewers != '' }}
     - name: Set reviewers (teams)
+      if: ${{ inputs.team-reviewers != '' }}
       uses: dannysauer/actions-assigner@ca2ca780928294ee5126986cc31db6c2ee7d69b0 # pin@v2.0.1
       with:
         team-reviewers: ${{ inputs.team-reviewers }}
         token: ${{ inputs.github-token }}
-      if: ${{ inputs.team-reviewers != '' }}

--- a/configure-pull-request/action.yml
+++ b/configure-pull-request/action.yml
@@ -29,26 +29,26 @@ runs:
   steps:
     - name: Set labels
       if: ${{ inputs.labels != '' }}
-      uses: buildsville/add-remove-label@eeae411a9be2e173f2420e1644514edbecc4e835 # pin@v2.0.0
+      uses: buildsville/add-remove-label@v2.0.0
       with:
         labels: ${{ inputs.labels }}
         token: ${{ inputs.github-token }}
         type: add
     - name: Set project
       if: ${{ inputs.project-url != '' }}
-      uses: actions/add-to-project@960fbad431afda394cfcf8743445e741acd19e85 # pin@v0.4.0
+      uses: actions/add-to-project@v0.4.0
       with:
         github-token: ${{ inputs.github-token }}
         project-url: ${{ inputs.project-url }}
     - name: Set reviewers (users)
       if: ${{ inputs.reviewers != '' }}
-      uses: dannysauer/actions-assigner@ca2ca780928294ee5126986cc31db6c2ee7d69b0 # pin@v2.0.1
+      uses: dannysauer/actions-assigner@v2.0.1
       with:
         reviewers: ${{ inputs.reviewers }}
         token: ${{ inputs.github-token }}
     - name: Set reviewers (teams)
       if: ${{ inputs.team-reviewers != '' }}
-      uses: dannysauer/actions-assigner@ca2ca780928294ee5126986cc31db6c2ee7d69b0 # pin@v2.0.1
+      uses: dannysauer/actions-assigner@v2.0.1
       with:
         team-reviewers: ${{ inputs.team-reviewers }}
         token: ${{ inputs.github-token }}

--- a/configure-pull-request/action.yml
+++ b/configure-pull-request/action.yml
@@ -22,28 +22,28 @@ inputs:
 runs:
   using: composite
   steps:
-  - name: Set labels
-    uses: buildsville/add-remove-label@v2.0.0
-    with:
-      labels: ${{ inputs.labels }}
-      token: ${{ inputs.github-token }}
-      type: add
-    if: ${{ inputs.labels != '' }}
-  - name: Set project
-    uses: actions/add-to-project@v0.4.0
-    with:
-      github-token: ${{ inputs.github-token }}
-      project-url: ${{ inputs.project-url }}
-    if: ${{ inputs.project-url != '' }}
-  - name: Set reviewers (users)
-    uses: dannysauer/actions-assigner@v2.0.1
-    with:
-      reviewers: ${{ inputs.reviewers }}
-      token: ${{ inputs.github-token }}
-    if: ${{ inputs.reviewers != '' }}
-  - name: Set reviewers (teams)
-    uses: dannysauer/actions-assigner@v2.0.1
-    with:
-      team-reviewers: ${{ inputs.team-reviewers }}
-      token: ${{ inputs.github-token }}
-    if: ${{ inputs.team-reviewers != '' }}
+    - name: Set labels
+      uses: buildsville/add-remove-label@eeae411a9be2e173f2420e1644514edbecc4e835 # pin@v2.0.0
+      with:
+        labels: ${{ inputs.labels }}
+        token: ${{ inputs.github-token }}
+        type: add
+      if: ${{ inputs.labels != '' }}
+    - name: Set project
+      uses: actions/add-to-project@960fbad431afda394cfcf8743445e741acd19e85 # pin@v0.4.0
+      with:
+        github-token: ${{ inputs.github-token }}
+        project-url: ${{ inputs.project-url }}
+      if: ${{ inputs.project-url != '' }}
+    - name: Set reviewers (users)
+      uses: dannysauer/actions-assigner@ca2ca780928294ee5126986cc31db6c2ee7d69b0 # pin@v2.0.1
+      with:
+        reviewers: ${{ inputs.reviewers }}
+        token: ${{ inputs.github-token }}
+      if: ${{ inputs.reviewers != '' }}
+    - name: Set reviewers (teams)
+      uses: dannysauer/actions-assigner@ca2ca780928294ee5126986cc31db6c2ee7d69b0 # pin@v2.0.1
+      with:
+        team-reviewers: ${{ inputs.team-reviewers }}
+        token: ${{ inputs.github-token }}
+      if: ${{ inputs.team-reviewers != '' }}

--- a/configure-pull-request/action.yml
+++ b/configure-pull-request/action.yml
@@ -6,18 +6,23 @@ inputs:
   github-token:
     description: A GitHub access token with write access to the project
     required: true
+    type: string
   labels:
     description: Comma-separated list of labels
     required: false
+    type: string
   project-url:
     description: URL of a GitHub project
     required: false
+    type: string
   reviewers:
     description: Comma-separated list of users
     required: false
+    type: string
   team-reviewers:
     description: Comma-separated list of teams
     required: false
+    type: string
 
 runs:
   using: composite


### PR DESCRIPTION
Related to https://github.com/camunda/team-infrastructure/issues/204

Add a new composite GitHub action to configure a Pull Request. It is part of the refactoring of the `maintenance_project.yml` workflow but the logic can be reused for other needs.
