### PR TITLE
Delete GitHub deployments/environments when destroying preview-env

### DIFF
--- a/preview-env/destroy/README.md
+++ b/preview-env/destroy/README.md
@@ -1,0 +1,26 @@
+# preview-env-destroy
+
+This composite GitHub Action (GHA) can be used to deactivate deployments and (optional) destroy them and the associated environment.
+
+In order to delete the environment, a personal access token (PAT) with `deployments:write` and `administration:write` permissions is required.
+If such PAT is not provided, the environment will be maintained and the deployments will only be deactivated.
+
+By default, a set of environments are 'protected' from deletion:
+
+- main
+- master
+- production
+- stage
+
+## Usage
+
+### Inputs
+
+| Field         | Description                                                                                                                                      | Required | Default                        |
+|---------------|--------------------------------------------------------------------------------------------------------------------------------------------------|----------|--------------------------------|
+| `app_name`    | Argocd app name to be deleted.                                                                                                                   | Yes      | -                              |
+| `revision`    | Revision or branch of the Helm chart. Typically the branch to be deployed, or `master`.                                                          | Yes      | -                              |
+| `argocd_server` | URL of the Argo CD instance to target.                                                                                                          | No       | `argocd.int.camunda.com`       |
+| `argocd_token` | An Argo CD token with sufficient permissions to create Applications.                                                                             | Yes      | -                              |
+| `argocd_version`| Version tag of Argo CD CLI tool                                                                                                                | No       | `v2.13.3`                      |
+| `github_token`  | Personal access token used to delete the deployment and the environment; If present, the deployment environment also gets deleted. Token must include `deployments:write` and `administration:write` permissions for environment to be deleted. | No       | -                              |

--- a/preview-env/destroy/README.md
+++ b/preview-env/destroy/README.md
@@ -2,8 +2,8 @@
 
 This composite GitHub Action (GHA) can be used to deactivate deployments and (optional) destroy them and the associated environment.
 
-In order to delete the environment, a personal access token (PAT) with `deployments:write` and `administration:write` permissions is required.
-If such PAT is not provided, the environment will be maintained and the deployments will only be deactivated.
+In order to delete the environment, a GitHub token with `deployments:write` and `administration:write` permissions is required.
+If such GitHub token is not provided, the environment will be maintained and the deployments will only be deactivated.
 
 By default, a set of environments are 'protected' from deletion:
 
@@ -23,4 +23,4 @@ By default, a set of environments are 'protected' from deletion:
 | `argocd_server` | URL of the Argo CD instance to target.                                                                                                          | No       | `argocd.int.camunda.com`       |
 | `argocd_token` | An Argo CD token with sufficient permissions to create Applications.                                                                             | Yes      | -                              |
 | `argocd_version`| Version tag of Argo CD CLI tool                                                                                                                | No       | `v2.13.3`                      |
-| `github_token`  | Personal access token used to delete the deployment and the environment; If present, the deployment environment also gets deleted. Token must include `deployments:write` and `administration:write` permissions for environment to be deleted. | No       | -                              |
+| `github_token`  | GitHub token used to delete the deployment and the environment; If present, the deployment environment also gets deleted. Token must include `deployments:write` and `administration:write` permissions for environment to be deleted. | No       | -                              |

--- a/preview-env/destroy/action.yml
+++ b/preview-env/destroy/action.yml
@@ -26,6 +26,11 @@ inputs:
     default: v2.13.3
     description: Version tag of Argo CD CLI tool
     required: false
+
+  github_token:
+    description: Personal access token used to delete the deployment and the environment
+    required: false
+
 runs:
   using: composite
   steps:
@@ -61,5 +66,14 @@ runs:
     with:
       step: deactivate-env
       token: "${{ github.token }}"
