### PR TITLE
Don't use Python in submit-build-action

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -2,5 +2,4 @@
 # renovate: datasource=github-tags depName=rhysd/actionlint
 actionlint 1.6.24
 
-# renovate: datasource=github-tags depName=pre-commit/pre-commit
 pre-commit 3.3.2

--- a/submit-build-status/action.yml
+++ b/submit-build-status/action.yml
@@ -33,17 +33,26 @@ runs:
       echo "User description: ${{ inputs.user_description }}"
 
   - name: Validate inputs
-    shell: python
+    shell: bash
+    env:
+      BUILD_STATUS: "${{ inputs.build_status }}"
+      USER_REASON: "${{ inputs.user_reason }}"
+      USER_DESCRIPTION: "${{ inputs.user_description }}"
     run: |
-      if '${{ inputs.build_status }}' == '':
-        print('Need to specify a build status that is not empty!')
-        sys.exit(1)
-      if len('${{ inputs.user_reason }}') > 200:
-        print('Specified user reason has more than 200 characters!')
-        sys.exit(1)
-      if len('${{ inputs.user_description }}') > 1000:
-        print('Specified user description has more than 1000 characters!')
-        sys.exit(1)
+      if [ "$BUILD_STATUS" == "" ]; then
+        echo "Need to specify a build status that is not empty!"
+        exit 1
+      fi
+
+      if [ "${#USER_REASON}" -gt 200 ]; then
+        echo "Specified user reason has more than 200 characters!"
+        exit 1
+      fi
+
+      if [ "${#USER_DESCRIPTION}" -gt 1000 ]; then
+        echo "Specified user description has more than 1000 characters!"
+        exit 1
+      fi
 
   - name: Login to Google Cloud
     id: auth
@@ -57,7 +66,6 @@ runs:
   - name: Submit build status to CI Analytics
     shell: bash
     env:
-      # TODO: change to prod
       BIG_QUERY_TABLE_NAME: ci-30-162810:prod_ci_analytics.build_status_v2
     run: |
       cat <<EOF | tr '\n' ' ' | bq insert "$BIG_QUERY_TABLE_NAME"


### PR DESCRIPTION
We discovered that GHA self-hosted runner images based on Ubuntu 22.04 do not contain `python` by default anymore - find the background here: https://github.com/actions/actions-runner-controller/pull/2050

We only need Python here for input validation (nicer to code than in Bash) but it can be done in Bash as well which avoids having to install Python just for this.

Example runs:

- failed run when one input is too long (I reduced the limit to 2 chars): https://github.com/camunda/infra-core/actions/runs/5058585353/jobs/9078888781?pr=5855
- successful run with proper inputs: https://github.com/camunda/infra-core/actions/runs/5058585353/jobs/9078992674?pr=5855