### PR TITLE
chore(gha) Adding additional inputs for docker build.

### DIFF
--- a/build-docker-image/README.md
+++ b/build-docker-image/README.md
@@ -17,6 +17,10 @@ This composite GHA can be used in any non-public repository with a `Dockerfile` 
 | build_args        | Allows defining extra build-args, supply as list with \| (pipe bar) |
 | extra_tags        | Allows defining extra tags according to the [metadata action](https://github.com/docker/metadata-action), supply as list with \| (pipe bar) |
 | force_push        | Allows overwriting the image push behaviour, by setting to 'true' as input |
+| build_context     | Docker build context location                      |
+| build_allow       | Extra privilege entitlements to give builder       |
+| buildx_driver     | Driver to use for buildx builder                   |
+| buildx_version    | Which release version of a buildx action to use    |
 
 For the above example inputs the resulting Docker image would be named `gcr.io/example/image`.
 

--- a/build-docker-image/action.yml
+++ b/build-docker-image/action.yml
@@ -26,6 +26,19 @@ inputs:
     description: Allow overwriting the push behaviour by setting it to 'true'
     required: false
     default: 'false'
+  build_context:
+    description: Docker build context.
+    required: false
+    default: '.'
+  build_allow:
+    description: Extra privilege entitlements to give builder.
+    requried: false
+  buildx_driver:
+    description: Driver for buildx builder.
+    required: false
+  buildx_version:
+    description: Which release version of buildx action to use
+    required: false
 
 outputs:
   image_digest:
@@ -49,9 +62,13 @@ runs:
     run: |
       echo "Inputs"
       echo "-----"
-      echo "Registry host: ${{ inputs.registry_host }}"
-      echo "Image name:    ${{ inputs.image_name }}"
-      echo "Build-Args:    ${{ inputs.build_args }}"
+      echo "Registry host:   ${{ inputs.registry_host }}"
+      echo "Image name:      ${{ inputs.image_name }}"
+      echo "Build-Args:      ${{ inputs.build_args }}"
+      echo "Context:         ${{ inputs.build_context }}"
+      echo "Allow:          ${{ inputs.build_allow }}"
+      echo "Buildx Driver:   ${{ inputs.buildx_driver }}"
+      echo "Buildx Version:  ${{ inputs.buildx_version }}"
 
   - name: Validate inputs
     shell: bash
@@ -89,7 +106,11 @@ runs:
       echo "SHOULD_WE_PUSH=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || startsWith(github.ref, 'refs/tags/') || endsWith(github.ref, '-push') || inputs.force_push == 'true' }}" | tee -a "$GITHUB_ENV" "$GITHUB_OUTPUT"
 
   - name: Set up Docker Buildx
+    id: buildx
     uses: docker/setup-buildx-action@v2
+    with:
+      version: ${{ inputs.buildx_version }}
+      driver: ${{ inputs.buildx_driver }}
 
   - name: Login to Docker registry
     uses: docker/login-action@v2
@@ -106,7 +127,9 @@ runs:
     id: build-push
     uses: docker/build-push-action@v3
     with:
-      context: .
+      allow: ${{ inputs.build_allow }}
+      context: ${{ inputs.build_context }}
+      builder: ${{ steps.buildx.output.name }}
       build-args: ${{ inputs.build_args }}
       push: ${{ env.SHOULD_WE_PUSH }}
       tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
This PR will add some additional inputs for the `docker build and push` action and make some configurable with sensible defaults:

- build_context: Many images place dockerfiles and install scripts in subdirectories. This will default to root.
- build_allow: This allows configuring additional entitlements when building images that require this.
- buildx_driver: Allows you to specify which driver to use for the buildx builder.
- Builx_version: Allows you to specify a certain revision of the buildx action to use when building.