### PR TITLE
ci: avoid opening 2 actionlint-renovate PRs

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,4 @@
 
-# renovate: datasource=github-tags depName=rhysd/actionlint
 actionlint 1.7.3
 
 pre-commit 4.0.1


### PR DESCRIPTION
This annotation is unnecessary and sometimes causes duplicate renovate PRs (see example [1](https://github.com/kellervater/renovate-test/pull/7) and [2](https://github.com/kellervater/renovate-test/pull/8)).
Validated with [this PR](https://github.com/kellervater/renovate-test/pull/8).

> [!NOTE]
> Due to security reasons, this (yet) personal repository is private, so unauthorized people won't see our global renovate config. If there's no need for privacy here, I can make them public. You can also request contributor access OR we can move it as sandbox project to Camunda.