### PR TITLE
chore(feat): enable using google workload identity

### DIFF
--- a/build-docker-image/README.md
+++ b/build-docker-image/README.md
@@ -8,23 +8,24 @@ This composite GHA can be used in any non-public repository with a `Dockerfile` 
 
 ### Inputs
 
-| Input name        | Description                                        |
-|-------------------|----------------------------------------------------|
-| registry_host     | Host name of target Docker registry, e.g. `gcr.io` |
-| registry_username | Username used for authenticating to registry host  |
-| registry_password | Password used for authenticating to registry host  |
-| image_name        | Docker image name (*without* registry and Docker tag), e.g. `example/image` |
-| build_args        | Allows defining extra build-args, supply as list with \| (pipe bar) |
-| extra_tags        | Allows defining extra tags according to the [metadata action](https://github.com/docker/metadata-action), supply as list with \| (pipe bar) |
-| force_push        | Allows overwriting the image push behaviour, by setting to 'true' as input |
-| build_context     | Docker build context location                      |
-| build_allow       | Extra privilege entitlements to give builder       |
-| build_platforms   | List of [target platforms](https://docs.docker.com/engine/reference/commandline/buildx_build/#platform) for build        |
-| buildx_driver     | Driver to use for buildx builder                   |
-| buildx_version    | Which release version of a buildx action to use    |
-| docker_load       | Whether or not to load docker image builds into the local Docker Images |
-| qemu_image        | QEMU static binaries Docker image                  |
-| qemu_platforms    | Platforms to install (e.g., `arm64,riscv64,arm`)   |
+| Input name                 | Description                                        |
+|----------------------------|----------------------------------------------------|
+| registry_host              | Host name of target Docker registry, e.g. `gcr.io` |
+| registry_username          | Username used for authenticating to registry host  |
+| registry_password          | Password used for authenticating to registry host  |
+| use_workload_identity_auth | Use Google Workload Identity for authenticating to registry host |
+| image_name                 | Docker image name (*without* registry and Docker tag), e.g. `example/image` |
+| build_args                 | Allows defining extra build-args, supply as list with \| (pipe bar) |
+| extra_tags                 | Allows defining extra tags according to the [metadata action](https://github.com/docker/metadata-action), supply as list with \| (pipe bar) |
+| force_push                 | Allows overwriting the image push behaviour, by setting to 'true' as input |
+| build_context              | Docker build context location                      |
+| build_allow                | Extra privilege entitlements to give builder       |
+| build_platforms            | List of [target platforms](https://docs.docker.com/engine/reference/commandline/buildx_build/#platform) for build        |
+| buildx_driver              | Driver to use for buildx builder                   |
+| buildx_version             | Which release version of a buildx action to use    |
+| docker_load                | Whether or not to load docker image builds into the local Docker Images |
+| qemu_image                 | QEMU static binaries Docker image                  |
+| qemu_platforms             | Platforms to install (e.g., `arm64,riscv64,arm`)   |
 
 For the above example inputs the resulting Docker image would be named `gcr.io/example/image`.
 

--- a/build-docker-image/action.yml
+++ b/build-docker-image/action.yml
@@ -13,6 +13,16 @@ inputs:
   registry_password:
     description: Registry password used for authenticating to registry host.
     required: true
+  # NOTE: Schroedinger's credentials.
+  # When using Workload Identity for authentication, technically we don't need
+  # a username and a password. But those are required inputs for the "conventional" logins.
+  # Therefore in case of using Workload Identity any username and password combination will do
+  # as they won't be used by the workflow step anyway. In this case the proper authentiaction
+  # should be handled in the caller workflow.
+  use_workload_identity_auth:
+    description: Use Google Workload Identity for authenticating to registry host.
+    required: false
+    default: 'false'
   image_name:
     description: Docker image name WITHOUT registry and WITHOUT Docker tag, e.g. example/image.
     required: true
@@ -143,12 +153,19 @@ runs:
       version: ${{ inputs.buildx_version }}
       driver: ${{ inputs.buildx_driver }}
 
+  - name: Check for Google Workload Identity auth
+    # Promote switching to Google Workload Identity authentication
+    shell: bash
+    if: ${{ env.SHOULD_WE_PUSH == 'true' && inputs.use_workload_identity_auth == 'false' }}
+    run: echo "::warning::Workload Identity authentication is not enabled. To follow security best practices please consider switching. Proceeding with the provided credentials now."
+
   - name: Login to Docker registry
     uses: docker/login-action@v3
-    # Only attempt login when we want to push. This avoids depending on a 3rd
-    # party service when not needed. In case the registry is unavailable
-    # the non-push builds will continue to be green.
-    if: ${{ env.SHOULD_WE_PUSH == 'true' }}
+    # Only attempt login when we want to push and use a conventional login.
+    # (The login step is not needed for Google Workload Identity.)
+    # This avoids depending on a 3rd party service when not needed.
+    # In case the registry is unavailable the non-push builds will continue to be green.
+    if: ${{ env.SHOULD_WE_PUSH == 'true' && inputs.use_workload_identity_auth == 'false' }}
     with:
       registry: ${{ inputs.registry_host }}
       username: ${{ inputs.registry_username }}


### PR DESCRIPTION
Skip authenticating with a Docker registry using username/password in case of the caller workflow uses Google Workload Identity.

Related:
camunda/team-infrastructure/issues/629