### PR TITLE
fix(download-center): setup python with supported version

### DIFF
--- a/download-center-upload/action.yml
+++ b/download-center-upload/action.yml
@@ -37,7 +37,7 @@ runs:
   - name: Setup python
     uses: actions/setup-python@v5
     with:
-      python-version: '3.11'
+      python-version: '3.11' # gsutil requires python 3.5-3.11 (https://cloud.google.com/storage/docs/gsutil_install#specifications)
 
   - name: Resolve variables
     shell: bash

--- a/download-center-upload/action.yml
+++ b/download-center-upload/action.yml
@@ -34,6 +34,11 @@ runs:
   using: "composite"
 
   steps:
+  - name: Setup python
+    uses: actions/setup-python@v5
+    with:
+      python-version: '3.11'
+
   - name: Resolve variables
     shell: bash
     id: variables


### PR DESCRIPTION
This is required due to gsutil not supporting Python 3.12 and newer. Cf. https://github.com/camunda/camunda-modeler/actions/runs/11371346205/job/31633203620#step:9:95