### PR TITLE
Camunda 24303 use composite action to check caching

### DIFF
--- a/setup-yarn-cache/action.yml
+++ b/setup-yarn-cache/action.yml
@@ -40,7 +40,7 @@ runs:
 
     # Check if PR contains a label to disable the cache
   - name: Check if cache is enabled
-    uses: camunda/infra-global-github-action/is-cache-enabled@6f325f913625cc0025659822abaf8168f867e432
+    uses: camunda/infra-global-github-actions/is-cache-enabled@6f325f913625cc0025659822abaf8168f867e432
     id: is-cache-enabled
 
   - name: Get Yarn global cache directory

--- a/setup-yarn-cache/action.yml
+++ b/setup-yarn-cache/action.yml
@@ -38,6 +38,11 @@ runs:
         echo "result=false" >> $GITHUB_OUTPUT
       fi
 
+    # Check if PR contains a label to disable the cache
+  - name: Check if cache is enabled
+    uses: camunda/infra-global-github-action/is-cache-enabled@6f325f913625cc0025659822abaf8168f867e432
+    id: is-cache-enabled
+
   - name: Get Yarn global cache directory
     shell: bash
     working-directory: ${{ inputs.directory }}
@@ -68,8 +73,8 @@ runs:
         ${{ runner.environment }}-${{ runner.os }}-yarn
 
   - name: Restore global Yarn cache always
-    # Restore cache (but don't save it) if we're not on main or stable/* branches
-    if: ${{ steps.is-cache-create-branch.outputs.result != 'true' }}
+    # Restore cache (but don't save it) if we're not on main or stable/* branches and cache is not disabled
+    if: ${{ steps.is-cache-create-branch.outputs.result != 'true' && steps.is-cache-enabled.outputs.is-cache-enabled == 'true' }}
     uses: actions/cache/restore@v4
     with:
       path: "${{ env.CUSTOM_YARN_GLOBAL_CACHE_DIR }}"

--- a/setup-yarn-cache/action.yml
+++ b/setup-yarn-cache/action.yml
@@ -40,7 +40,7 @@ runs:
 
     # Check if PR contains a label to disable the cache
   - name: Check if cache is enabled
-    uses: camunda/infra-global-github-actions/is-cache-enabled@6f325f913625cc0025659822abaf8168f867e432
+    uses: camunda/infra-global-github-actions/is-cache-enabled@main
     id: is-cache-enabled
 
   - name: Get Yarn global cache directory


### PR DESCRIPTION
I've moved the setup-yarn-cache code (and its dependency on is-cache-enabled) to a dedicated PR.
This commit has been used also for testing on the monorepo
- https://github.com/camunda/camunda/pull/26294

This will replace:
- https://github.com/camunda/infra-global-github-actions/pull/318