### PR TITLE
chore(renovate): Remove the Renovate configuration for labeling (dependency-upgrade) and requesting review for new maintenance PRs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,8 +6,6 @@
     ":automergeDisabled",
     ":semanticCommits",
     ":dependencyDashboard",
-    ":label(dependency-upgrade)",
-    ":reviewer(team:infra-maintenance-dri)",
   ],
   schedule: ["on the 1st and 3rd day instance on sunday after 9pm"],
   commitBodyTable: true,


### PR DESCRIPTION
Related to camunda/team-infrastructure#204

Since the new maintenance workflow handles labeling (dependency-upgrade) and review request for all maintenance PRs, the Renovate configuration can be adjusted to no longer perform these same actions.
