### PR TITLE
feat(setup-yarn-cache): add new action, from the C8 monorepo

### DIFF
--- a/setup-yarn-cache/README.md
+++ b/setup-yarn-cache/README.md
@@ -1,0 +1,60 @@
+# setup-yarn-cache
+
+This composite Github Action (GHA) can be used by Camunda teams to reduce GHA cache usage for Yarn projects by only persisting caches on `main` or other persistent branches, see the [C8 Monorepo Caching Strategy](https://github.com/camunda/camunda/wiki/CI-&-Automation#caching-strategy) for details. This reduces likelihood of build failures and increases cache hit rate especially in mono repositories.
+
+## Usage
+
+This composite GHA can be used in any repository that uses Yarn and wants to utilize GHA cache more efficiently than e.g. `setup-node` [does by default](https://github.com/actions/setup-node/issues/663) at scale.
+
+### Inputs
+
+| Input name           | Description                                        |
+|----------------------|----------------------------------------------------|
+| directory | Directory of the project for which Yarn to GHA cache should be configured |
+| cache_create_branch_regex | GHA cache will only be saved on branches that match this regex |
+
+### Behavior
+
+This action should be invoked by a GHA job after installing NodeJS/Yarn in the desired version (make sure to disable caching for e.g. `setup-node` since it will conflict) to set up more efficient GHA cache usage for Yarn. No further configuration is needed, see example below.
+
+### Integration
+
+It is task of the user to integrate this action into their GHA workflows by invoking it at all suitable places and providing the desired inputs. See the next section for one possible simple integration.
+
+### Workflow Example
+
+Assuming a Yarn workspace resides in the directory `frontend/client` in the repository:
+
+```yaml
+---
+name: ci
+
+on: [push, pull_request]
+
+jobs:
+  frontend-build:
+    runs-on: ubuntu-22.04
+    steps:
+    # Needed to create a workspace and have composite GHA available
+    - uses: actions/checkout@v4
+
+    - name: Setup NodeJS
+      uses: actions/setup-node@v4
+      with:
+        node-version: "20"
+        # DON'T specify any cache-related options here!
+
+    # This sets up the GHA cache for Yarn (no save on PRs)
+    - uses: camunda/infra-global-github-actions/setup-yarn-cache@main
+      with:
+        directory: frontend/client
+
+    - name: Install node dependencies
+      working-directory: ./frontend/client
+      run: yarn install
+
+    - name: Build frontend
+      working-directory: ./frontend/client
+      run: yarn build
+
+```

--- a/setup-yarn-cache/action.yml
+++ b/setup-yarn-cache/action.yml
@@ -1,0 +1,78 @@
+
+---
+name: Set up GHA caching for Yarn
+
+description: Configures GHA cache for Yarn global cache dir (no save on PRs), see https://github.com/camunda/camunda/wiki/CI-&-Automation#caching-strategy
+
+inputs:
+  directory:
+    description: Directory of the project for which Yarn to GHA cache should be configured
+    required: true
+
+  cache_create_branch_regex:
+    description: GHA cache will only be saved on branches that match this regex, see https://github.com/camunda/camunda/wiki/CI-&-Automation#caching-strategy
+    required: false
+    default: '^(stable\/.+|main)$'
+
+runs:
+  using: composite
+  steps:
+  - name: Echo inputs
+    shell: bash
+    run: |
+      echo "Inputs"
+      echo "-----"
+      echo "Yarn workspace directory: ${{ inputs.directory }}"
+      echo "Cache create branch regex: ${{ inputs.cache_create_branch_regex }}"
+
+  - name: Check if cache should be created
+    id: is-cache-create-branch
+    shell: bash
+    run: |
+      BRANCH_NAME=${GITHUB_REF#refs/heads/}
+      BRANCH_REGEX="${{ inputs.cache_create_branch_regex }}"
+
+      if [[ $BRANCH_NAME =~ $BRANCH_REGEX ]]; then
+        echo "result=true" >> $GITHUB_OUTPUT
+      else
+        echo "result=false" >> $GITHUB_OUTPUT
+      fi
+
+  - name: Get Yarn global cache directory
+    shell: bash
+    working-directory: ${{ inputs.directory }}
+    run: |
+      yarn_version=$(yarn --version)
+      echo "yarn version: $yarn_version"
+
+      if [[ $yarn_version == 1* ]]; then
+        echo "Yarn version 1.x"
+        yarn cache dir || true
+        echo "CUSTOM_YARN_GLOBAL_CACHE_DIR=$(yarn cache dir)" >> $GITHUB_ENV
+      else
+        echo "Yarn version 2.x?"
+        yarn config get cacheFolder || true
+        echo "CUSTOM_YARN_GLOBAL_CACHE_DIR=$(yarn config get cacheFolder)" >> $GITHUB_ENV
+      fi
+
+  - name: Save global Yarn cache on non-PRs
+    if: ${{ steps.is-cache-create-branch.outputs.result == 'true' }}
+    uses: actions/cache@v4
+    with:
+      # need to use an environment variable here, thx to https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7415
+      path: "${{ env.CUSTOM_YARN_GLOBAL_CACHE_DIR }}"
+      # it matters for caching as absolute paths on self-hosted and Github runners differ
+      # self-hosted: `/runner/` vs gh-hosted: `/home/runner`
+      key: ${{ runner.environment }}-${{ runner.os }}-yarn-${{ hashFiles(format('{0}/yarn.lock', inputs.directory)) }}
+      restore-keys: |
+        ${{ runner.environment }}-${{ runner.os }}-yarn
+
+  - name: Restore global Yarn cache always
+    # Restore cache (but don't save it) if we're not on main or stable/* branches
+    if: ${{ steps.is-cache-create-branch.outputs.result != 'true' }}
+    uses: actions/cache/restore@v4
+    with:
+      path: "${{ env.CUSTOM_YARN_GLOBAL_CACHE_DIR }}"
+      key: ${{ runner.environment }}-${{ runner.os }}-yarn-${{ hashFiles(format('{0}/yarn.lock', inputs.directory)) }}
+      restore-keys: |
+        ${{ runner.environment }}-${{ runner.os }}-yarn


### PR DESCRIPTION
This action was originally created in https://github.com/camunda/camunda/issues/21427 but is now relocated for wider use also in other repositories (disccused in [Slack](https://camunda.slack.com/archives/CHY2S7KDJ/p1725364793383679?thread_ts=1725281533.019179&cid=CHY2S7KDJ)).

Noteworthy is the new input for this action `cache_create_branch_regex` which allows configuring on which branches to save the cache on (done via Bash now instead of GHA expression to allow parameterization), the defaults suit the C8 monorepo to avoid repeating configuration.

The new action is successfully used in https://github.com/camunda/camunda/actions/runs/10699692498/job/29661839825?pr=21915 as an example