### PR TITLE
chore(submit-test-status): disable echoing potentially long test record input

### DIFF
--- a/submit-test-status/action.yml
+++ b/submit-test-status/action.yml
@@ -26,7 +26,6 @@ runs:
     run: |
       echo "Inputs"
       echo "-----"
-      echo "Test event record: ${{ inputs.test_event_record }}"
       echo "BQ table name (for testing): ${{ inputs.big_query_table_name }}"
 
   - name: login to Google Cloud


### PR DESCRIPTION
Small change I noticed while working on https://github.com/camunda/camunda/pull/26715 that showing the test record input can potentially result in many 100 lines of output. I'd propose to not echo this.