### PR TITLE
chore(submit-build-status): ensure unique build_id

### DIFF
--- a/submit-build-status/action.yml
+++ b/submit-build-status/action.yml
@@ -79,7 +79,7 @@ runs:
         "ci_url": "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY",
         "workflow_name": "$GITHUB_WORKFLOW",
         "job_name": "$GITHUB_JOB",
-        "build_id": "$GITHUB_RUN_ID",
+        "build_id": "$GITHUB_RUN_ID/$GITHUB_RUN_ATTEMPT",
         "build_trigger": "$GITHUB_EVENT_NAME",
         "build_status": "${{ inputs.build_status }}",
         "build_ref": "$GITHUB_REF"


### PR DESCRIPTION
It turns out `$GITHUB_RUN_ID` does not change if a workflow run is re-run leading potentially to duplicate rows. We also have to consider the separate `$GITHUB_RUN_ATTEMPT` variable according to https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables

The options I considered were:

* adding a new optional column called e.g. `build_attempt` to `build_status_v2` table (cannot add mandatory fields to existing tables) - more effort and wouldn't be mandatory
* creating a new `build_status_v3` table with mandatory column `build_attempt` - more effort and makes the `build_status_v2` table specific to only GHA wihle it is intended to be abstract from a specific CI (should also be able to hold Jenkins info)
* extending the value of the existing `build_id` with the `$GITHUB_RUN_ATTEMPT` info to ensure unique values (IN THIS PR) - least effort and hides the GHA implementation details while still allowing access to all data through later parsing if needed