### PR TITLE
chore(gha): Implement a composite action, allowing to invoke the reus…

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -35,7 +35,7 @@ jobs:
  rerun-failed-jobs:
     needs:
       - job1
-    if: failure() && fromJSON(github.run_attempt) < 3 #This limit the job to only be retried two times
+    if: failure() && fromJSON(github.run_attempt) < 3 #This limits the job to only be retried two times
     runs-on: ubuntu-latest
     steps:
       - name: Import secrets

--- a/.github/workflows/rerun-failed-run.yml
+++ b/.github/workflows/rerun-failed-run.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Import Secrets
         id: secrets
-        uses: hashicorp/vault-action@v2.8.0
+        uses: hashicorp/vault-action@v3.0.0
         with:
           url: ${{ secrets.VAULT_ADDR }}
           method: approle

--- a/rerun-failed-run/README.md
+++ b/rerun-failed-run/README.md
@@ -10,7 +10,7 @@ To employ this action, provide the ID of the failed run you wish to retry, along
 
 | Input name                 | Description                                                                                                                                  |
 |----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
-| run-id (required)          | The ID of the failed run to be retried.                                                                                                      |
+| run-id (required)          | The ID of the failed workflow run to be retried.                                                                                             |
 | error-message (required)   | Custom error message to search for in the logs.                                                                                              |
 | repository (required)      | The name of the repository containing the workflow to be retried in the format ORG/REPO_NAME (example: `camunda/infra-global-github-action`) |
 | vault-addr (required)      | The vault URL.                                                                                                                               |
@@ -18,6 +18,7 @@ To employ this action, provide the ID of the failed run you wish to retry, along
 | vault-secret-id (required) | The Vault Secret ID.                                                                                                                         |
 
 ### Workflow Example
+```yaml
 jobs:
   build:
     runs-on: gcp-core-2-default
@@ -38,3 +39,4 @@ jobs:
           vault-addr: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+```

--- a/rerun-failed-run/README.md
+++ b/rerun-failed-run/README.md
@@ -13,7 +13,7 @@ To employ this action, provide the ID of the failed run you wish to retry, along
 | run-id (required)          | The ID of the failed workflow run to be retried.                                                                                             |
 | error-message (required)   | Custom error message to search for in the logs.                                                                                              |
 | repository (required)      | The name of the repository containing the workflow to be retried in the format ORG/REPO_NAME (example: `camunda/infra-global-github-action`) |
-| vault-addr (required)      | The vault URL.                                                                                                                               |
+| vault-addr (required)      | The Vault URL.                                                                                                                               |
 | vault-role-id (required)   | The Vault Role ID.                                                                                                                           |
 | vault-secret-id (required) | The Vault Secret ID.                                                                                                                         |
 

--- a/rerun-failed-run/README.md
+++ b/rerun-failed-run/README.md
@@ -1,0 +1,40 @@
+### Retrigger Failed Run Action
+
+This composite Github Action can be used to retrigger runs which have failed.
+
+### Usage
+
+To employ this action, provide the ID of the failed run you wish to retry, along with the specific error message you aim to address. This targeted approach helps rerun only those actions that failed due to the specified error, rather than all runs. Furthermore, ensure that the repository from which you invoke this composite action has the following secrets configured: VAULT_ADDR, VAULT_ROLE_ID, and VAULT_SECRET_ID. If these secrets are not configured, please contact the infrastructure team to set them up for you.
+
+### Inputs
+
+| Input name                 | Description                                                                                                                                  |
+|----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
+| run-id (required)          | The ID of the failed run to be retried.                                                                                                      |
+| error-message (required)   | Custom error message to search for in the logs.                                                                                              |
+| repository (required)      | The name of the repository containing the workflow to be retried in the format ORG/REPO_NAME (example: `camunda/infra-global-github-action`) |
+| vault-addr (required)      | The vault URL.                                                                                                                               |
+| vault-role-id (required)   | The Vault Role ID.                                                                                                                           |
+| vault-secret-id (required) | The Vault Secret ID.                                                                                                                         |
+
+### Workflow Example
+jobs:
+  build:
+    runs-on: gcp-core-2-default
+    ...
+
+  # rerun the failed job
+  rerun-failed-jobs:
+    needs: build
+    if: failure() && fromJSON(github.run_attempt) < 3 #This limits the job to only be retried two times
+    runs-on: ubuntu-latest
+    steps:
+      - name: Retrigger job
+        uses: camunda/infra-global-github-actions/rerun-failed-job
+        with:
+          error-message: "Process completed with exit code 1."
+          run-id: ${{ github.run_id }}
+          repository: ${{ github.repository }}
+          vault-addr: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}

--- a/rerun-failed-run/README.md
+++ b/rerun-failed-run/README.md
@@ -4,7 +4,12 @@ This composite Github Action can be used to retrigger runs which have failed.
 
 ### Usage
 
-To employ this action, provide the ID of the failed run you wish to retry, along with the specific error message you aim to address. This targeted approach helps rerun only those actions that failed due to the specified error, rather than all runs. Furthermore, ensure that the repository from which you invoke this composite action has the following secrets configured: VAULT_ADDR, VAULT_ROLE_ID, and VAULT_SECRET_ID. If these secrets are not configured, please contact the infrastructure team to set them up for you.
+To call this action, you need to provide:
+- the ID of a failed GitHub Action workflow run to rerun
+- an error message that needs to be present in the workflow run logs
+This targeted approach helps retrigger only those runs that failed due to the specified error.
+You also need ensure that the repository from which you invoke this composite action has the following secrets configured: `VAULT_ADDR`, `VAULT_ROLE_ID`, and `VAULT_SECRET_ID`.
+If these secrets are not present, please contact the infrastructure team to set them up for you.
 
 ### Inputs
 
