### PR TITLE
chore(preview-env): Use ArgoCD 2.5.11 by default

### DIFF
--- a/preview-env/create/action.yml
+++ b/preview-env/create/action.yml
@@ -28,7 +28,7 @@ inputs:
 
   argocd_version:
   # renovate: datasource=docker depName=argoproj/argocd
-    default: v2.5.4
+    default: v2.5.11
     description: Version tag of Argo CD CLI tool
     required: false
 

--- a/preview-env/destroy/action.yml
+++ b/preview-env/destroy/action.yml
@@ -23,7 +23,7 @@ inputs:
 
   argocd_version:
   # renovate: datasource=docker depName=argoproj/argocd
-    default: v2.5.4
+    default: v2.5.11
     description: Version tag of Argo CD CLI tool
     required: false
 runs:


### PR DESCRIPTION
Followed guide in https://confluence.camunda.com/display/SRE/ArgoCD

Related: https://camunda.slack.com/archives/CHY2S7KDJ/p1677159633536829