### PR TITLE
refactor(download-center-upload): use gcloud storage

### DIFF
--- a/download-center-upload/README.md
+++ b/download-center-upload/README.md
@@ -5,7 +5,7 @@
 This action uploads files to [Camunda Download center]( https://downloads.camunda.cloud/). This is useful when you want
 to upload artifacts from your workflow.
 
-This action is owned by Infra team.
+This action is owned by the [Infrastructure Team](https://camunda.slack.com/archives/C5AHF1D8T).
 
 ## Usage
 

--- a/download-center-upload/action.yml
+++ b/download-center-upload/action.yml
@@ -89,7 +89,7 @@ runs:
   - name: Upload files
     shell: bash
     run: |
-      gsutil -m cp ${{ inputs.artifact_file }} gs://${{ steps.variables.outputs.bucket_name }}/${{ steps.variables.outputs.dc_repo }}/${{ steps.variables.outputs.subpath }}${{ steps.variables.outputs.version }}${{ steps.variables.outputs.subversion }}
+      gcloud storage cp ${{ inputs.artifact_file }} gs://${{ steps.variables.outputs.bucket_name }}/${{ steps.variables.outputs.dc_repo }}/${{ steps.variables.outputs.subpath }}${{ steps.variables.outputs.version }}${{ steps.variables.outputs.subversion }}
 
 branding:
   icon: upload


### PR DESCRIPTION
Replace `gsutils -m cp` with `gcloud storage cp` to be working appropriately with python `>=3.12` which is installed on current ubuntu runner images (>= `24.04`).