### PR TITLE
chore(gha): add common-tooling action for easier use with self-hosted runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,20 @@
+---
+self-hosted-runner:
+  # Labels of self-hosted runner in array of string
+  labels:
+  - gcp-core-2-release
+  - gcp-core-4-release
+  - gcp-core-8-release
+  - gcp-core-16-release
+  - gcp-core-32-release
+  - gcp-core-2-longrunning
+  - gcp-core-4-longrunning
+  - gcp-core-8-longrunning
+  - gcp-core-16-longrunning
+  - gcp-core-32-longrunning
+  - gcp-core-2-default
+  - gcp-core-4-default
+  - n1-standard-32-netssd-preempt
+  - n1-standard-16-netssd-preempt
+  - n1-standard-8-netssd-preempt
+  - n1-standard-8-netssd-preempt-quick

--- a/.github/workflows/test-common-tooling.yml
+++ b/.github/workflows/test-common-tooling.yml
@@ -1,0 +1,75 @@
+---
+name: Test Common Tooling
+
+on:
+  push:
+
+jobs:
+  test-common-tooling:
+    strategy:
+      matrix:
+        label: ["ubuntu-latest", "gcp-core-2-default"]
+    runs-on: ${{ matrix.label }}
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ./common-tooling
+      with:
+        secrets: ${{ toJSON(secrets) }}
+    - run: |
+        if ! command -v node &> /dev/null
+        then
+            echo "node could not be found"
+            exit 1
+        else
+            node --version
+        fi
+        if ! command -v yarn &> /dev/null
+        then
+            echo "yarn could not be found"
+            exit 1
+        else
+            yarn --version
+        fi
+        if ! command -v docker buildx &> /dev/null
+        then
+            echo "docker buildx could not be found"
+            exit 1
+        else
+            docker buildx version
+        fi
+        if ! command -v java &> /dev/null
+        then
+            echo "java could not be found"
+            exit 1
+        else
+            java --version
+        fi
+        if ! command -v mvn &> /dev/null
+        then
+            echo "mvn could not be found"
+            exit 1
+        else
+            mvn --version
+        fi
+        if ! command -v python &> /dev/null
+        then
+            echo "python could not be found"
+            exit 1
+        else
+            python --version
+        fi
+    - uses: ./common-tooling
+      with:
+        secrets: ${{ toJSON(secrets) }}
+        node-enabled: "false"
+        yarn-enabled: "false"
+        python-enabled: "false"
+        java-enabled: "false"
+        qemu-enabled: "false"
+        buildx-enabled: "false"
+    - uses: ./common-tooling
+      with:
+        secrets: ${{ toJSON(secrets) }}
+        overwrite: "false"
+    - uses: ./common-tooling

--- a/.github/workflows/test-common-tooling.yml
+++ b/.github/workflows/test-common-tooling.yml
@@ -9,16 +9,17 @@ on:
 jobs:
   test-common-tooling:
     strategy:
+      fail-fast: false
       matrix:
         label: ["ubuntu-latest", "gcp-core-2-default"]
     runs-on: ${{ matrix.label }}
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@v3
-    - uses: ./common-tooling
-      with:
-        secrets: ${{ toJSON(secrets) }}
-    - run: |
+    - name: Install if required common software tooling
+      uses: ./common-tooling
+    - name: Check that installed software is available
+      run: |
         if ! command -v node &> /dev/null
         then
             echo "node could not be found"
@@ -33,7 +34,8 @@ jobs:
         else
             yarn --version
         fi
-        if ! command -v docker buildx &> /dev/null
+        docker_buildx_count=$(docker buildx 2>&1 | grep -c "docker buildx")
+        if [[ $docker_buildx_count -eq 0 ]]
         then
             echo "docker buildx could not be found"
             exit 1
@@ -61,17 +63,24 @@ jobs:
         else
             python --version
         fi
-    - uses: ./common-tooling
+    - name: Install nothing, just for testing
+      uses: ./common-tooling
       with:
-        secrets: ${{ toJSON(secrets) }}
         node-enabled: "false"
         yarn-enabled: "false"
         python-enabled: "false"
         java-enabled: "false"
         qemu-enabled: "false"
         buildx-enabled: "false"
-    - uses: ./common-tooling
+    - name: Install and overwrite common software tooling
+      uses: ./common-tooling
       with:
-        secrets: ${{ toJSON(secrets) }}
-        overwrite: "false"
-    - uses: ./common-tooling
+        overwrite: "true"
+    - name: Install and overwrite common software tooling
+      uses: ./common-tooling
+      with:
+        node-version: 20 # see https://github.com/actions/setup-node#supported-version-syntax for supported syntax
+        java-version: 20 # see https://github.com/marketplace/actions/setup-java-jdk#supported-version-syntax for supported syntax
+        java-distribution: adopt # see https://github.com/marketplace/actions/setup-java-jdk#supported-distributions for supported distros
+        python-version: 3 # see https://github.com/actions/setup-python#supported-version-syntax for supported syntax
+        overwrite: 'true'

