### PR TITLE
chore(submit-build-status): add extra info about base ref and runner

### DIFF
--- a/submit-build-status/action.yml
+++ b/submit-build-status/action.yml
@@ -76,6 +76,8 @@ runs:
 
   - name: Submit build status to CI Analytics
     shell: bash
+    env:
+      BUILD_BASE_REF: "${{ github.base_ref && format('refs/heads/{0}', github.base_ref) || github.event.merge_group.base_ref }}"
     run: |
       cat <<EOF | tr '\n' ' ' | bq insert "${{ inputs.big_query_table_name }}"
       {
@@ -86,7 +88,11 @@ runs:
         "build_id": "$GITHUB_RUN_ID/$GITHUB_RUN_ATTEMPT",
         "build_trigger": "$GITHUB_EVENT_NAME",
         "build_status": "${{ inputs.build_status }}",
-        "build_ref": "$GITHUB_REF"
+        "build_ref": "$GITHUB_REF",
+        "runner_name": "$(echo $RUNNER_NAME | tr '[:upper:]' '[:lower:]')",
+        "runner_arch": "$(echo $RUNNER_ARCH | tr '[:upper:]' '[:lower:]')",
+        "runner_os": "$(echo $RUNNER_OS | tr '[:upper:]' '[:lower:]')"
+        ${{ (env.BUILD_BASE_REF == '') && ' ' || format(', "build_base_ref": "{0}"', env.BUILD_BASE_REF) }}
         ${{ (inputs.user_reason == '') && ' ' || format(', "user_reason": "{0}"', inputs.user_reason) }}
         ${{ (inputs.user_description == '') && ' ' || format(', "user_description": "{0}"', inputs.user_description) }}
       }


### PR DESCRIPTION
This PR needs https://github.com/camunda/infra-core/pull/7580 to collect and ingest additional metadata about GHA runs into CI Analytics.

The new info is helpful for users and Infra operators and easy to collect:

* `build_base_ref` is the target branch of a PR or merge queue run. This is important if you have multiple persistent branches like `main` and `stable/*` to identify for which branch a GHA workflow run was done and filter statistics e.g. only for `main`
* `runner_name` in lowercase like "github actions 123" for Github-hosted runners or the agent name of our self-hosted runners, allows Infra to distinguish and isolate problems with self-hosted runners
* `runner_arch` in lowercase is nice to know in case arm64 or amd64
* `runner_os` in lowercase in case we ever do esoteric stuff on macos or windows runners

The information is retrieved from [GitHub variables](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables) available in every run. Special handling is required for [extracting the base ref in merge queues](https://github.com/orgs/community/discussions/40277).

This was tested in `dev` environment already as part of a POC of https://github.com/camunda/zeebe/pull/17517 and working:

![image](https://github.com/camunda/infra-global-github-actions/assets/800933/8f414d9e-e312-47d7-8d82-bd02dd450bf4)

Also works if `build_base_ref` is not present (e.g. on push, basically outside of PRs or merge queues):

![image](https://github.com/camunda/infra-global-github-actions/assets/800933/875bcd63-ba3d-4c79-8c7b-7fb294c847e5)

Go to https://console.cloud.google.com/bigquery?project=ci-30-162810 and look into `ci_analytics_dev`