### PR TITLE
feat(action): allow snyk bot

### DIFF
--- a/assert-camunda-git-emails/README.md
+++ b/assert-camunda-git-emails/README.md
@@ -29,6 +29,8 @@ The following email addresses are hardcoded as allowed:
 - `@users.noreply.github.com` (used for Github users that chose to [keep their email address private](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-github-user-account/managing-email-preferences/adding-an-email-address-to-your-github-account))
 - `noreply@github.com` (used on merge commits created by Github web UI)
 - `github-actions@github.com` (used for commits created by Github Actions runs)
+- `bot@renovateapp.com` (used for commits created by [Renovate](https://github.com/marketplace/renovate))
+- `snyk-bot@snyk.io` (used for commits created by [Snyk](https://github.com/marketplace/snyk))
 
 **Note: Pull Requests to extend this list are welcome when you discover edge cases!**
 

--- a/assert-camunda-git-emails/check.sh
+++ b/assert-camunda-git-emails/check.sh
@@ -3,7 +3,7 @@
 set -eu
 
 # This variable has to contain regex expression for the grep tool
-HARDCODED_ALLOWED_EMAILS_REGEX="@camunda.com\|@users.noreply.github.com\|noreply@github.com\|github-actions@github.com\|bot@renovateapp.com"
+HARDCODED_ALLOWED_EMAILS_REGEX="@camunda.com\|@users.noreply.github.com\|noreply@github.com\|github-actions@github.com\|bot@renovateapp.com\|snyk-bot@snyk.io"
 
 if [ "$ADDITIONAL_ALLOWED_EMAILS_REGEX" = "" ]; then
   ALLOWED_EMAILS_REGEX="$HARDCODED_ALLOWED_EMAILS_REGEX"


### PR DESCRIPTION
Allows commits from Snyk as more and more engineering teams are adopting the solution. See https://github.com/camunda/web-modeler/actions/runs/5038877138/jobs/9036654407?pr=4738 for an example of a failed run without this addition.