### PR TITLE
chore(sanitize-branch-name): Quote the branch name before passing it to sanitize.sh

### DIFF
--- a/sanitize-branch-name/action.yml
+++ b/sanitize-branch-name/action.yml
@@ -30,4 +30,4 @@ runs:
     id: sanitize
     shell: bash
     run: |
-      echo "branch_name=$(${{ github.action_path }}/sanitize.sh ${{ inputs.branch }} ${{ inputs.max_length }})" >> "$GITHUB_OUTPUT"
+      echo "branch_name=$(${{ github.action_path }}/sanitize.sh '${{ inputs.branch }}' ${{ inputs.max_length }})" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
To avoid escaping issues when special chars like `(` or `)` are present in the source branch name.

Related: https://camunda.slack.com/archives/C5AHF1D8T/p1694065338633579

Tested locally:

```bash
$ echo "branch_name=$(./sanitize.sh '5978-Postpend-(copy)-for$$-templates-saved-as-copies' 31)"
branch_name=5978-postpend--copy--for---temp
```