### PR TITLE
Add a new 'configure-maintenance-pull-request' composite GitHub action

### DIFF
--- a/teams/infra/configure-maintenance-pull-request/README.md
+++ b/teams/infra/configure-maintenance-pull-request/README.md
@@ -1,0 +1,37 @@
+# configure-maintenance-pull-request
+
+This composite Github Action (GHA) is aimed to be used by the Camunda Infrastructure team for configuring a maintenance Pull Request according to the team guidelines.
+
+**Infra team guidelines**
+- If the PR is opened by a vendor (Renovate or Snyk):
+    - Add the label `dependency-upgrade` to the PR
+    - Add the PR to the maintenance [project](https://github.com/orgs/camunda/projects/42/)
+    - Add the `infra-maintenance-dri` team as reviewer of the PR
+- If the PR is labeled with `dependency-upgrade`:
+    - Add the PR to the maintenance [project](https://github.com/orgs/camunda/projects/42/)
+
+## Usage
+
+This composite GHA can be used in any repository and must be triggered on `pull_request` events.
+
+### Inputs
+| Input name           | Description                                               |
+|----------------------|-----------------------------------------------------------|
+| github-token         | A GitHub access token with sufficient scope (*) |
+
+(*) This action relies on the [configure-pull-request](../../../configure-pull-request) action to edit a Pull Request and requires sufficient scope.
+
+### Workflow Example
+```yaml
+---
+name: example
+on:
+  pull_request:
+jobs:
+  configure-pr:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: camunda/infra-global-github-actions/teams/infra/configure-maintenance-pull-request@main
+      with:
+        github-token: ${{ secrets.A_GITHUB_TOKEN }}
+```

--- a/teams/infra/configure-maintenance-pull-request/README.md
+++ b/teams/infra/configure-maintenance-pull-request/README.md
@@ -33,5 +33,5 @@ jobs:
     steps:
     - uses: camunda/infra-global-github-actions/teams/infra/configure-maintenance-pull-request@main
       with:
-        github-token: ${{ secrets.A_GITHUB_TOKEN }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/teams/infra/configure-maintenance-pull-request/action.yml
+++ b/teams/infra/configure-maintenance-pull-request/action.yml
@@ -85,7 +85,7 @@ runs:
       } >> $GITHUB_OUTPUT
     shell: bash
   - name: Apply Pull Request configuration
-    uses: camunda/infra-global-github-actions/configure-pull-request@gh-204-configure-pull-request
+    uses: camunda/infra-global-github-actions/configure-pull-request@main
     with:
       github-token: ${{ inputs.github-token }}
       labels: ${{ steps.pr-configuration.outputs.labels }}

--- a/teams/infra/configure-maintenance-pull-request/action.yml
+++ b/teams/infra/configure-maintenance-pull-request/action.yml
@@ -1,0 +1,93 @@
+name: Configure a maintenance Pull Request
+
+description: Configure a maintenance Pull Request according to the Infra team guidelines
+
+inputs:
+  github-token:
+    description: A GitHub access token with write access to the project
+    required: true
+    type: string
+
+runs:
+  using: composite
+  steps:
+  # Set global values as outputs to be reused in other steps
+  - id: global # Maintenance parameters of the Infra team
+    run: |
+      {
+        echo maintenance-label=dependency-upgrade
+        echo maintenance-project-url=https://github.com/orgs/camunda/projects/42/
+        echo maintenance-team-reviewers=infra-maintenance-dri
+      } >> $GITHUB_OUTPUT
+    shell: bash
+  - name: Get info about the Pull Request event
+    id: pr-event-info
+    run: |
+      {
+        # Get the action type of the event
+        echo action=${{ github.event.action }}
+
+        # Get labels if any
+        echo labels=${{ format('{0}', join(github.event.pull_request.labels.*.name)) }}
+
+        # Identify the vendor from the branch prefix
+        echo vendor=${{
+          startsWith(github.head_ref, 'renovate/') && 'renovate' ||
+          startsWith(github.head_ref, 'snyk-fix-')  && 'snyk' ||
+          ''
+        }}
+      } >> $GITHUB_OUTPUT
+    shell: bash
+  - name: Deduce assertions about the Pull Request event
+    id: pr-event-assertions
+    run: |
+      {
+        # Is labeled by a vendor ?
+        echo is-opened-by-vendor=${{
+          steps.pr-event-info.outputs.action == 'opened' &&
+          steps.pr-event-info.outputs.vendor != ''
+        }}
+
+        # Is labeled with 'dependency-upgrade'
+        echo is-labeled-with-dependency-upgrade=${{
+          steps.pr-event-info.outputs.action == 'labeled' &&
+          contains(steps.pr-event-info.outputs.labels, steps.global.outputs.maintenance-label) 
+        }}
+      } >> $GITHUB_OUTPUT
+    shell: bash
+  - name: Determine the Pull Request configuration to apply from context and Infra team guidelines
+    id: pr-configuration
+    run: |
+      {
+        # Label the PR if opened by a vendor
+        echo labels=${{
+          (
+            steps.pr-event-assertions.outputs.is-opened-by-vendor == 'true' &&
+            steps.global.outputs.maintenance-label
+          ) || ''
+        }}
+
+        # Add the PR to the maintenance project if labeled (dependecy-upgrade) or opened by a vendor
+        echo project-url=${{
+          (
+            steps.pr-event-assertions.outputs.is-labeled-with-dependency-upgrade == 'true' ||
+            steps.pr-event-assertions.outputs.is-opened-by-vendor == 'true'
+          ) && steps.global.outputs.maintenance-project-url || ''
+        }}
+        
+        # Set the infra-maintenace-dri team as reviewer of the PR if opened by a vendor
+        echo team-reviewers=${{
+          (
+            steps.pr-event-assertions.outputs.is-opened-by-vendor == 'true' &&
+            steps.global.outputs.maintenance-team-reviewers
+          ) || ''
+        }}
+      } >> $GITHUB_OUTPUT
+    shell: bash
+  - name: Apply Pull Request configuration
+    uses: camunda/infra-global-github-actions/configure-pull-request@gh-204-configure-pull-request
+    with:
+      github-token: ${{ inputs.github-token }}
+      labels: ${{ steps.pr-configuration.outputs.labels }}
+      project-url: ${{ steps.pr-configuration.outputs.project-url }}
+      team-reviewers: ${{ steps.pr-configuration.outputs.team-reviewers }}


### PR DESCRIPTION
Related to https://github.com/camunda/team-infrastructure/issues/204

Add a new composite GitHub action to configure a maintenance Pull Request according to the Infra team [guidelines](https://github.com/camunda/infra-global-github-actions/pull/32/files#diff-f6a634806877868e521ee7057c9d223f2d0ce012e7d42cef6a128ddc45c4cf5bR5-R11). It is part of the refactoring of the `maintenance_project.yml` workflow.

**This PR is still in draft mode**. Here are the remaining tasks before merging:

- [x] Merge the PR https://github.com/camunda/infra-global-github-actions/pull/31 that introduced the new `configure-pull-request` GHA to edit a PR