### PR TITLE
Add three new GitHub actions to edit and sync the configurations of Kubernetes resources managed by ArgoCD

### DIFF
--- a/argocd-sync-applications/README.md
+++ b/argocd-sync-applications/README.md
@@ -1,0 +1,37 @@
+# argocd-sync-applications
+
+This composite Github Action (GHA) is aimed to be used by the Camunda Infrastructure team for synchronizing ArgoCD applications.
+
+## Usage
+
+This composite GHA can be used in any repository.
+
+### Inputs
+|       Input name        | Description                                                                                                                                                          |      Required      | Default |
+| :---------------------: | :------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :----------------: | :-----: |
+|        app-name         | ArgoCD application to be synced.                                                                                                                                     | :heavy_check_mark: |         |
+|      argocd-token       | ArgoCD token with sufficient permissions to sync the ArgoCD application.                                                                                             | :heavy_check_mark: |         |
+|      github-token       | A GitHub token to get a higher GitHub's API rate limit to avoid limitations when pulling the ArgoCD CLI from the ArgoCD repository.                                  | :heavy_check_mark: |         |
+|       cli-version       | Version of the ArgoCD CLI to use.                                                                                                                                    |                    |         |
+| max-waiting-time-health | The time (in seconds) to wait for the ArgoCD application to be healthy (does not wait if set to 0).                                                                  |                    |   600   |
+|  max-waiting-time-sync  | The time (in seconds) to wait for the ArgoCD application to be synced (does not wait if set to 0).                                                                   |                    |   30    |
+|         server          | URL of the ArgoCD server. | :heavy_check_mark: |         |
+
+
+### Workflow Example
+```yaml
+---
+name: example
+on:
+  push:
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: camunda/infra-global-github-actions/argocd-sync-applications@main
+      with:
+        app-name: my-argocd-app-name
+        argocd-token: my-argocd-token-***
+        github-token: my-github-token-***
+        server: dev
+```

--- a/argocd-sync-applications/action.yml
+++ b/argocd-sync-applications/action.yml
@@ -1,0 +1,74 @@
+name: Sync ArgoCD applications
+
+description: Sync ArgoCD applications
+
+inputs:
+  app-name:
+    description: ArgoCD application to be synced.
+    required: true
+  argocd-token:
+    description: ArgoCD token with sufficient permissions to sync the ArgoCD application.
+    required: true
+  github-token:
+    description: |
+      A GitHub token to get a higher GitHub's API rate limit to avoid limitations when pulling
+      the ArgoCD CLI from the ArgoCD repository.
+    required: true
+  cli-version:
+    description: Version of the ArgoCD CLI to use.
+    default: 2.5.11
+  max-waiting-time-health:
+    description: |
+      The time (in seconds) to wait for the ArgoCD application to be healthy.
+      Does not wait if set to 0.
+    default: "600"
+  max-waiting-time-sync:
+    description: |
+      The time (in seconds) to wait for the ArgoCD application to be synced.
+      Does not wait if set to 0.
+    default: "30"
+  server:
+    description: URL of the ArgoCD server.
+
+runs:
+  using: composite
+  steps:
+  - name: Sync of the ArgoCD application (app-name=${{ inputs.app-name }})
+    uses: clowdhaus/argo-cd-action@v1.16.0
+    env:
+      # Only required for first step in job where API is called
+      # All subsequent setps in a job will not re-download the CLI
+      GITHUB_TOKEN: ${{ inputs.github-token }}
+    with:
+      command: app sync ${{ inputs.app-name }}
+      options: >-
+        --async
+        --auth-token ${{ inputs.argocd-token }}
+        --force
+        --grpc-web
+        --server ${{ inputs.server }}
+      version: ${{ inputs.cli-version }}
+  - name: Wait for the ArgoCD application to be synced (app-name=${{ inputs.app-name }}, timemout=${{ inputs.max-waiting-time-sync }}s)
+    uses: clowdhaus/argo-cd-action@v1.16.0
+    if: inputs.max-waiting-time-sync != '0'
+    with:
+      command: app wait ${{ inputs.app-name }}
+      options: >-
+        --auth-token ${{ inputs.argocd-token }}
+        --grpc-web
+        --server ${{ inputs.server }}
+        --sync
+        --timeout ${{ inputs.max-waiting-time-sync }}
+      version: ${{ inputs.cli-version }}
+  - name: Wait for the ArgoCD application to be healthy (app-name=${{ inputs.app-name }}, timemout=${{ inputs.max-waiting-time-health }}s)
+    uses: clowdhaus/argo-cd-action@v1.16.0
+    if: inputs.max-waiting-time-health != '0'
+    with:
+      command: app wait ${{ inputs.app-name }}
+      options: >-
+        --auth-token ${{ inputs.argocd-token }}
+        --grpc-web
+        --health
+        --server ${{ inputs.server }}
+        --timeout ${{ inputs.max-waiting-time-health }}
+      version: ${{ inputs.cli-version }}