+      env: ${{ inputs.app_name }}
+      ref: ${{ inputs.revision }}
+
+  - uses: bobheadxi/deployments@v1.5.0
+    if: ${{ inputs.github_token }}
+    name: Delete GitHub Deployment environment
+    with:
+      step: delete-env
+      token: "${{ inputs.github_token }}"
       env: ${{ inputs.app_name }}
       ref: ${{ inputs.revision }}

--- a/preview-env/destroy/action.yml
+++ b/preview-env/destroy/action.yml
@@ -29,7 +29,7 @@ inputs:
 
   github_token:
     description: |-
-      Personal access token used to delete the deployment and the environment;
+      GitHub token used to delete the deployment and the environment;
       If present, the deployment environment also gets deleted.
       Token must include deployments:write and administration:write permissions
       for environment to be deleted

--- a/preview-env/destroy/action.yml
+++ b/preview-env/destroy/action.yml
@@ -77,22 +77,28 @@ runs:
     id: removable-environment
     shell: bash
     env:
+      GITHUB_TOKEN: ${{ inputs.github_token }}
       ENVIRONMENT: ${{ inputs.app_name }}
     run: |-
-      echo "Verifying if GitHub environment can be deleted"
-      case "$ENVIRONMENT" in
-        production | stage | main | master )
-          is_removable="false"
-          ;;
-        *)
-          is_removable="true"
-          ;;
-      esac
+      echo "Verifying if GitHub Environment can be deleted"
+      is_removable="false"
+      if [[ -n "$GITHUB_TOKEN" ]]; then
+        case "$ENVIRONMENT" in
+          production | stage | main | master )
+            echo "Environment '$ENVIRONMENT' is protected and can't be removed"
+            ;;
+          *)
+            is_removable="true"
+            ;;
+        esac
+      else
+        echo "No GitHub token provided, environment can't be removed"
+      fi
       echo "is-removable=$is_removable" | tee -a $GITHUB_OUTPUT
 
   - uses: bobheadxi/deployments@v1.5.0
-    if: ${{ inputs.github_token != '' && steps.removable-environment.outputs.is-removable == 'true' }}
-    name: Delete GitHub Deployment environment
+    if: ${{ steps.removable-environment.outputs.is-removable == 'true' }}
+    name: Delete GitHub Environment
     with:
       step: delete-env
       token: "${{ inputs.github_token }}"

--- a/preview-env/destroy/action.yml
+++ b/preview-env/destroy/action.yml
@@ -28,7 +28,11 @@ inputs:
     required: false
 
   github_token:
-    description: Personal access token used to delete the deployment and the environment
+    description: |-
+      Personal access token used to delete the deployment and the environment;
+      If present, the deployment environment also gets deleted.
+      Token must include deployments:write and administration:write permissions
+      for environment to be deleted
     required: false
 
 runs:

--- a/preview-env/destroy/action.yml
+++ b/preview-env/destroy/action.yml
@@ -69,8 +69,25 @@ runs:
       env: ${{ inputs.app_name }}
       ref: ${{ inputs.revision }}
 
+  - name: Verify protected environment
+    id: removable-environment
+    shell: bash
+    env:
+      ENVIRONMENT: ${{ inputs.app_name }}
+    run: |-
+      echo "Verifying if GitHub environment can be deleted"
+      case "$ENVIRONMENT" in
+        production | stage | main | master )
+          is_removable="false"
+          ;;
+        *)
+          is_removable="true"
+          ;;
+      esac
+      echo "is-removable=$is_removable" | tee -a $GITHUB_OUTPUT
+
   - uses: bobheadxi/deployments@v1.5.0
-    if: ${{ inputs.github_token }}
+    if: ${{ inputs.github_token != '' && steps.removable-environment.outputs.is-removable == 'true' }}
     name: Delete GitHub Deployment environment
     with:
       step: delete-env


### PR DESCRIPTION
This PR is to include a new step to delete the deployments and the environments as part of the `preview-env/destroy` composite action

Related to: camunda/team-infrastructure#456