### PR TITLE
chore(submit-build-status): support windows

### DIFF
--- a/submit-build-status/action.yml
+++ b/submit-build-status/action.yml
@@ -78,8 +78,9 @@ runs:
     shell: bash
     env:
       BUILD_BASE_REF: "${{ github.base_ref && format('refs/heads/{0}', github.base_ref) || github.event.merge_group.base_ref }}"
+      BG_COMMAND: "${{ (runner.os == 'Windows') && 'bq.cmd' || 'bq' }}"
     run: |
-      cat <<EOF | tr '\n' ' ' | bq insert "${{ inputs.big_query_table_name }}"
+      cat <<EOF | tr '\n' ' ' | $BG_COMMAND insert "${{ inputs.big_query_table_name }}"
       {
         "report_time": "$(date '+%Y-%m-%d %H:%M:%S')",
         "ci_url": "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY",


### PR DESCRIPTION
If we are on Windows we have to use a different executable name apparently for the BigQuery client executable.

Solution via https://stackoverflow.com/questions/72924110/how-can-one-detect-if-a-github-actions-runner-is-running-in-ubuntu-or-windows to detect if we are on Windows and https://stackoverflow.com/questions/28464658/bigquery-command-line-tool-on-windows to know the correct executable name: works -> https://github.com/camunda/zeebe/actions/runs/8967179607/job/24627763741?pr=18224

Found in https://github.com/camunda/zeebe/pull/18224