### PR TITLE
chore: setup automerge for actionlint patch updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -73,6 +73,6 @@
       ],
       addLabels: ["automerge"],
       automerge: true,
-    } 
+    }
   ]
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -56,6 +56,14 @@
       addLabels: ["automerge"],
       automerge: true
     },
+    {
+      matchUpdateTypes: ["patch"],
+      matchPackageNames: [
+        "/actionlint/"
+      ],
+      addLabels: ["automerge"],
+      automerge: true,
+    },
     // For known Github repositories that use Github tags/releases of format
     // "v1.2.3" and where the asdf plugin ignores the "v" prefix, we also tell
     // Renovate to ignore it via extractVersion when updating .tool-version file
@@ -65,14 +73,6 @@
         "quay.io/argoproj/argocd",
       ],
       extractVersion: "^v(?<version>.*)$",
-    },
-    {
-      matchUpdateTypes: ["patch"],
-      matchPackageNames: [
-        "/actionlint/"
-      ],
-      addLabels: ["automerge"],
-      automerge: true,
     }
   ]
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -66,5 +66,13 @@
       ],
       extractVersion: "^v(?<version>.*)$",
     },
+    {
+      matchUpdateTypes: ["patch"],
+      matchPackageNames: [
+        "/actionlint/"
+      ],
+      addLabels: ["automerge"],
+      automerge: true,
+    } 
   ]
 }

--- a/README.md
+++ b/README.md
@@ -3,3 +3,11 @@
 This repository contains Github Actions (GHA) maintained by the Infra team. Those actions are intended to be consumed by other teams inside Camunda.
 
 They are **publicly accessible** and thus must not contain any secrets.
+
+## Contributing
+
+Before contributing, please make sure to activate `pre-commit` in this repository:
+
+```shell
+pre-commit install --install-hooks -t commit-msg -t pre-commit
+```


### PR DESCRIPTION
In camunda's renovate shared configuration, actionlint patch updates are automerged by default. 
Adding the same rule here to simplify maintenance