### PR TITLE
Add a new `generate-github-app-token-from-vault-secrets` composite GHA

### DIFF
--- a/generate-github-app-token-from-vault-secrets/README.md
+++ b/generate-github-app-token-from-vault-secrets/README.md
@@ -1,0 +1,48 @@
+# generate-github-app-token-from-vault-secrets
+
+This composite Github Action (GHA) is aimed to be used by Camunda teams to generate a GitHub token from Github App secrets (ID & Private Key) stored in Vault.
+
+## Usage
+
+This composite GHA can be used in any repository.
+
+### Inputs
+| Input name                          | Description                                                            |
+|-------------------------------------|------------------------------------------------------------------------|
+| github-app-id-vault-key             | The key of the Vault secret storing the ID of the GitHub App  |
+| github-app-id-vault-path            | The path of the Vault secret storing the ID of the GitHub App |
+| github-app-private-key-vault-key    | The key of the Vault secret storing the private key of the GitHub App |
+| github-app-private-key-vault-path   | The path of the Vault secret storing the private key of the GitHub App |
+| vault-auth-method                   | The method to use to authenticate with Vault (*) |
+| vault-auth-role-id                  | The Role Id for (Vault) App Role authentication |
+| vault-auth-secret-id                | The Secret Id for (Vault) App Role authentication |
+| vault-url                           | The URL for the Vault endpoint |
+
+> (*) The above Vault properties only support App Role authentication (`vault-auth-method=approle`) for now. New inputs may be added in the future to support other authentication methods.
+
+### Outputs
+| Output name      | Description                 |
+|------------------|-----------------------------|
+| token            | The generated GitHub token  |
+
+### Workflow Example
+```yaml
+---
+name: example
+on:
+  pull_request:
+jobs:
+  configure-pr:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
+      with:
+        github-app-id-vault-key: THE_KEY_NAME_OF_THE_VAULT_SECRET_STORING_THE_APP_ID
+        github-app-id-vault-path: the/path/of/the/vault/secret/storing/the/app/id
+        github-app-private-key-vault-key: THE_KEY_NAME_OF_THE_VAULT_SECRET_STORING_THE_APP_PRIVATE_KEY
+        github-app-private-key-vault-path: the/path/of/the/vault/secret/storing/the/app/private/key
+        vault-auth-method: approle
+        vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
+        vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID}}
+        vault-url: ${{ secrets.VAULT_ADDR }}
+```

--- a/generate-github-app-token-from-vault-secrets/action.yml
+++ b/generate-github-app-token-from-vault-secrets/action.yml
@@ -1,0 +1,88 @@
+name: Generate a GitHub App token from secrets stored in Vault
+
+description: Generate a GitHub token from GitHub App secrets (ID & Private Key) stored in Vault
+
+inputs:
+  github-app-id-vault-key:
+    description: The key of the Vault secret storing the ID of the GitHub App
+    required: true
+    type: string
+  github-app-id-vault-path:
+    description: The path of the Vault secret storing the ID of the GitHub App
+    required: true
+    type: string
+  github-app-private-key-vault-key:
+    description: The key of the Vault secret storing the private key of the GitHub App
+    required: true
+    type: string
+  github-app-private-key-vault-path:
+    description: The path of the Vault secret storing the private key of the GitHub App
+    required: true
+    type: string
+  vault-auth-method: 
+    description: The method to use to authenticate with Vault
+    required: true
+    type: string
+  vault-auth-role-id:
+    description: The Role Id for (Vault) App Role authentication
+    required: true
+    type: string
+  vault-auth-secret-id:
+    description: The Secret Id for (Vault) App Role authentication
+    required: true
+    type: string
+  vault-url:
+    description: The URL for the Vault endpoint
+    required: true
+    type: string
+
+outputs:
+  token:
+    description: The generated GitHub token
+    value: ${{ steps.github-token.outputs.token }}
+
+runs:
+  using: composite
+  steps:
+  - name: Import the GitHub App ID from vault
+    id: app-id
+    uses: hashicorp/vault-action@v2.5.0
+    with:
+      url: ${{ inputs.vault-url }}
+      method: ${{ inputs.vault-auth-method }}
+      roleId: ${{ inputs.vault-auth-role-id }}
+      secretId: ${{ inputs.vault-auth-secret-id }}
+      exportEnv: false
+      secrets: > 
+        ${{ 
+          format(
+            '{0} {1} | {2};',
+            inputs.github-app-id-vault-path,
+            inputs.github-app-id-vault-key,
+            'id'
+          ) 
+        }}
+  - name: Import the GitHub App secret key from vault
+    id: app-private-key
+    uses: hashicorp/vault-action@v2.5.0
+    with:
+      url: ${{ inputs.vault-url }}
+      method: ${{ inputs.vault-auth-method }}
+      roleId: ${{ inputs.vault-auth-role-id }}
+      secretId: ${{ inputs.vault-auth-secret-id }}
+      exportEnv: false
+      secrets: >
+        ${{ 
+          format(
+            '{0} {1} | {2};',
+            inputs.github-app-private-key-vault-path,
+            inputs.github-app-private-key-vault-key,
+            'private-key'
+          ) 
+        }}
+  - name: Generate a Github App token
+    id: github-token
+    uses: tibdex/github-app-token@v1
+    with:
+      app_id: ${{ steps.app-id.outputs.id }}
+      private_key: ${{ steps.app-private-key.outputs.private-key }}


### PR DESCRIPTION
Related to https://github.com/camunda/team-infrastructure/issues/204

Add a new composite GitHub action to generate a GitHub token from Github App secrets (ID & Private Key) stored in Vault. It is part of the refactoring of the `maintenance_project.yml` workflow.