### PR TITLE
chore(build-docker-image): set default for load input

### DIFF
--- a/build-docker-image/action.yml
+++ b/build-docker-image/action.yml
@@ -42,6 +42,7 @@ inputs:
   docker_load:
     description: Whether load docker image from build into local Docker Images
     required: false
+    default: 'false'
 
 outputs:
   image_digest:


### PR DESCRIPTION
set default for load input as otherwise it fails with nothing defined.

```
Error: Input does not meet YAML 1.2 "Core Schema" specification: load
```