### PR TITLE
chore(preview-env/clean): don't crash on long comments in PRs

### DIFF
--- a/preview-env/clean/github.sh
+++ b/preview-env/clean/github.sh
@@ -224,7 +224,8 @@ function get_pull_requests_by_states_with_last_100_comments {
       "${state_fields[@]}" \
       --field "query=@$RELATIVE_SCRIPT_PATH/graphql/query_get_pull_requests_by_states_with_last_100_comments.gql" |
       jq -s \
-        '[.[].data.repository.pullRequests.nodes[]]'
+        '[.[].data.repository.pullRequests.nodes[]] |
+         (.[].comments.nodes[] | select(.body | length > 1000)).body |= .[0:980] + " ... (truncated)"'
   )
 
   echo "$results"


### PR DESCRIPTION
If pull requests have comments that consist out of several thousand characters, our [script fails](https://github.com/camunda/camunda-optimize/actions/runs/6783837906/job/18438912286?pr=9321) with the following error:

`/home/runner/work/_actions/camunda/infra-global-github-actions/fix-preview-cleanup/preview-env/clean/cleanup.sh: line 296: /usr/bin/jq: Argument list too long`

This is due to passing the JSON with all the PR data via command line to `jq` and exceeding the maximum allowed length. This didn't happen so far in any project of Camunda since comments are usually short (enough). But Optimize employs SonarCloud which posts a comment with >3500 characters under each PR. We do not care about those comments in the cleanup logic (only our own) so I propose to filter for too long comments.

This works now for Optimize in: https://github.com/camunda/camunda-optimize/actions/runs/6783837906?pr=9321

Related to https://github.com/camunda/team-infrastructure/issues/440