### PR TITLE
feat: on workflow retry, wait for completion

### DIFF
--- a/.github/workflows/rerun-failed-run.yml
+++ b/.github/workflows/rerun-failed-run.yml
@@ -58,4 +58,6 @@ jobs:
           GH_DEBUG: api
           GITHUB_TOKEN: ${{ steps.github-token.outputs.token }}
         run: |
+          : # wait until the job is completed
+          gh run watch ${{ inputs.run_id }} -R ${{ inputs.repository }} > /dev/null 2>&1
           gh run rerun ${{ inputs.run_id }} -R ${{ inputs.repository }} --failed

--- a/rerun-failed-run/action.yml
+++ b/rerun-failed-run/action.yml
@@ -51,9 +51,6 @@ runs:
         GITHUB_TOKEN: ${{ steps.github-token.outputs.token }}
       shell: bash
       run: |
-        : # wait until the job is completed
-        gh run watch -R "${{ inputs.repository }}" "${{ inputs.run-id }}" > /dev/null 2>&1
-
         error_messages="${{ inputs.error-messages }}"
         result=$(echo "$error_messages" | jq -c -n -R '[inputs | select(length > 0)]')
         echo "result: $result"


### PR DESCRIPTION
This PR introduces a mechanism to wait for the workflow that needs to be retried to complete properly. Without this waiting mechanism, the retry fails: [workflow link](https://github.com/camunda/infra-global-github-actions/actions/runs/9568479702/job/26378796649).

I haven't been able to test it since the action calls a workflow_dispatch.

This scenario occurs when cleanup actions exist after capturing the fail handover (https://github.com/camunda/keycloak/pull/131).