### PR TITLE
chore(renovate): fix configurations for ArgoCD clients and actionlint

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -40,4 +40,30 @@
       versioningTemplate: "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
     },
   ],
+  packageRules: [
+    {
+      datasources: ["docker"],
+      packagePatterns: ["argocd"],
+      groupName: "ArgoCD clients",
+    },
+    // For known Github repositories that use Github tags/releases of format
+    // "v1.2.3" and where the asdf plugin ignores the "v" prefix, we also tell
+    // Renovate to ignore it via extractVersion when updating .tool-version file
+    {
+      matchManagers: ["regex"],
+      matchPaths: ["**/.tool-versions", "**/*.tf"],
+      matchPackageNames: [
+        "rhysd/actionlint",
+      ],
+      extractVersion: "^v(?<version>.*)$",
+    },
+    {
+      matchManagers: ["regex"],
+      matchPaths: ["**/argocd-sync-applications/action.yml"],
+      matchPackageNames: [
+        "quay.io/argoproj/argocd",
+      ],
+      extractVersion: "^v(?<version>.*)$",
+    },
+  ]
 }

--- a/argocd-sync-applications/action.yml
+++ b/argocd-sync-applications/action.yml
@@ -16,7 +16,8 @@ inputs:
     required: true
   cli-version:
     description: Version of the ArgoCD CLI to use.
-    default: 2.5.11
+    # renovate: datasource=docker depName=quay.io/argoproj/argocd
+    default: 2.7.3
   max-waiting-time-health:
     description: |
       The time (in seconds) to wait for the ArgoCD application to be healthy.

--- a/preview-env/create/action.yml
+++ b/preview-env/create/action.yml
@@ -27,8 +27,8 @@ inputs:
     required: true
 
   argocd_version:
-  # renovate: datasource=docker depName=argoproj/argocd
-    default: v2.6.9
+    # renovate: datasource=docker depName=quay.io/argoproj/argocd
+    default: v2.7.3
     description: Version tag of Argo CD CLI tool
     required: false
 

--- a/preview-env/destroy/action.yml
+++ b/preview-env/destroy/action.yml
@@ -22,8 +22,8 @@ inputs:
     required: true
 
   argocd_version:
-  # renovate: datasource=docker depName=argoproj/argocd
-    default: v2.6.9
+    # renovate: datasource=docker depName=quay.io/argoproj/argocd
+    default: v2.7.3
     description: Version tag of Argo CD CLI tool
     required: false
 runs:


### PR DESCRIPTION
This fixes the following renovate configurations:
- `rhysd/actionlint` -> github tag versions were not correctly extracted
- `argocd` -> use the docker registry `quay.io/argoproj/argocd` to get new versions + group argocd-related deps