### PR TITLE
chore(preview-env/create): Add a retry logic to the `argocd` `wait` command

### DIFF
--- a/preview-env/create/action.yml
+++ b/preview-env/create/action.yml
@@ -98,7 +98,7 @@ runs:
         fi
         echo "Retry $i ..."
         ((i++))
-        sleep 1
+        sleep 5
       done
       echo "::endgroup::"
     env:

--- a/preview-env/create/action.yml
+++ b/preview-env/create/action.yml
@@ -80,7 +80,14 @@ runs:
     shell: bash
     run: |-
       echo "::group::wait for sync"
-      argocd app wait ${{ inputs.app_name }} --timeout 1200 --health
+      i=1
+      until argocd app wait ${{ inputs.app_name }} --timeout 1200 --health \
+        || [ $i -gt 5 ];
+      do
+        echo Retry $i ...
+        sleep 1
+        ((i++))
+      done
       echo "::endgroup::"
     env:
       ARGOCD_AUTH_TOKEN: ${{ inputs.argocd_token }}

--- a/preview-env/create/action.yml
+++ b/preview-env/create/action.yml
@@ -80,13 +80,25 @@ runs:
     shell: bash
     run: |-
       echo "::group::wait for sync"
+      # Wait for the ArgoCD app to reach a synced and healthy state
+      # Retry if error code = PermissionDenied, as this may be a consistency problem
       i=1
-      until argocd app wait ${{ inputs.app_name }} --timeout 1200 --health \
-        || [ $i -gt 5 ];
+      until \
+        error=$(argocd app wait ${{ inputs.app_name }} --timeout 1200 --health 3>&2 2>&1 1>&3);
       do
-        echo Retry $i ...
-        sleep 1
+        error_code=$?
+        echo "$error" 1>&2
+        # Check if PermissionDenied error
+        if ! echo "$error" | grep "code = PermissionDenied" > /dev/null; then
+          exit $error_code
+        fi
+        # Exit after 5 attempts
+        if [ $i -ge 5 ]; then
+          exit $error_code
+        fi
+        echo "Retry $i ..."
         ((i++))
+        sleep 1
       done
       echo "::endgroup::"
     env:


### PR DESCRIPTION
Related to ask-infra request https://camunda.slack.com/archives/C5AHF1D8T/p1694771504886029.

Permission denied issues are encountered by Operate when deploying a preview environment even though the token used has the right permissions.

It's not related to the Dex crash loop as mentioned in this [comment](https://camunda.slack.com/archives/CHY2S7KDJ/p1694430900442579?thread_ts=1694428700.790319&cid=CHY2S7KDJ). Dex is not part of the authorization validation process.

The most likely hypothesis is a consistency problem between the creation of the app and the execution of the wait command immediately afterwards, as suggested [here](https://camunda.slack.com/archives/CTYKBESCE/p1695026795048189?thread_ts=1695026504.084219&cid=CTYKBESCE), but I couldn't reproduce this scenario in dev.

As a first iteration, we can set up a retry mechanism and see if this solves the problem.

PR has been [validated](https://github.com/camunda/operate/actions/runs/6227962067) on this [test](https://github.com/camunda/operate/tree/infra-request-test-do-not-merge) branch.

Once merged:
- [ ] Delete the [test](https://github.com/camunda/operate/tree/infra-request-test-do-not-merge) branch and associated argocd app