@@ -31,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Retrigger job
-        uses: camunda/infra-global-github-actions/rerun-failed-job
+        uses: camunda/infra-global-github-actions/rerun-failed-run
         with:
           error-message: "Process completed with exit code 1."
           run-id: ${{ github.run_id }}

--- a/rerun-failed-run/action.yml
+++ b/rerun-failed-run/action.yml
@@ -28,7 +28,7 @@ runs:
   steps:
     - name: Import Secrets
       id: vault-secrets
-      uses: hashicorp/vault-action@3.0.0
+      uses: hashicorp/vault-action@v3.0.0
       with:
         url: ${{ inputs.vault-addr }}
         method: approle

--- a/rerun-failed-run/action.yml
+++ b/rerun-failed-run/action.yml
@@ -20,7 +20,7 @@ inputs:
     description: The Vault role ID for fetching secrets
     required: true
   vault-secret-id:
-    description: The secret id for vault
+    description: The Vault secret ID for fetching secrets
     required: true
 
 runs:

--- a/rerun-failed-run/action.yml
+++ b/rerun-failed-run/action.yml
@@ -1,0 +1,54 @@
+---
+name: Rerun failed run
+
+description: Rerun a run which has failed
+
+inputs:
+  run-id:
+    description: The id of the run we wanna re-trigger.
+    required: true
+  repository:
+    description: The name of the repository in which the run exists.
+    required: true
+  error-message:
+    description: The error message which we want to test against
+    required: true
+  vault-addr:
+    description: The url of vault
+    required: false
+  vault-role-id:
+    description: The role id for vault
+    required: false
+  vault-secret-id:
+    description: The secret id for vault
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Import Secrets
+      id: vault-secrets
+      uses: hashicorp/vault-action@affa6f04da5c2d55e6e115b7d1b044a6b1af8c74 # v2.7.4
+      with:
+        url: ${{ inputs.vault-addr }}
+        method: approle
+        roleId: ${{ inputs.vault-role-id }}
+        secretId: ${{ inputs.vault-secret-id }}
+        secrets: |
+          secret/data/products/infra/ci/retrigger-gha-workflow RETRIGGER_APP_ID;
+          secret/data/products/infra/ci/retrigger-gha-workflow RETRIGGER_APP_KEY;
+
+    - name: Generate a GitHub token
+      id: github-token
+      uses: tibdex/github-app-token@v2
+      with:
+        app_id: ${{ steps.vault-secrets.outputs.RETRIGGER_APP_ID }}
+        private_key: ${{ steps.vault-secrets.outputs.RETRIGGER_APP_KEY }}
+
+    - name: Retrigger run
+      env:
+        GH_DEBUG: api
+      shell: bash
+      run: |
+        echo ${{ steps.github-token.outputs.token }} | gh auth login --with-token
+        gh workflow run rerun-failed-run.yml -R camunda/infra-global-github-actions --ref=main -F run_id=${{ inputs.run-id }} -F repository=${{ inputs.repository }} -F error_message=${{ inputs.error-message }}

--- a/rerun-failed-run/action.yml
+++ b/rerun-failed-run/action.yml
@@ -1,34 +1,34 @@
 ---
 name: Rerun failed run
 
-description: Rerun a run which has failed
+description: Retrigger a GitHub Actions workflow run that has failed with a specific error message
 
 inputs:
   run-id:
-    description: The id of the run we wanna re-trigger.
+    description: The id of the workflow run to re-trigger
     required: true
   repository:
-    description: The name of the repository in which the run exists.
+    description: The name of the repository to which the workflow run belongs
     required: true
   error-message:
-    description: The error message which we want to test against
+    description: The error message to check for in the workflow run logs. Only if the message is found the failed jobs of the workflow run will be retriggered
     required: true
   vault-addr:
-    description: The url of vault
-    required: false
+    description: The Vault URL for fetching secrets
+    required: true
   vault-role-id:
-    description: The role id for vault
-    required: false
+    description: The Vault role ID for fetching secrets
+    required: true
   vault-secret-id:
     description: The secret id for vault
-    required: false
+    required: true
 
 runs:
   using: composite
   steps:
     - name: Import Secrets
       id: vault-secrets
-      uses: hashicorp/vault-action@affa6f04da5c2d55e6e115b7d1b044a6b1af8c74 # v2.7.4
+      uses: hashicorp/vault-action@3.0.0
       with:
         url: ${{ inputs.vault-addr }}
         method: approle


### PR DESCRIPTION
…able workflow to retrigger a gha run

## Description
This pr adds a new composite function aiming to be used by other teams. It invoked the rerun-failed-run workflow and retriggers a run if the inputted error message has been encountered.

## Tests
All tests were made with the aid of the web-modeler repo

Test 1 - Run gets retriggered
[Commit](https://github.com/camunda/web-modeler/pull/8087/commits/a9055e0faaced3784ec7273d36f2db8c9b0feab6)
[Workflow run attempt 1](https://github.com/camunda/web-modeler/actions/runs/7977585978/job/21781209561?pr=8087)
[Workflow run attempt 2](https://github.com/camunda/web-modeler/actions/runs/7977585978?pr=8087)

Test 2 - Run doesnt gets retriggered because the error message is not encountered
[Commit](https://github.com/camunda/web-modeler/pull/8087/commits/342d0b12dcf09ff0134e0083da7d8642f808bff9)
[Workflow run](https://github.com/camunda/web-modeler/actions/runs/7975513522)