--- a/yq-yaml-processor/README.md
+++ b/yq-yaml-processor/README.md
@@ -1,0 +1,96 @@
+# yq-yaml-processor
+
+This composite Github Action (GHA) is aimed to process YAML content by leveraging the capabilities of the [YQ](https://github.com/mikefarah/yq) processor.
+
+## Usage
+
+This composite GHA can be used in any repository.
+
+### Inputs
+| Input name | Description                                                                                                       |      Required      |   Default   |
+| :--------: | :---------------------------------------------------------------------------------------------------------------- | :----------------: | :---------: |
+|  patches   | A list of YAML contents (env, file, inline) with associated YQ expressions to apply (piped in the defined order). | :heavy_check_mark: |             |
+|  options   | Command options passed to the YQ CLI                                                                              |                    | `--inplace` |
+
+### Outputs
+| Output name | Description                                                                              |
+| :---------: | :--------------------------------------------------------------------------------------- |
+|   results   | A JSON array with the results of each YQ command executed for each defined YAML content. |
+
+
+### Workflow Example
+```yaml
+---
+name: example
+on:
+  push:
+jobs:
+  processing-yaml-files:
+    # With a.yml and b.yml having the following content
+    #
+    # a.yaml
+    # ----
+    # a:
+    #   count: 0
+    #   enabled: false
+    #   name: Big A
+    #
+    # b.yaml
+    # ---
+    # b:
+    #   count: 0
+    #   enabled: false
+    #   name: Big B
+    runs-on: ubuntu-latest
+    steps:
+    - uses: camunda/infra-global-github-actions/yq-yaml-processor@main
+      with:
+        patches: |
+          - file: path/to/a.yaml
+            expressions :
+            - '.a.count = 1'
+            - '.a.enabled = true'
+            - '.a.name = "A"'
+          - file: path/to/b.yaml
+            expressions :
+            - '.b.enabled = true'
+        options: "--inplace"
+  processing-flow:
+    runs-on: ubuntu-latest
+    steps:
+    - id: step-1
+      uses: camunda/infra-global-github-actions/yq-yaml-processor@main
+      with:
+        patches: |
+          - inline: |-
+              users:
+              - name: a
+                age: 10
+              - name: b
+                age: 5
+            expressions :
+            - '.'
+    - id: step-2
+      uses: camunda/infra-global-github-actions/yq-yaml-processor@main
+      env:
+        PREVIOUS_STEP_OUTPUT: ${{ fromJSON(steps.step-1.outputs.results)[0] }}
+      with:
+        patches: |
+          - env: PREVIOUS_STEP_OUTPUT
+            expressions :
+            - '(.users[] | select(.name == "a")).age += 1'
+    - id: step-3
+      uses: camunda/infra-global-github-actions/yq-yaml-processor@main
+      env:
+        PREVIOUS_STEP_OUTPUT: ${{ fromJSON(steps.step-2.outputs.results)[0] }}
+      with:
+        patches: |
+          - env: PREVIOUS_STEP_OUTPUT
+            expressions :
+            - '(.users[] | select(.name == "b")).age += 1'
+    - name: Print the result
+      env:
+        PREVIOUS_STEP_OUTPUT: ${{ fromJSON(steps.step-3.outputs.results)[0] }}
+      run: |
+        echo "${PREVIOUS_STEP_OUTPUT}"
+```

--- a/yq-yaml-processor/action.yml
+++ b/yq-yaml-processor/action.yml
@@ -1,0 +1,70 @@
+name: YQ YAML processor
+
+description: Process YAML content by leveraging the capabilities of the [YQ](https://github.com/mikefarah/yq) processor.
+
+inputs:
+  patches:
+    description: |
+      A list of YAML contents (env, file, inline) with associated YQ expressions to apply (piped in the defined order).
+      Consult the ./README.md for more information and examples.
+    required: true
+  options:
+    description: Command options passed to the YQ CLI
+    default: ""
+
+outputs:
+  results:
+    description: |
+      A JSON array with the results of each YQ command executed for each defined YAML content.
+    value: ${{ steps.process.outputs.results }}
+
+runs:
+  using: composite
+  steps:
+  - name: Process patches
+    uses: mikefarah/yq@v4.33.1
+    id: process
+    env:
+      OPTIONS: ${{ inputs.options }}
+      PATCHES: ${{ inputs.patches }}
+    with:
+      cmd: | 
+        # Convert to an array of key/value pairs
+        PATCHES=$(echo "$PATCHES" | yq 'to_entries')
+
+        # Create a temporary file to store standard outputs in JSON format
+        echo '[]' > outputs.tmp 
+
+        for index in $(echo "$PATCHES" | yq '.[].key'); do
+          # Get the patch
+          patch=$(echo "$PATCHES" | i=$index yq '.[env(i)].value')
+
+          # Get the YAML source (env,file,inline)
+          type=$(echo "$patch" | yq 'keys | .[] | select(test("^env|file|inline$"))')
+
+          # Get the yq expressions to apply
+          expressions=$(echo "$patch" | yq '.expressions | join(" | ")')
+
+          # Get the YAML content
+          yaml=""
+          final_options="$OPTIONS"
+          if [[ $type == "env" ]]; then
+            env=$(echo "$patch" | yq '.env')
+            yaml="$(eval echo \\"\$$env\\")"
+          elif [[ $type == "file" ]]; then
+            file=$(echo "$patch" | yq '.file')
+            final_options="$file $final_options"
+          elif [[ $type == "inline" ]]; then
+            yaml=$(echo "$patch" | yq '.inline')
+          fi
+
+          # Apply the yq expressions to the YAML content
+          echo "$yaml" | yq "$expressions" $final_options | \
+            yq '[(. | to_yaml)]' | \
+            yq eval-all --inplace --indent 0 --output-format json \
+              '. as $file ireduce([]; . + $file)' outputs.tmp -
+        done
+
+        # Set the results as an output
+        echo results="$(cat outputs.tmp)" >> $GITHUB_OUTPUT
+        rm outputs.tmp


### PR DESCRIPTION
Related to https://github.com/camunda/team-infrastructure/issues/268

Add three new GitHub actions:
- [edit-and-sync-configurations-managed-by-argocd](https://github.com/camunda/infra-global-github-actions/pull/44/files#diff-7082b988058bc6a5612281406d4beb7e2e911306468d290356e6456d779646ca) to automate the update of the configurations of Kubernetes resources (source of truth) managed by ArgoCD.
- [sync-argocd-applications](https://github.com/camunda/infra-global-github-actions/pull/44/files#diff-137c4a613cb300c4adc97ea8c894a29bab7b54daf07506e4d0ac6540d4decd94) to  sync ArgoCD applications.
- [yq-yaml-processor](https://github.com/camunda/infra-global-github-actions/pull/44/files#diff-92c14ad80dadf917b56ea47d2c3b30902bb4a76d71a8416811ecf7cd23fe1673) to process YAML content by leveraging the capabilities of the [YQ](https://github.com/mikefarah/yq) processor.