### PR TITLE
chore(build-docker-image): disable provenance feature

### DIFF
--- a/build-docker-image/action.yml
+++ b/build-docker-image/action.yml
@@ -135,6 +135,7 @@ runs:
       context: ${{ inputs.build_context }}
       builder: ${{ steps.buildx.output.name }}
       build-args: ${{ inputs.build_args }}
+      provenance: false
       push: ${{ env.SHOULD_WE_PUSH }}
       tags: ${{ steps.meta.outputs.tags }}
       labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Disable provenance for the Docker images

Context: https://github.com/camunda/tasklist/pull/4033