### PR TITLE
chore(submit-test-status): add GH job name for unique relation to build status

### DIFF
--- a/submit-test-status/README.md
+++ b/submit-test-status/README.md
@@ -12,6 +12,7 @@ This composite GHA can be used in any repository that was set up to provide cred
 | Input name           | Description                                        |
 |----------------------|----------------------------------------------------|
 | test_event_record    | Multi-line string that contains the details of the test events in [JSONL format](https://jsonlines.org). One test event per line. |
+| job_name_override    | Optional string being used for the `job_name` field instead of the default `$GITHUB_JOB`, useful e.g. for matrix builds |
 | gcp_credentials_json | Credentials for a Google Cloud ServiceAccount allowed to publish to Big Query formatted as contents of credentials.json file |
 
 Please check out Camunda's [Github Actions Recipes](https://github.com/camunda/github-actions-recipes#secrets=) for how to retrieve secrets from Vault.
@@ -44,6 +45,7 @@ All data submitted by this action is stored as one record per JSONL input line i
 | report_time                      | TIMESTAMP  | REQUIRED   | Time of record submission |
 | ci_url                           | STRING     | REQUIRED   | Github repository URL from `"$GITHUB_SERVER_URL/$GITHUB_REPOSITORY"` |
 | build_id                         | STRING     | REQUIRED   | GHA workflow run ID from `"$GITHUB_RUN_ID/$GITHUB_RUN_ATTEMPT"` |
+| job_name                         | STRING     | REQUIRED   | GHA workflow job ID from `"$GITHUB_JOB"` |
 | test_class_name                  | STRING     | NULLABLE   | Individual (unit) test cases are usually grouped together in a container/class. This field holds the name of the container. |
 | test_class_duration_milliseconds | INTEGER    | NULLABLE   | Based on user input (time a test class needed from start to finish) |
 | test_name                        | STRING     | REQUIRED   | Name of the individual test case, can include parameters for uniqueness |

--- a/submit-test-status/action.yml
+++ b/submit-test-status/action.yml
@@ -12,6 +12,11 @@ inputs:
     description: Credentials for a Google Cloud ServiceAccount allowed to publish to Big Query formatted as contents of credentials.json file.
     required: true
 
+  job_name_override:
+    description: Optional string being used for the `job_name` field instead of the default `$GITHUB_JOB` useful e.g. for matrix builds
+    required: false
+    default: ''
+
   big_query_table_name:
     description: Use only for infrastructure testing purposes to target e.g. dev environment.
     required: false
@@ -26,6 +31,7 @@ runs:
     run: |
       echo "Inputs"
       echo "-----"
+      echo "Job name override: ${{ inputs.job_name_override }} (default job name: $GITHUB_JOB)"
       echo "BQ table name (for testing): ${{ inputs.big_query_table_name }}"
 
   - name: login to Google Cloud
@@ -90,7 +96,8 @@ runs:
         --arg REPORT_TIME "$REPORT_TIME" \
         --arg CI_URL "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" \
         --arg BUILD_ID "$GITHUB_RUN_ID/$GITHUB_RUN_ATTEMPT" \
-        '. + {"report_time": $REPORT_TIME} + {"ci_url": $CI_URL} + {"build_id": $BUILD_ID}' \
+        --arg JOB_NAME "${{ (inputs.job_name_override == '') && '$GITHUB_JOB' || inputs.job_name_override }}" \
+        '. + {"report_time": $REPORT_TIME} + {"ci_url": $CI_URL} + {"build_id": $BUILD_ID} + {"job_name": $JOB_NAME}' \
         $TEMP_DIR/input_test_event_record.json > $TEMP_DIR/test_event_record.json
 
       # upload data to CI Analytics


### PR DESCRIPTION
Populate the new `job_name` column as done by the sister action `submit-build-status`: https://github.com/camunda/infra-core/pull/8973

Related to https://github.com/camunda/camunda/issues/26930