### PR TITLE
chore(build status actions): add head ref parameter

### DIFF
--- a/submit-aborted-gha-status/README.md
+++ b/submit-aborted-gha-status/README.md
@@ -31,6 +31,7 @@ All data submitted by this action is stored as one record in the Big Query table
 | build_status     | STRING     | REQUIRED   | `"aborted"` |
 | build_ref        | STRING     | NULLABLE   | Git object reference from `"$GITHUB_REF"` |
 | build_base_ref   | STRING     | NULLABLE   | Git object reference of target branch for PRs or GH merge queue |
+| build_head_ref   | STRING     | NULLABLE   | Git object reference of the branch PR was built against |
 | build_duration_milliseconds | INTEGER | NULLABLE | `null` (not implemented yet) |
 | runner_name      | STRING     | NULLABLE   | Lowercase name of the runner executing the GHA workflow job |
 | runner_arch      | STRING     | NULLABLE   | `null` (cannot be determined afterwards) |

--- a/submit-aborted-gha-status/action.yml
+++ b/submit-aborted-gha-status/action.yml
@@ -43,6 +43,7 @@ runs:
     env:
       BG_COMMAND: "${{ (runner.os == 'Windows') && 'bq.cmd' || 'bq' }}"
       BUILD_BASE_REF: "${{ github.base_ref && format('refs/heads/{0}', github.base_ref) || github.event.merge_group.base_ref }}"
+      BUILD_HEAD_REF: "${{ github.head_ref && format('refs/heads/{0}', github.head_ref) || github.event.merge_group.head_ref }}"
       GH_TOKEN: ${{ github.token }}
     run: |
       gh api -X GET "repos/camunda/camunda/actions/runs/$GITHUB_RUN_ID/attempts/$GITHUB_RUN_ATTEMPT/jobs?per_page=100" --jq '.jobs[] | select(.conclusion=="failure") .id' | while read job_id; do
@@ -72,6 +73,7 @@ runs:
         "runner_name": "$runner_name",
         "user_reason": "agent-disconnected"
         ${{ (env.BUILD_BASE_REF == '') && ' ' || format(', "build_base_ref": "{0}"', env.BUILD_BASE_REF) }}
+        ${{ (env.BUILD_HEAD_REF == '') && ' ' || format(', "build_head_ref": "{0}"', env.BUILD_HEAD_REF) }}
       }
       EOF
         fi

--- a/submit-build-status/README.md
+++ b/submit-build-status/README.md
@@ -36,6 +36,7 @@ All data submitted by this action is stored as one record in the Big Query table
 | build_status     | STRING     | REQUIRED   | Based on user input |
 | build_ref        | STRING     | NULLABLE   | Git object reference from `"$GITHUB_REF"` |
 | build_base_ref   | STRING     | NULLABLE   | Git object reference of target branch for PRs or GH merge queue |
+| build_head_ref   | STRING     | NULLABLE   | Git object reference of the branch PR was built against |
 | build_duration_milliseconds | INTEGER | NULLABLE | Based on user input (time a job needed from start to finish) |
 | runner_name      | STRING     | NULLABLE   | Lowercase name of the runner executing the GHA workflow job |
 | runner_arch      | STRING     | NULLABLE   | Lowercase name of the runner's CPU architecture executing the GHA workflow job |

--- a/submit-build-status/action.yml
+++ b/submit-build-status/action.yml
@@ -89,6 +89,7 @@ runs:
     env:
       BG_COMMAND: "${{ (runner.os == 'Windows') && 'bq.cmd' || 'bq' }}"
       BUILD_BASE_REF: "${{ github.base_ref && format('refs/heads/{0}', github.base_ref) || github.event.merge_group.base_ref }}"
+      BUILD_HEAD_REF: "${{ github.head_ref && format('refs/heads/{0}', github.head_ref) || github.event.merge_group.head_ref }}"
     run: |
       cat <<EOF | tr '\n' ' ' | $BG_COMMAND insert "${{ inputs.big_query_table_name }}"
       {
@@ -104,6 +105,7 @@ runs:
         "runner_arch": "$(echo $RUNNER_ARCH | tr '[:upper:]' '[:lower:]')",
         "runner_os": "$(echo $RUNNER_OS | tr '[:upper:]' '[:lower:]')"
         ${{ (env.BUILD_BASE_REF == '') && ' ' || format(', "build_base_ref": "{0}"', env.BUILD_BASE_REF) }}
+        ${{ (env.BUILD_HEAD_REF == '') && ' ' || format(', "build_head_ref": "{0}"', env.BUILD_HEAD_REF) }}
         ${{ (inputs.build_duration_millis == '') && ' ' || format(', "build_duration_milliseconds": "{0}"', inputs.build_duration_millis) }}
         ${{ (inputs.user_reason == '') && ' ' || format(', "user_reason": "{0}"', inputs.user_reason) }}
         ${{ (inputs.user_description == '') && ' ' || format(', "user_description": "{0}"', inputs.user_description) }}


### PR DESCRIPTION
This PR adds `build_head_ref` parameter to build status actions and requires https://github.com/camunda/infra-core/pull/8624 in production to work.

related to https://github.com/camunda/camunda/issues/24549