--- a/.github/workflows/test-common-tooling.yml
+++ b/.github/workflows/test-common-tooling.yml
@@ -2,7 +2,9 @@
 name: Test Common Tooling
 
 on:
-  push:
+  pull_request:
+    paths:
+    - 'common-tooling/action.yml'
 
 jobs:
   test-common-tooling:

--- a/common-tooling/README.md
+++ b/common-tooling/README.md
@@ -2,11 +2,34 @@
 
 This composite Github Action (GHA) is aimed to be used by Camunda teams for configuring either hosted or self-hosted runners with some basic software. Especially useful to have the basics available on self-hosted runners since they come with close to no software.
 
+## Default Software
+- Buildx - latest
+- JDK - 17
+- Maven - 3.9
+- Node - 16
+- Python - 3.11
+- Qemu - for multi arch builds (has to be enabled via `qemu-enabled: true`)
+- Yarn - 1.22
+
+## Used Actions
+See following actions for further information on available inputs and their usages.
+
+- [Setup-Buildx-Action](https://github.com/docker/setup-buildx-action)
+- [Setup-Maven-Action](https://github.com/s4u/setup-maven-action)
+- [Setup-Node](https://github.com/actions/setup-node)
+- [Setup-Python](https://github.com/actions/setup-python)
+- [Setup-Qemu-Action](https://github.com/docker/setup-qemu-action)
+- Yarn installed via Ubuntu package manager
+
 ## Usage
 
 This composite GHA can be used in any repository and should generally run as one of the first actions. Directly before or after the checkout.
 
 ### Inputs
+The inputs of the mentioned actions are mirrored and prefixed with the tooling itself.
+e.g.
+`architecture` --> `node-architecture`
+
 | Input name           | Description                                               | default |
 |----------------------|-----------------------------------------------------------| --------|
 | node-always-auth         | Set always-auth in npmrc. |
@@ -36,7 +59,7 @@ This composite GHA can be used in any repository and should generally run as one
 | buildx-enabled | Whether to install buildx or not |
 | qemu-image | QEMU static binaries Docker image (e.g. tonistiigi/binfmt:latest) |
 | qemu-platforms | Platforms to install (e.g. arm64,riscv64,arm) | all |
-| qemu-enabled | Whether to install qemu or not |
+| qemu-enabled | Whether to install qemu or not | false |
 | java-version | The Java version to set up | 17 |
 | java-distribution | Java distribution | temurin |
 | java-cache-prefix | Cache key prefix |
@@ -54,9 +77,7 @@ This composite GHA can be used in any repository and should generally run as one
 | python-update-environment | Set this option if you want the action to update environment variables. |
 | python-allow-prereleases | When 'true', a version range passed to 'python-version' input will match prerelease versions if no GA versions are found. Only 'x.y' version range is supported for CPython. |
 | python-enabled | Whether to install python or not |
-| overwrite | Defines whether on hosted runners the present version should be overwritten | true |
-| secrets | toJSON passed GitHub secrets |
-| berlin-timezone | Whether to keep the runner at UTC or set Berlin timezone| true|
+| overwrite | Defines whether on hosted runners the present version should be overwritten | false |
 
 ### Workflow Example
 ```yaml
@@ -69,13 +90,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     # install any defaults
-    - uses: camunda/infra-global-github-actions/common-tooling@main
-    # install any defaults and configure maven-settings.xml
-    - uses: camunda/infra-global-github-actions/common-tooling@main
-      with:
-        secrets: ${{ toJSON(secrets) }}
+    - name: Install if required common software tooling
+      uses: camunda/infra-global-github-actions/common-tooling@main
     # only install missing software components
-    - uses: camunda/infra-global-github-actions/common-tooling@main
+    - name: Install and overwrite common software tooling
+      uses: camunda/infra-global-github-actions/common-tooling@main
       with:
         overwrite: "false"
+    # Install missing software with specific node and JDK version
+    - name: Install and overwrite common software tooling
+      uses: camunda/infra-global-github-actions/common-tooling@main
+      with:
+        node-version: 20 # see https://github.com/actions/setup-node#supported-version-syntax for supported syntax
+        java-version: 20 # see https://github.com/marketplace/actions/setup-java-jdk#supported-version-syntax for supported syntax
+        java-distribution: adopt # see https://github.com/marketplace/actions/setup-java-jdk#supported-distributions for supported distros
+        python-version: 3 # see https://github.com/actions/setup-python#supported-version-syntax for supported syntax
 ```

--- a/common-tooling/README.md
+++ b/common-tooling/README.md
@@ -1,0 +1,80 @@
+# common-tooling
+
+This composite Github Action (GHA) is aimed to be used by Camunda teams for configuring either hosted or self-hosted runners with some basic software. Especially useful to have the basics available on self-hosted runners since they come with close to no software.
+
+## Usage
+
+This composite GHA can be used in any repository and should generally run as one of the first actions. Directly before or after the checkout.
+
+### Inputs
+| Input name           | Description                                               | default |
+|----------------------|-----------------------------------------------------------| --------|
+| node-always-auth         | Set always-auth in npmrc. |
+| node-version               | Version Spec of the version to use. Examples: 12.x, 10.15.1, >=10.15.0. | 16 |
+| node-version-file          | File containing the version Spec of the version to use.  Examples: .nvmrc, .node-version, .tool-versions. |
+| node-architecture            | Target architecture for Node to use. Examples: x86, x64. Will use system architecture by default. |
+| node-check-latest       | Set this option if you want the action to check for the latest available version that satisfies the version spec. |
+| node-registry-url | Optional registry to set up for auth. Will set the registry in a project level .npmrc and .yarnrc file, and set up auth to read in from env.NODE_AUTH_TOKEN. | 
+| node-scope | Optional scope for authenticating against scoped registries. Will fall back to the repository owner when using the GitHub Packages registry (https://npm.pkg.github.com/). | 
+| node-token | Used to pull node distributions from node-versions. Since there's a default, this is typically not supplied by the user. When running this action on github.com, the default value is sufficient. When running on GHES, you can pass a personal access token for github.com if you are experiencing rate limiting. |
+| node-cache | Used to specify a package manager for caching in the default directory. Supported values: npm, yarn, pnpm. | 
+| node-cache-dependency-path | Used to specify the path to a dependency file: package-lock.json, yarn.lock, etc. Supports wildcards or a list of file names for caching multiple dependencies. | 
+| node-enabled | Whether to install node or not | 
+| yarn-enabled | Whether to install the latest yarn or not | latest (~1.22) |
+| buildx-version | Buildx version. (eg. v0.3.0)| latest |
+| buildx-driver | Sets the builder driver to be used | 
+| buildx-driver-opts | List of additional driver-specific options. (eg. image=moby/buildkit:master) | 
+| buildx-buildkitd-flags | Flags for buildkitd daemon |
+| buildx-install | Sets up docker build command as an alias to docker buildx build | 
+| buildx-use | Switch to this builder instance | 
+| buildx-endpoint | Optional address for docker socket or context from `docker context ls` |
+| buildx-platforms | Fixed platforms for current node. If not empty, values take priority over the detected ones |
+| buildx-config | BuildKit config file |
+| buildx-config-inline | Inline BuildKit config |
+| buildx-append | Append additional nodes to the builder | 
+| buildx-cleanup | Cleanup temp files and remove builder at the end of a job |
+| buildx-enabled | Whether to install buildx or not |
+| qemu-image | QEMU static binaries Docker image (e.g. tonistiigi/binfmt:latest) |
+| qemu-platforms | Platforms to install (e.g. arm64,riscv64,arm) | all |
+| qemu-enabled | Whether to install qemu or not |
+| java-version | The Java version to set up | 17 |
+| java-distribution | Java distribution | temurin |
+| java-cache-prefix | Cache key prefix | 
+| java-cache-path | Cache path |
+| java-cache-path-add | Additional item for cache path |
+| java-maven-version | The Maven version to set up | 
+| java-enabled | Whether to install java or not |
+| python-version | Version range or exact version of Python or PyPy to use, using SemVer's version range syntax. Reads from .python-version if unset. | 3.11 |
+| python-version-file | File containing the Python version to use. Example: .python-version |
+| python-cache | Used to specify a package manager for caching in the default directory. Supported values: pip, pipenv, poetry. |
+| python-architecture | The target architecture (x86, x64) of the Python or PyPy interpreter. |
+| python-check-latest | Set this option if you want the action to check for the latest available version that satisfies the version spec. |
+| python-token | The token used to authenticate when fetching Python distributions from https://github.com/actions/python-versions. When running this action on github.com, the default value is sufficient. When running on GHES, you can pass a personal access token for github.com if you are experiencing rate limiting. |
+| python-cache-dependency-path | Used to specify the path to dependency files. Supports wildcards or a list of file names for caching multiple dependencies. |
+| python-update-environment | Set this option if you want the action to update environment variables. |
+| python-allow-prereleases | When 'true', a version range passed to 'python-version' input will match prerelease versions if no GA versions are found. Only 'x.y' version range is supported for CPython. |
+| python-enabled | Whether to install python or not |
+| overwrite | Defines whether on hosted runners the present version should be overwritten | true |
+| secrets | toJSON passed GitHub secrets |
+
+### Workflow Example
+```yaml
+---
+name: example
+on:
+  pull_request:
+jobs:
+  some-job:
+    runs-on: ubuntu-latest
+    steps:
+    # install any defaults
+    - uses: camunda/infra-global-github-actions/common-tooling@main
+    # install any defaults and configure maven-settings.xml
+    - uses: camunda/infra-global-github-actions/common-tooling@main
+      with:
+        secrets: ${{ toJSON(secrets) }}
+    # only install missing software components
+    - uses: camunda/infra-global-github-actions/common-tooling@main
+      with:
+        overwrite: "false"
+```

--- a/common-tooling/README.md
+++ b/common-tooling/README.md
@@ -14,24 +14,24 @@ This composite GHA can be used in any repository and should generally run as one
 | node-version-file          | File containing the version Spec of the version to use.  Examples: .nvmrc, .node-version, .tool-versions. |
 | node-architecture            | Target architecture for Node to use. Examples: x86, x64. Will use system architecture by default. |
 | node-check-latest       | Set this option if you want the action to check for the latest available version that satisfies the version spec. |
-| node-registry-url | Optional registry to set up for auth. Will set the registry in a project level .npmrc and .yarnrc file, and set up auth to read in from env.NODE_AUTH_TOKEN. | 
-| node-scope | Optional scope for authenticating against scoped registries. Will fall back to the repository owner when using the GitHub Packages registry (https://npm.pkg.github.com/). | 
+| node-registry-url | Optional registry to set up for auth. Will set the registry in a project level .npmrc and .yarnrc file, and set up auth to read in from env.NODE_AUTH_TOKEN. |
+| node-scope | Optional scope for authenticating against scoped registries. Will fall back to the repository owner when using the GitHub Packages registry (https://npm.pkg.github.com/). |
 | node-token | Used to pull node distributions from node-versions. Since there's a default, this is typically not supplied by the user. When running this action on github.com, the default value is sufficient. When running on GHES, you can pass a personal access token for github.com if you are experiencing rate limiting. |
-| node-cache | Used to specify a package manager for caching in the default directory. Supported values: npm, yarn, pnpm. | 
-| node-cache-dependency-path | Used to specify the path to a dependency file: package-lock.json, yarn.lock, etc. Supports wildcards or a list of file names for caching multiple dependencies. | 
-| node-enabled | Whether to install node or not | 
+| node-cache | Used to specify a package manager for caching in the default directory. Supported values: npm, yarn, pnpm. |
+| node-cache-dependency-path | Used to specify the path to a dependency file: package-lock.json, yarn.lock, etc. Supports wildcards or a list of file names for caching multiple dependencies. |
+| node-enabled | Whether to install node or not |
 | yarn-enabled | Whether to install the latest yarn or not | latest (~1.22) |
 | buildx-version | Buildx version. (eg. v0.3.0)| latest |
-| buildx-driver | Sets the builder driver to be used | 
-| buildx-driver-opts | List of additional driver-specific options. (eg. image=moby/buildkit:master) | 
+| buildx-driver | Sets the builder driver to be used |
+| buildx-driver-opts | List of additional driver-specific options. (eg. image=moby/buildkit:master) |
 | buildx-buildkitd-flags | Flags for buildkitd daemon |
-| buildx-install | Sets up docker build command as an alias to docker buildx build | 
-| buildx-use | Switch to this builder instance | 
+| buildx-install | Sets up docker build command as an alias to docker buildx build |
+| buildx-use | Switch to this builder instance |
 | buildx-endpoint | Optional address for docker socket or context from `docker context ls` |
 | buildx-platforms | Fixed platforms for current node. If not empty, values take priority over the detected ones |
 | buildx-config | BuildKit config file |
 | buildx-config-inline | Inline BuildKit config |
-| buildx-append | Append additional nodes to the builder | 
+| buildx-append | Append additional nodes to the builder |
 | buildx-cleanup | Cleanup temp files and remove builder at the end of a job |
 | buildx-enabled | Whether to install buildx or not |
 | qemu-image | QEMU static binaries Docker image (e.g. tonistiigi/binfmt:latest) |
@@ -39,10 +39,10 @@ This composite GHA can be used in any repository and should generally run as one
 | qemu-enabled | Whether to install qemu or not |
 | java-version | The Java version to set up | 17 |
 | java-distribution | Java distribution | temurin |
-| java-cache-prefix | Cache key prefix | 
+| java-cache-prefix | Cache key prefix |
 | java-cache-path | Cache path |
 | java-cache-path-add | Additional item for cache path |
-| java-maven-version | The Maven version to set up | 
+| java-maven-version | The Maven version to set up |
 | java-enabled | Whether to install java or not |
 | python-version | Version range or exact version of Python or PyPy to use, using SemVer's version range syntax. Reads from .python-version if unset. | 3.11 |
 | python-version-file | File containing the Python version to use. Example: .python-version |
@@ -56,6 +56,7 @@ This composite GHA can be used in any repository and should generally run as one
 | python-enabled | Whether to install python or not |
 | overwrite | Defines whether on hosted runners the present version should be overwritten | true |
 | secrets | toJSON passed GitHub secrets |
+| berlin-timezone | Whether to keep the runner at UTC or set Berlin timezone| true|
 
 ### Workflow Example
 ```yaml

--- a/common-tooling/action.yml
+++ b/common-tooling/action.yml
@@ -1,0 +1,296 @@
+name: Install Common Tooling
+
+description: Install common Camunda tooling
+
+inputs:
+  # Node inputs
+  node-always-auth:
+    description: 'Set always-auth in npmrc.'
+    default: 'false'
+  node-version:
+    description: 'Version Spec of the version to use. Examples: 12.x, 10.15.1, >=10.15.0.'
+    default: '16' # used by a lot of actions as default
+  node-version-file:
+    description: 'File containing the version Spec of the version to use.  Examples: .nvmrc, .node-version, .tool-versions.'
+  node-architecture:
+    description: 'Target architecture for Node to use. Examples: x86, x64. Will use system architecture by default.'
+  node-check-latest:
+    description: 'Set this option if you want the action to check for the latest available version that satisfies the version spec.'
+    default: 'false'
+  node-registry-url:
+    description: 'Optional registry to set up for auth. Will set the registry in a project level .npmrc and .yarnrc file, and set up auth to read in from env.NODE_AUTH_TOKEN.'
+  node-scope:
+    description: 'Optional scope for authenticating against scoped registries. Will fall back to the repository owner when using the GitHub Packages registry (https://npm.pkg.github.com/).'
+  node-token:
+    description: Used to pull node distributions from node-versions. Since there's a default, this is typically not supplied by the user. When running this action on github.com, the default value is sufficient. When running on GHES, you can pass a personal access token for github.com if you are experiencing rate limiting.
+    default: ${{ github.server_url == 'https://github.com' && github.token || '' }}
+  node-cache:
+    description: 'Used to specify a package manager for caching in the default directory. Supported values: npm, yarn, pnpm.'
+  node-cache-dependency-path:
+    description: 'Used to specify the path to a dependency file: package-lock.json, yarn.lock, etc. Supports wildcards or a list of file names for caching multiple dependencies.'
+  node-enabled:
+    description: 'Whether to install node or not'
+    default: 'true'
+  # Yarn
+  yarn-enabled:
+    description: 'Whether to install yarn or not'
+    default: 'true'
+  # BuildX
+  buildx-version:
+    description: 'Buildx version. (eg. v0.3.0)'
+    required: false
+  buildx-driver:
+    description: 'Sets the builder driver to be used'
+    default: 'docker-container'
+    required: false
+  buildx-driver-opts:
+    description: 'List of additional driver-specific options. (eg. image=moby/buildkit:master)'
+    required: false
+  buildx-buildkitd-flags:
+    description: 'Flags for buildkitd daemon'
+    default: '--allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host'
+    required: false
+  buildx-install:
+    description: 'Sets up docker build command as an alias to docker buildx build'
+    default: 'false'
+    required: false
+  buildx-use:
+    description: 'Switch to this builder instance'
+    default: 'true'
+    required: false
+  buildx-endpoint:
+    description: 'Optional address for docker socket or context from `docker context ls`'
+    required: false
+  buildx-platforms:
+    description: 'Fixed platforms for current node. If not empty, values take priority over the detected ones'
+    required: false
+  buildx-config:
+    description: 'BuildKit config file'
+    required: false
+  buildx-config-inline:
+    description: 'Inline BuildKit config'
+    required: false
+  buildx-append:
+    description: 'Append additional nodes to the builder'
+    required: false
+  buildx-cleanup:
+    description: 'Cleanup temp files and remove builder at the end of a job'
+    default: 'true'
+    required: false
+  buildx-enabled:
+    description: 'Whether to install buildx or not'
+    default: 'true'
+  # Qemu
+  qemu-image:
+    description: 'QEMU static binaries Docker image (e.g. tonistiigi/binfmt:latest)'
+    default: 'tonistiigi/binfmt:latest'
+    required: false
+  qemu-platforms:
+    description: 'Platforms to install (e.g. arm64,riscv64,arm)'
+    default: 'all'
+    required: false
+  qemu-enabled:
+    description: 'Whether to install qemu or not'
+    default: 'true'
+  # Java / Maven
+  java-version:
+    description: 'The Java version to set up'
+    default: '17'
+    required: false
+  java-distribution:
+    description: 'Java distribution'
+    default: 'temurin'
+    required: false
+  java-cache-prefix:
+    description: 'Cache key prefix'
+    required: false
+  java-cache-path:
+    description: 'Cache path'
+    default: '~/.m2/repository'
+    required: false
+  java-cache-path-add:
+    description: 'Additional item for cache path'
+    required: false
+  java-maven-version:
+    description: 'The Maven version to set up'
+    default: '3.9.2'
+    required: false
+  secrets:
+    required: false
+    default: ''
+    description: toJSON passed GitHub secrets
+  java-enabled:
+    description: 'Whether to install java or not'
+    default: 'true'
+  # Python
+  python-version:
+    description: "Version range or exact version of Python or PyPy to use, using SemVer's version range syntax. Reads from .python-version if unset."
+    default: "3.11"
+  python-version-file:
+    description: "File containing the Python version to use. Example: .python-version"
+  python-cache:
+    description: "Used to specify a package manager for caching in the default directory. Supported values: pip, pipenv, poetry."
+    required: false
+  python-architecture:
+    description: "The target architecture (x86, x64) of the Python or PyPy interpreter."
+  python-check-latest:
+    description: "Set this option if you want the action to check for the latest available version that satisfies the version spec."
+    default: "false"
+  python-token:
+    description: "The token used to authenticate when fetching Python distributions from https://github.com/actions/python-versions. When running this action on github.com, the default value is sufficient. When running on GHES, you can pass a personal access token for github.com if you are experiencing rate limiting."
+    default: ${{ github.server_url == 'https://github.com' && github.token || '' }}
+  python-cache-dependency-path:
+    description: "Used to specify the path to dependency files. Supports wildcards or a list of file names for caching multiple dependencies."
+  python-update-environment:
+    description: "Set this option if you want the action to update environment variables."
+    default: 'true'
+  python-allow-prereleases:
+    description: "When 'true', a version range passed to 'python-version' input will match prerelease versions if no GA versions are found. Only 'x.y' version range is supported for CPython."
+    default: "false"
+  python-enabled:
+    description: 'Whether to install python or not'
+    default: 'true'
+  overwrite:
+    description: 'Defines whether on hosted runners the present version should be overwritten'
+    default: 'true'
+
+runs:
+  using: composite
+  steps:
+  # figure out what's installed and potentially skip
+  - name: Assess System
+    shell: bash
+    run: |
+      if ! command -v node &> /dev/null
+      then
+          echo "node_missing=true" >> "$GITHUB_ENV"
+      fi
+
+      if ! command -v docker buildx &> /dev/null
+      then
+          echo "buildx_missing=true" >> "$GITHUB_ENV"
+      fi
+
+      if ! command -v python &> /dev/null
+      then
+          echo "python_missing=true" >> "$GITHUB_ENV"
+      fi
+
+      if ! command -v yarn &> /dev/null
+      then
+          echo "yarn_missing=true" >> "$GITHUB_ENV"
+      fi
+
+      if ! command -v java &> /dev/null
+      then
+          echo "java_missing=true" >> "$GITHUB_ENV"
+      fi
+  # Add support for more platforms with QEMU
+  - name: Set up QEMU
+    if: ${{ inputs.qemu-enabled == 'true' }}
+    id: qemu
+    uses: docker/setup-qemu-action@v2
+    with:
+      image: ${{ inputs.qemu-image }}
+      platforms: ${{ inputs.qemu-platforms }}
+  # Docker Buildx
+  - name: Set up Docker Buildx
+    if: ${{ inputs.buildx-enabled == 'true' && ( env.buildx_missing == 'true' || inputs.overwrite == 'true' ) }}
+    uses: docker/setup-buildx-action@v2
+    with:
+      version: ${{ inputs.buildx-version }}
+      driver: ${{ inputs.buildx-driver }}
+      driver-opts: ${{ inputs.buildx-driver-opts }}
+      buildkitd-flags: ${{ inputs.buildx-buildkitd-flags }}
+      install: ${{ inputs.buildx-install }}
+      use: ${{ inputs.buildx-use }}
+      endpoint: ${{ inputs.buildx-endpoint }}
+      platforms: ${{ inputs.buildx-platforms }}
+      config: ${{ inputs.buildx-config }}
+      config-inline: ${{ inputs.buildx-config-inline }}
+      append: ${{ inputs.buildx-append }}
+      cleanup: ${{ inputs.buildx-cleanup }}
+  # Yarn
+  - name: Install Yarn
+    if: ${{ inputs.yarn-enabled == 'true' && ( env.yarn_missing == 'true' || inputs.overwrite == 'true' ) }}
+    shell: bash
+    run: |
+      curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+      echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+      sudo apt update && sudo apt install yarn -y
+      export PATH="$PATH:`yarn global bin`"
+  # Install node
+  - uses: actions/setup-node@v3
+    if: ${{ inputs.node-enabled == 'true' && ( env.node_missing == 'true' || inputs.overwrite == 'true' ) }}
+    with:
+      always-auth: ${{ inputs.node-always-auth }}
+      node-version: ${{ inputs.node-version }}
+      node-version-file: ${{ inputs.node-version-file }}
+      architecture: ${{ inputs.node-architecture }}
+      check-latest: ${{ inputs.node-check-latest }}
+      registry-url: ${{ inputs.node-registry-url }}
+      scope: ${{ inputs.node-scope }}
+      token: ${{ inputs.node-token }}
+      cache: ${{ inputs.node-cache }}
+      cache-dependency-path: ${{ inputs.node-cache-dependency-path }}
+  # Setup Maven
+  - name: Import secrets
+    if: ${{ inputs.secrets != '' && inputs.java-enabled == 'true' && ( env.java_missing == 'true' || inputs.overwrite == 'true' ) }}
+    id: secrets
+    uses: hashicorp/vault-action@v2.7.0
+    with:
+      url: ${{ fromJSON(inputs.secrets).VAULT_ADDR }}
+      method: approle
+      roleId: ${{ fromJSON(inputs.secrets).VAULT_ROLE_ID }}
+      secretId: ${{ fromJSON(inputs.secrets).VAULT_SECRET_ID }}
+      secrets: |
+        secret/data/github.com/organizations/camunda NEXUS_USR;
+        secret/data/github.com/organizations/camunda NEXUS_PSW;
+  - name: Setup Maven Action
+    if: ${{ inputs.java-enabled == 'true' && ( env.java_missing == 'true' || inputs.overwrite == 'true' ) }}
+    uses: s4u/setup-maven-action@v1.8.0
+    with:
+      java-version: ${{ inputs.java-version }}
+      java-distribution: ${{ inputs.java-distribution }}
+      maven-version: ${{ inputs.java-maven-version }}
+      cache-prefix: ${{ inputs.java-cache-prefix }}
+      cache-path: ${{ inputs.java-cache-path }}
+      cache-path-add: ${{ inputs.java-cache-path-add }}
+  - name: 'Create settings.xml'
+    if: ${{ inputs.secrets != '' && inputs.java-enabled == 'true' && ( env.java_missing == 'true' || inputs.overwrite == 'true' ) }}
+    uses: s4u/maven-settings-action@v2.8.0
+    with:
+      githubServer: false
+      servers: |
+        [{
+          "id": "camunda-nexus",
+          "username": "${{ steps.secrets.outputs.NEXUS_USR }}",
+          "password": "${{ steps.secrets.outputs.NEXUS_PSW }}"
+        }]
+      mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
+  # Change Timezone to Berlin
+  - shell: bash
+    run: |
+      sudo rm -rf /etc/localtime
+      sudo ln -s /usr/share/zoneinfo/Europe/Berlin /etc/localtime
+  # Install Python, removed on self-hosted runners
+  - uses: actions/setup-python@v4
+    if: ${{ inputs.python-enabled == 'true' && ( env.python_missing == 'true' || inputs.overwrite == 'true' ) }}
+    with:
+      python-version: ${{ inputs.python-version }}
+      python-version-file: ${{ inputs.python-version-file }}
+      cache: ${{ inputs.python-cache }}
+      architecture: ${{ inputs.python-architecture }}
+      check-latest: ${{ inputs.python-check-latest }}
+      token: ${{ inputs.python-token }}
+      cache-dependency-path: ${{ inputs.python-cache-dependency-path }}
+      update-environment: ${{ inputs.python-update-environment }}
+      allow-prereleases: ${{ inputs.python-allow-prereleases }}
+  - name: Unset Environment variables
+    shell: bash
+    run: |
+      echo "node_missing=" >> "$GITHUB_ENV"
+      echo "java_missing=" >> "$GITHUB_ENV"
+      echo "buildx_missing=" >> "$GITHUB_ENV"
+      echo "python_missing=" >> "$GITHUB_ENV"
+      echo "yarn_missing=" >> "$GITHUB_ENV"

--- a/common-tooling/action.yml
+++ b/common-tooling/action.yml
@@ -115,10 +115,6 @@ inputs:
     description: 'The Maven version to set up'
     default: '3.9.2'
     required: false
-  secrets:
-    required: false
-    default: ''
-    description: toJSON passed GitHub secrets
   java-enabled:
     description: 'Whether to install java or not'
     default: 'true'
@@ -150,9 +146,18 @@ inputs:
   python-enabled:
     description: 'Whether to install python or not'
     default: 'true'
+  # misc
   overwrite:
     description: 'Defines whether on hosted runners the present version should be overwritten'
     default: 'true'
+  secrets:
+    required: false
+    default: ''
+    description: toJSON passed GitHub secrets
+  berlin-timezone:
+    description: 'Whether to keep the runner at UTC or set Berlin timezone'
+    default: 'true'
+
 
 runs:
   using: composite
@@ -270,6 +275,7 @@ runs:
       mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
   # Change Timezone to Berlin
   - shell: bash
+    if: ${{ inputs.berlin-timezone == 'true' }}
     run: |
       sudo rm -rf /etc/localtime
       sudo ln -s /usr/share/zoneinfo/Europe/Berlin /etc/localtime

--- a/common-tooling/action.yml
+++ b/common-tooling/action.yml
@@ -91,7 +91,7 @@ inputs:
     required: false
   qemu-enabled:
     description: 'Whether to install qemu or not'
-    default: 'true'
+    default: 'false'
   # Java / Maven
   java-version:
     description: 'The Java version to set up'
@@ -149,15 +149,7 @@ inputs:
   # misc
   overwrite:
     description: 'Defines whether on hosted runners the present version should be overwritten'
-    default: 'true'
-  secrets:
-    required: false
-    default: ''
-    description: toJSON passed GitHub secrets
-  berlin-timezone:
-    description: 'Whether to keep the runner at UTC or set Berlin timezone'
-    default: 'true'
-
+    default: 'false'
 
 runs:
   using: composite
@@ -171,9 +163,11 @@ runs:
           echo "node_missing=true" >> "$GITHUB_ENV"
       fi
 
-      if ! command -v docker buildx &> /dev/null
+      # custom case since buildx is a subcomamand of docker
+      docker_buildx_count=$(docker buildx 2>&1 | grep -c "docker buildx" || true)
+      if [[ $docker_buildx_count -eq 0 ]]
       then
-          echo "buildx_missing=true" >> "$GITHUB_ENV"
+        echo "buildx_missing=true" >> "$GITHUB_ENV"
       fi
 
       if ! command -v python &> /dev/null
@@ -190,6 +184,10 @@ runs:
       then
           echo "java_missing=true" >> "$GITHUB_ENV"
       fi
+  # For easier debugging which version is missing
+  - name: Print $GITHUB_ENV
+    shell: bash
+    run: echo $GITHUB_ENV
   # Add support for more platforms with QEMU
   - name: Set up QEMU
     if: ${{ inputs.qemu-enabled == 'true' }}
@@ -225,7 +223,8 @@ runs:
       sudo apt update && sudo apt install yarn -y
       export PATH="$PATH:`yarn global bin`"
   # Install node
-  - uses: actions/setup-node@v3
+  - name: Install NodeJS
+    uses: actions/setup-node@v3
     if: ${{ inputs.node-enabled == 'true' && ( env.node_missing == 'true' || inputs.overwrite == 'true' ) }}
     with:
       always-auth: ${{ inputs.node-always-auth }}
@@ -239,18 +238,6 @@ runs:
       cache: ${{ inputs.node-cache }}
       cache-dependency-path: ${{ inputs.node-cache-dependency-path }}
   # Setup Maven
-  - name: Import secrets
-    if: ${{ inputs.secrets != '' && inputs.java-enabled == 'true' && ( env.java_missing == 'true' || inputs.overwrite == 'true' ) }}
-    id: secrets
-    uses: hashicorp/vault-action@v2.7.0
-    with:
-      url: ${{ fromJSON(inputs.secrets).VAULT_ADDR }}
-      method: approle
-      roleId: ${{ fromJSON(inputs.secrets).VAULT_ROLE_ID }}
-      secretId: ${{ fromJSON(inputs.secrets).VAULT_SECRET_ID }}
-      secrets: |
-        secret/data/github.com/organizations/camunda NEXUS_USR;
-        secret/data/github.com/organizations/camunda NEXUS_PSW;
   - name: Setup Maven Action
     if: ${{ inputs.java-enabled == 'true' && ( env.java_missing == 'true' || inputs.overwrite == 'true' ) }}
     uses: s4u/setup-maven-action@v1.8.0
@@ -261,26 +248,9 @@ runs:
       cache-prefix: ${{ inputs.java-cache-prefix }}
       cache-path: ${{ inputs.java-cache-path }}
       cache-path-add: ${{ inputs.java-cache-path-add }}
-  - name: 'Create settings.xml'
-    if: ${{ inputs.secrets != '' && inputs.java-enabled == 'true' && ( env.java_missing == 'true' || inputs.overwrite == 'true' ) }}
-    uses: s4u/maven-settings-action@v2.8.0
-    with:
-      githubServer: false
-      servers: |
-        [{
-          "id": "camunda-nexus",
-          "username": "${{ steps.secrets.outputs.NEXUS_USR }}",
-          "password": "${{ steps.secrets.outputs.NEXUS_PSW }}"
-        }]
-      mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
-  # Change Timezone to Berlin
-  - shell: bash
-    if: ${{ inputs.berlin-timezone == 'true' }}
-    run: |
-      sudo rm -rf /etc/localtime
-      sudo ln -s /usr/share/zoneinfo/Europe/Berlin /etc/localtime
-  # Install Python, removed on self-hosted runners
-  - uses: actions/setup-python@v4
+  # Install Python, it's absent on self-hosted runners
+  - name: Install Python3
+    uses: actions/setup-python@v4
     if: ${{ inputs.python-enabled == 'true' && ( env.python_missing == 'true' || inputs.overwrite == 'true' ) }}
     with:
       python-version: ${{ inputs.python-version }}


### PR DESCRIPTION
related to https://github.com/camunda/team-infrastructure/issues/389

The action pretty much just copies the inputs from the existing actions and prefixes them with whatever the source is. Meaning you're in full control to overwrite anything.
Before running a check is done to see what's available to potentially skip installing a software. Requires `overwrite = false`. Default is to overwrite to have the same versions on `hosted` and `self-hosted` since on `hosted` everything is available.

Creates `common-tooling` action with some defaults on.
Node - 16 lts --> most used by GitHub Actions
Python - 3.11
Java - 17 LTS
Rest is latest where possible.

Added a workflow to test the action with different parameters.
In the case software is already available, the run is a lot quicker, see GHA vs self-hosted or any subsequent run.