### PR TITLE
ci(preview-env): fix argoCD template

### DIFF
--- a/preview-env/create/templates/comment-cancelled.md
+++ b/preview-env/create/templates/comment-cancelled.md
@@ -1,4 +1,4 @@
 ### `${APP_NAME}`
 * __Status:__ :x:
-* __ArgoCD:__ :link: [Link](https://${ARGOCD_SERVER}/applications?search=${APP_NAME})
+* __ArgoCD:__ :link: [Link](https://${ARGOCD_SERVER}/applications/argocd/${APP_NAME}?view=tree&resource=)([degraded resources](https://${ARGOCD_SERVER}/applications/argocd/${APP_NAME}?view=tree&resource=health%3ADegraded))
 * __Deployment Jobs:__ :clipboard: [Link](https://github.com/${REPO}/actions/runs/${RUN_ID})

--- a/preview-env/create/templates/comment-failure.md
+++ b/preview-env/create/templates/comment-failure.md
@@ -1,4 +1,4 @@
 ### `${APP_NAME}`
 * __Status:__ :x:
-* __ArgoCD:__ :link: [Link](https://${ARGOCD_SERVER}/applications?search=${APP_NAME})
+* __ArgoCD:__ :link: [Link](https://${ARGOCD_SERVER}/applications/argocd/${APP_NAME}?view=tree&resource=)([degraded resources](https://${ARGOCD_SERVER}/applications/argocd/${APP_NAME}?view=tree&resource=health%3ADegraded))
 * __Deployment Jobs:__ :clipboard: [Link](https://github.com/${REPO}/actions/runs/${RUN_ID})

--- a/preview-env/create/templates/comment-success.md
+++ b/preview-env/create/templates/comment-success.md
@@ -1,5 +1,5 @@
 ### `${APP_NAME}`
 * __Status:__ :white_check_mark:
 * __URL:__ :globe_with_meridians: [Link](${APP_URL})
-* __ArgoCD:__ :link: [Link](https://${ARGOCD_SERVER}/applications?search=${APP_NAME})
+* __ArgoCD:__ :link: [Link](https://${ARGOCD_SERVER}/applications/argocd/${APP_NAME}?view=tree&resource=)
 * __Deployment Jobs:__ :clipboard: [Link](https://github.com/${REPO}/actions/runs/${RUN_ID})


### PR DESCRIPTION
This PR is a fix for the comment summary templates as aligned in:
* https://github.com/camunda/team-infrastructure/issues/459#issuecomment-2258008062

It specifically fixes the ArgoCD URLs in the result templates.

Tested through this Draft PR: <tbd>