### PR TITLE
chore(download-center-upload): Disable parallel composite uploads

### DIFF
--- a/download-center-upload/action.yml
+++ b/download-center-upload/action.yml
@@ -89,6 +89,12 @@ runs:
   - name: Upload files
     shell: bash
     run: |
+      # the target buckets don't support parallel composite uploads
+      # turning it off so there's no checks requiring higher service account permissions
+      # https://stackoverflow.com/q/78548796
+      gcloud config set storage/parallel_composite_upload_enabled false
+      gcloud config set storage/parallel_composite_upload_compatibility_check false
+
       gcloud storage cp ${{ inputs.artifact_file }} gs://${{ steps.variables.outputs.bucket_name }}/${{ steps.variables.outputs.dc_repo }}/${{ steps.variables.outputs.subpath }}${{ steps.variables.outputs.version }}${{ steps.variables.outputs.subversion }}
 
 branding:


### PR DESCRIPTION
After https://github.com/camunda/infra-global-github-actions/pull/281, we're using `gcloud storage` instead of `gsutil` to upload files to the Download Center buckets.

`gcloud storage cp` has a different behaviour for small and larger (>150MB) files: for larger ones it tries to use parallel composite upload [approach](https://cloud.google.com/storage/docs/parallel-composite-uploads). However, this approach has a lot of demands on the bucket's configutation to work, and our download center buckets don't have them:

```
WARNING: Destination has a default storage class other than "STANDARD", hence parallel composite upload will not be performed. If you would like to disable this check, run: gcloud config set storage/parallel_composite_upload_compatibility_check=False
```

However, `gcloud storage` first tries to get the info about the bucket to see if it's compatible with the parallel composite. That means a service account used by `gcloud storage` needs to have that permission (to get the bucket's info). For the least principle privilege, we don't grant that permission to the service account used for the uploads to DC, making the upload fail for files over 150MB.

Since the bucket does not support the composite mode anyway, I'm forcefully turning off `gcloud`'s settings, so it does not try to use the parallel composite upload and also does not try to check if a bucket is even eligible for composite uploads.

Stackoverflow insights: https://stackoverflow.com/a/79032926

Context: https://camunda.slack.com/archives/C5AHF1D8T/p1730377605848339