### PR TITLE
chore: creates the is-cache-enabled action alone

### DIFF
--- a/is-cache-enabled/action.yml
+++ b/is-cache-enabled/action.yml
@@ -5,15 +5,11 @@ description: |
   Checks if cache is enabled given three conditions
   - is a pull request related event
   - the pull request does not contains a 'ci:no-cache' label
-  - the branch is neither 'main' nor 'stable/*'
   This information can be used to skip cache restoration
   in the setup-maven-cache and setup-yarn-cache to test
   workflows from scratch
 
-inputs: 
-  is-cache-restore-branch:
-    description: Specify if the current working branch valid for cache restore. true or false
-    required: true
+inputs: {}
 
 outputs:
   is-cache-disabled:
@@ -21,7 +17,6 @@ outputs:
       Output whether the workflows has cache enabled based on three conditions:
       - workflow is triggered by a pull_request event
       - pull_request does not contains 'ci:no-cache' label
-      - branch is valid for cache restoration
     value: ${{ steps.detect-cache-status.outputs.is-cache-enabled == 'true' }}
 
 runs:
@@ -33,13 +28,11 @@ runs:
     run: |
       IS_PR_EVENT=${{ github.event_name == 'pull_request' }}
       HAS_NO_CACHE_LABEL=${{ contains(github.event.pull_request.labels.*.name, 'ci:no-cache') }}
-      IS_CACHE_RESTORE_BRANCH=${{ inputs.is-cache-restore-branch }}
       echo "IS_PR_EVENT: $IS_PR_EVENT"
       echo "HAS_NO_CACHE_LABEL: $HAS_NO_CACHE_LABEL"
-      echo "IS_CACHE_RESTORE_BRANCH: $IS_CACHE_RESTORE_BRANCH"
 
       IS_CACHE_ENABLED="true"
-      if [[ $HAS_NO_CACHE_LABEL == "true" && $IS_PR_EVENT == "true" && $IS_VALID_CACHE_RESTORE_BRANCH == "true" ]]; then
+      if [[ $HAS_NO_CACHE_LABEL == "true" && $IS_PR_EVENT == "true" ]]; then
         IS_CACHE_ENABLED="false"
       fi
       echo "IS_CACHE_ENABLED: $IS_CACHE_ENABLED"

--- a/is-cache-enabled/action.yml
+++ b/is-cache-enabled/action.yml
@@ -1,0 +1,46 @@
+---
+name: Is cache enabled
+
+description: |
+  Checks if cache is enabled given three conditions
+  - is a pull request related event
+  - the pull request does not contains a 'ci:no-cache' label
+  - the branch is neither 'main' nor 'stable/*'
+  This information can be used to skip cache restoration
+  in the setup-maven-cache and setup-yarn-cache to test
+  workflows from scratch
+
+inputs: 
+  is-cache-restore-branch:
+    description: Specify if the current working branch valid for cache restore. true or false
+    required: true
+
+outputs:
+  is-cache-disabled:
+    description: |
+      Output whether the workflows has cache enabled based on three conditions:
+      - workflow is triggered by a pull_request event
+      - pull_request does not contains 'ci:no-cache' label
+      - branch is valid for cache restoration
+    value: ${{ steps.detect-cache-status.outputs.is-cache-enabled == 'true' }}
+
+runs:
+  using: composite
+  steps:
+
+  - id: detect-cache-status
+    shell: bash
+    run: |
+      IS_PR_EVENT=${{ github.event_name == 'pull_request' }}
+      HAS_NO_CACHE_LABEL=${{ contains(github.event.pull_request.labels.*.name, 'ci:no-cache') }}
+      IS_CACHE_RESTORE_BRANCH=${{ inputs.is-cache-restore-branch }}
+      echo "IS_PR_EVENT: $IS_PR_EVENT"
+      echo "HAS_NO_CACHE_LABEL: $HAS_NO_CACHE_LABEL"
+      echo "IS_CACHE_RESTORE_BRANCH: $IS_CACHE_RESTORE_BRANCH"
+
+      IS_CACHE_ENABLED="true"
+      if [[ $HAS_NO_CACHE_LABEL == "true" && $IS_PR_EVENT == "true" && $IS_VALID_CACHE_RESTORE_BRANCH == "true" ]]; then
+        IS_CACHE_ENABLED="false"
+      fi
+      echo "IS_CACHE_ENABLED: $IS_CACHE_ENABLED"
+      echo is-cache-enabled="$IS_CACHE_ENABLED" | tee -a $GITHUB_OUTPUT


### PR DESCRIPTION
I've created a dedicated PR for the `is-cache-enabled` composite action so that I will be able to reference it directly in the other composite actions as `camunda/infra-global-github-actions/is-cache-enabled@main` 