### PR TITLE
feat(ci): add troubleshooting information to preview environment

### DIFF
--- a/preview-env/create/README.md
+++ b/preview-env/create/README.md
@@ -1,0 +1,24 @@
+# preview-env-create
+
+This composite GitHub Action (GHA) is used to deploy preview environments.
+
+After deploying the environment (or attempting to do so) the action updates the PR with the deployment results.
+In order to gain more troubleshooting insights upon a deployment failure, an optional GitHub token can be passed to the action,
+with `contents: read`, `deployments:write` and `id-token:write` permissions.
+If such GitHub token is not provided then the available troubleshooting information will be limited.
+
+## Usage
+
+### Inputs
+
+| Field             | Description                                                                                                    | Required | Default                 |
+|-------------------|----------------------------------------------------------------------------------------------------------------|----------|-------------------------|
+| `revision`        | Revision or branch of the Helm chart. Typically the branch to be deployed, or `master`.                        | Yes      | -                       |
+| `app_name`        | Argocd app name to be created                                                                                  | Yes      | -                       |
+| `app_url`         | The URL to access the deployed app                                                                             | Yes      | -                       |
+| `argocd_server`   | URL of the Argo CD instance to target                                                                          | No       | `argocd.int.camunda.com`|
+| `argocd_token`    | An Argo CD token with sufficient permissions to create Applications                                            | Yes      | -                       |
+| `argocd_version`  | Version tag of Argo CD CLI tool                                                                                | No       | `v2.13.4`               |
+| `argocd_arguments`| List of arguments to pass to Argocd command for creating the new application                                   | Yes      | -                       |
+| `argocd_wait_for_sync_timeout`| The time (in seconds) that the action waits for the app to become healthy                          | No       | `1800`                  |
+| `github_token`    | GitHub token is used to authenticate with Teleport to gain additiona troubleshooting insights from the cluster | No       | -                       |

--- a/preview-env/create/README.md
+++ b/preview-env/create/README.md
@@ -5,6 +5,7 @@ This composite GitHub Action (GHA) is used to deploy preview environments.
 After deploying the environment (or attempting to do so) the action updates the PR with the deployment results.
 In order to gain more troubleshooting insights upon a deployment failure, an optional GitHub token can be passed to the action,
 with `contents: read`, `deployments:write` and `id-token:write` permissions.
+Information about defining GitHUb token permissions can be found [here](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token#defining-access-for-the-github_token-permissions.)
 If such GitHub token is not provided then the available troubleshooting information will be limited.
 
 ## Usage
@@ -21,4 +22,4 @@ If such GitHub token is not provided then the available troubleshooting informat
 | `argocd_version`  | Version tag of Argo CD CLI tool                                                                                | No       | `v2.13.4`               |
 | `argocd_arguments`| List of arguments to pass to Argocd command for creating the new application                                   | Yes      | -                       |
 | `argocd_wait_for_sync_timeout`| The time (in seconds) that the action waits for the app to become healthy                          | No       | `1800`                  |
-| `github_token`    | GitHub token is used to authenticate with Teleport to gain additiona troubleshooting insights from the cluster | No       | -                       |
+| `github_token`    | GitHub token is used to authenticate with Teleport to gain additional troubleshooting insights from the cluster | No       | -                       |

--- a/preview-env/create/action.yml
+++ b/preview-env/create/action.yml
@@ -148,7 +148,7 @@ runs:
 
       if [ "$ARGOCD_APP_STATUS" == "Healthy" ]; then
         echo "Application reached healthy state."
-        FAILURE=0 
+        exit 0
       else
         echo "Timeout reached. The application did not become healthy. Collecting troubleshooting information."
         ARGOCD_APP_DETAILS=$(cat <<EOF
@@ -166,10 +166,10 @@ runs:
         echo "argocd_app_details<<EOF" >> $GITHUB_OUTPUT
         echo "$ARGOCD_APP_DETAILS" >> $GITHUB_OUTPUT
         echo "EOF" >> $GITHUB_OUTPUT
-        FAILURE=1 
+        # ensure output is flushed before exiting
+        # sync
+        exit 1
       fi
-
-      exit $FAILURE
 
     env:
       ARGOCD_AUTH_TOKEN: ${{ inputs.argocd_token }}
@@ -243,7 +243,7 @@ runs:
       ARGOCD_SERVER: ${{ inputs.argocd_server }}
       REPO: ${{ github.repository }}
       RUN_ID: ${{ github.run_id }}
-      ARGOCD_APP_DETAILS: ${{ steps.wait-for-sync.outputs.argocd_app_details }}
+      ARGOCD_APP_DETAILS: ${{ steps.wait_for_sync.outputs.argocd_app_details }}
       KUBERNETES_EVENTS: ${{ steps.get_k8s_events.outputs.kubernetes_events }}
     run: |
       template=$(envsubst < ${{ github.action_path }}/templates/comment-${{ github.action_status }}.md)

--- a/preview-env/create/action.yml
+++ b/preview-env/create/action.yml
@@ -35,6 +35,11 @@ inputs:
   argocd_arguments:
     description: List of arguments to pass to Argocd command for creating the new application
     required: true
+
+  argocd_wait_for_sync_timeout:
+    description: The time (in seconds) that the action waits for the app to become healthy
+    required: false
+    default: "1200" # wait for up to 20 minutes
 runs:
   using: composite
   steps:
@@ -115,7 +120,7 @@ runs:
       # argocd app wait ${{ inputs.app_name }} --timeout 1200 --health
       # echo "::endgroup::"
 
-      TIMEOUT=1800  # Total timeout in seconds
+      TIMEOUT=${{ inputs.argocd_wait_for_sync_timeout }}
       INTERVAL=30   # Interval between retries in seconds
       ELAPSED=0
       while [ $ELAPSED -lt $TIMEOUT ]; do

--- a/preview-env/create/action.yml
+++ b/preview-env/create/action.yml
@@ -131,54 +131,6 @@ runs:
       APP_NAME: ${{ inputs.app_name }}
     run: |
       bash ${{ github.action_path }}/app-sync-status.sh
-
-      # echo "::group::wait for sync"
-
-      # TIMEOUT=${{ inputs.argocd_wait_for_sync_timeout }}
-      # INTERVAL=30   # Interval between retries in seconds
-      # ELAPSED=0
-      #
-      # while [ $ELAPSED -le $TIMEOUT ]; do
-      #   ARGOCD_APP_STATUS=$(argocd app get "${{ inputs.app_name }}" -o json | jq -r '.status.health.status')
-      #   echo "Current status: $ARGOCD_APP_STATUS"
-      #
-      #   if [ -n "$ARGOCD_APP_STATUS" && "$ARGOCD_APP_STATUS" == "Healthy" ]; then
-      #     echo "App is healthy."
-      #     break
-      #   fi
-      #
-      #   echo "App is not healthy yet. Retrying in $INTERVAL seconds..."
-      #   sleep $INTERVAL
-      #   ELAPSED=$((ELAPSED + INTERVAL))
-      #   echo "Elapsed time is $ELAPSED seconds."
-      # done
-      #
-      # echo "::endgroup::"
-      #
-      # if [ "$ARGOCD_APP_STATUS" == "Healthy" ]; then
-      #   echo "Application reached healthy state."
-      #   exit 0
-      # else
-      #   echo "Timeout reached. The application did not become healthy. Collecting troubleshooting information."
-      #   ARGOCD_APP_DETAILS=$(cat <<EOF
-      # ArgoCD App details
-      # ------------------
-      # App health: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.health.status')
-      # App sync: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.sync.status')
-      # App conditions: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.conditions')
-      # State of the latest operation phase: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.operationState.phase')
-      # Message from the latest operation phase: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.operationState.message')
-      # Sync results:
-      # $(argocd app get ${{ inputs.app_name }} -o json | jq '.status.operationState.syncResult[]')
-      # EOF
-      #   )
-      #   echo "argocd_app_details<<EOF" >> $GITHUB_OUTPUT
-      #   echo "$ARGOCD_APP_DETAILS" >> $GITHUB_OUTPUT
-      #   echo "EOF" >> $GITHUB_OUTPUT
-      #   exit 1
-      # fi
-
-
     #########################################################################
     # Get additional troubleshooting information from Kubernetes events
     # in case of the app didn't reach healthy state.
@@ -206,8 +158,6 @@ runs:
     id: get_k8s_events
     shell: bash
     run: |
-      kubectl auth whoami
-      kubectl get ns ${{ inputs.app_name }}
       KUBERNETES_EVENTS=$(cat <<EOF
       Kubernetes events
       -----------------
@@ -216,10 +166,9 @@ runs:
         jq -s 'sort_by(.time) | reverse | .[] | "\(.time) \(.message)"')
       EOF
       )
-      echo "kubernetes_events<<EOF" >> $GITHUB_OUTPUT
-      echo "$KUBERNETES_EVENTS" >> $GITHUB_OUTPUT
-      echo "EOF" >> $GITHUB_OUTPUT
-
+      echo "kubernetes_events<<EOF" >> "$GITHUB_OUTPUT"
+      echo "$KUBERNETES_EVENTS" >> "$GITHUB_OUTPUT"
+      echo "EOF" >> "$GITHUB_OUTPUT"
     #########################################################################
     # Update the deployment status so we can see the result in the Pull Request
     # or in the list of environments.

--- a/preview-env/create/action.yml
+++ b/preview-env/create/action.yml
@@ -126,8 +126,10 @@ runs:
       EOF
       )
 
-      echo "argocd_app_details=${ARGOCD_APP_DETAILS}" >> $GITHUB_OUTPUT
-
+      echo "argocd_app_details<<EOF" >> $GITHUB_OUTPUT
+      echo "$ARGOCD_APP_DETAILS" >> $GITHUB_OUTPUT
+      echo "EOF" >> $GITHUB_OUTPUT
+      
       # echo "::group::get app status details"
       # echo "App health: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.health.status')"
       # echo "App sync: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.sync.status')"

--- a/preview-env/create/action.yml
+++ b/preview-env/create/action.yml
@@ -113,36 +113,33 @@ runs:
       echo "::group::wait for sync"
       argocd app wait ${{ inputs.app_name }} --timeout 1200 --health
       echo "::endgroup::"
-      
-      echo "::group::get app status details"
-      echo "App health: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.health.status')"
-      echo "App sync: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.sync.status')"
-      echo "App conditions: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.conditions')"
-      echo "State of the latest operation phase: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.operationState.phase')"
-      echo "Message from the lastest operation phase: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.operationState.message')"
-      echo "Sync results: $(argocd app get ${{ inputs.app_name }} -o json | jq '.status.operationState.syncResult[]')"
-      # echo "Kubernetes warnings (if any): $()"
-      echo "::endgroup::"
+
+      ARGOCD_APP_DETAILS=$(cat <<EOF
+      App health: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.health.status')
+      App sync: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.sync.status')
+      App conditions: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.conditions')
+      State of the latest operation phase: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.operationState.phase')
+      Message from the latest operation phase: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.operationState.message')
+      Sync results:
+      $(argocd app get ${{ inputs.app_name }} -o json | jq '.status.operationState.syncResult[]')
+      EOF
+      )
+
+      echo $ARGOCD_APP_STATUS
+
+      # echo "::group::get app status details"
+      # echo "App health: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.health.status')"
+      # echo "App sync: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.sync.status')"
+      # echo "App conditions: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.conditions')"
+      # echo "State of the latest operation phase: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.operationState.phase')"
+      # echo "Message from the lastest operation phase: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.operationState.message')"
+      # echo "Sync results: $(argocd app get ${{ inputs.app_name }} -o json | jq '.status.operationState.syncResult[]')"
+      # # echVo "Kubernetes warnings (if any): $()"
+      # echo "::endgroup::"
     env:
       ARGOCD_AUTH_TOKEN: ${{ inputs.argocd_token }}
       ARGOCD_OPTS: "--grpc-web"
       ARGOCD_SERVER: ${{ inputs.argocd_server  }}
-  # - name: Get app status details
-  #   shell: bash
-  #   run: |-
-  #     echo "::group::get app status details"
-  #     echo "App health: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.health.status')"
-  #     echo "App sync: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.sync.status')"
-  #     echo "App conditions: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.conditions')"
-  #     echo "State of the latest operation phase: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.operationState.phase')"
-  #     echo "Message from the lastest operation phase: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.operationState.message')"
-  #     echo "Sync results: $(argocd app get ${{ inputs.app_name }} -o json | jq '.status.operationState.syncResult[]')"
-  #     # echo "Kubernetes warnings (if any): $()"
-  #     echo "::endgroup::"
-  #   env:
-  #     ARGOCD_AUTH_TOKEN: ${{ inputs.argocd_token }}
-  #     ARGOCD_OPTS: "--grpc-web"
-  #     ARGOCD_SERVER: ${{ inputs.argocd_server  }}
     #########################################################################
     # Update the deployment status so we can see the result in the Pull Request
     # or in the list of environments.

--- a/preview-env/create/action.yml
+++ b/preview-env/create/action.yml
@@ -113,13 +113,7 @@ runs:
       echo "::group::wait for sync"
       argocd app wait ${{ inputs.app_name }} --timeout 1200 --health
       echo "::endgroup::"
-    env:
-      ARGOCD_AUTH_TOKEN: ${{ inputs.argocd_token }}
-      ARGOCD_OPTS: "--grpc-web"
-      ARGOCD_SERVER: ${{ inputs.argocd_server  }}
-  - name: Get app status details
-    shell: bash
-    run: |-
+      
       echo "::group::get app status details"
       echo "App health: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.health.status')"
       echo "App sync: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.sync.status')"
@@ -133,6 +127,22 @@ runs:
       ARGOCD_AUTH_TOKEN: ${{ inputs.argocd_token }}
       ARGOCD_OPTS: "--grpc-web"
       ARGOCD_SERVER: ${{ inputs.argocd_server  }}
+  # - name: Get app status details
+  #   shell: bash
+  #   run: |-
+  #     echo "::group::get app status details"
+  #     echo "App health: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.health.status')"
+  #     echo "App sync: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.sync.status')"
+  #     echo "App conditions: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.conditions')"
+  #     echo "State of the latest operation phase: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.operationState.phase')"
+  #     echo "Message from the lastest operation phase: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.operationState.message')"
+  #     echo "Sync results: $(argocd app get ${{ inputs.app_name }} -o json | jq '.status.operationState.syncResult[]')"
+  #     # echo "Kubernetes warnings (if any): $()"
+  #     echo "::endgroup::"
+  #   env:
+  #     ARGOCD_AUTH_TOKEN: ${{ inputs.argocd_token }}
+  #     ARGOCD_OPTS: "--grpc-web"
+  #     ARGOCD_SERVER: ${{ inputs.argocd_server  }}
     #########################################################################
     # Update the deployment status so we can see the result in the Pull Request
     # or in the list of environments.

--- a/preview-env/create/action.yml
+++ b/preview-env/create/action.yml
@@ -141,7 +141,7 @@ runs:
         echo "Application reached healthy state."
         exit 0
       else
-        echo "Timeout reached. The application did not become healthy. Collecting troubleshhoting information."
+        echo "Timeout reached. The application did not become healthy. Collecting troubleshooting information."
         # collect application details for troubleshooting if it didn't reach the healthy status
         ARGOCD_APP_DETAILS=$(cat <<EOF
       App health: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.health.status')
@@ -174,7 +174,7 @@ runs:
     with:
       version: 17.2.3
   - name: Authenticate with Teleport
-    if: success() && steps.setup_teleport.outcome == 'success'
+    if: failure() && steps.setup_teleport.outcome == 'success'
     id: auth_teleport
     uses: teleport-actions/auth-k8s@v2
     with:
@@ -182,7 +182,7 @@ runs:
       token: infra-ci-prod-github-action-preview-env-infra
       kubernetes-cluster: camunda-ci
   - name: Get Kubernetes events
-    if: success() && steps.auth_teleport.outcome == 'success'
+    if: failure() && steps.auth_teleport.outcome == 'success'
     id: get_k8s_events
     shell: bash
     run: |

--- a/preview-env/create/action.yml
+++ b/preview-env/create/action.yml
@@ -144,14 +144,14 @@ runs:
         echo "Timeout reached. The application did not become healthy. Collecting troubleshhoting information."
         # collect application details for troubleshooting if it didn't reach the healthy status
         ARGOCD_APP_DETAILS=$(cat <<EOF
-        App health: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.health.status')
-        App sync: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.sync.status')
-        App conditions: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.conditions')
-        State of the latest operation phase: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.operationState.phase')
-        Message from the latest operation phase: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.operationState.message')
-        Sync results:
-        $(argocd app get ${{ inputs.app_name }} -o json | jq '.status.operationState.syncResult[]')
-        EOF
+      App health: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.health.status')
+      App sync: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.sync.status')
+      App conditions: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.conditions')
+      State of the latest operation phase: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.operationState.phase')
+      Message from the latest operation phase: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.operationState.message')
+      Sync results:
+      $(argocd app get ${{ inputs.app_name }} -o json | jq '.status.operationState.syncResult[]')
+      EOF
         )
         echo "argocd_app_details<<EOF" >> $GITHUB_OUTPUT
         echo "$ARGOCD_APP_DETAILS" >> $GITHUB_OUTPUT
@@ -180,7 +180,7 @@ runs:
     with:
       proxy: camunda.teleport.sh:443
       token: infra-ci-prod-github-action-preview-env-infra
-      kubernetes-cluster: camunda-ci-prod
+      kubernetes-cluster: camunda-ci
   - name: Get Kubernetes events
     if: success() && steps.auth_teleport.outcome == 'success'
     id: get_k8s_events

--- a/preview-env/create/action.yml
+++ b/preview-env/create/action.yml
@@ -115,6 +115,7 @@ runs:
       argocd app wait ${{ inputs.app_name }} --timeout 1200 --health
       echo "::endgroup::"
 
+      # collect application details from ArgoCD for troubleshooting
       ARGOCD_APP_DETAILS=$(cat <<EOF
       App health: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.health.status')
       App sync: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.sync.status')
@@ -125,20 +126,10 @@ runs:
       $(argocd app get ${{ inputs.app_name }} -o json | jq '.status.operationState.syncResult[]')
       EOF
       )
-
       echo "argocd_app_details<<EOF" >> $GITHUB_OUTPUT
       echo "$ARGOCD_APP_DETAILS" >> $GITHUB_OUTPUT
       echo "EOF" >> $GITHUB_OUTPUT
-      
-      # echo "::group::get app status details"
-      # echo "App health: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.health.status')"
-      # echo "App sync: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.sync.status')"
-      # echo "App conditions: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.conditions')"
-      # echo "State of the latest operation phase: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.operationState.phase')"
-      # echo "Message from the lastest operation phase: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.operationState.message')"
-      # echo "Sync results: $(argocd app get ${{ inputs.app_name }} -o json | jq '.status.operationState.syncResult[]')"
-      # # echVo "Kubernetes warnings (if any): $()"
-      # echo "::endgroup::"
+
     env:
       ARGOCD_AUTH_TOKEN: ${{ inputs.argocd_token }}
       ARGOCD_OPTS: "--grpc-web"

--- a/preview-env/create/action.yml
+++ b/preview-env/create/action.yml
@@ -112,7 +112,7 @@ runs:
     shell: bash
     run: |-
       echo "::group::wait for sync"
-      argocd app wait ${{ inputs.app_name }} --timeout 1200 --health
+      argocd app wait ${{ inputs.app_name }} --timeout 1200 --health --sync
       echo "::endgroup::"
 
       # collect application details from ArgoCD for troubleshooting

--- a/preview-env/create/action.yml
+++ b/preview-env/create/action.yml
@@ -129,11 +129,12 @@ runs:
       TIMEOUT=${{ inputs.argocd_wait_for_sync_timeout }}
       INTERVAL=30   # Interval between retries in seconds
       ELAPSED=0
-      while [ $ELAPSED -lt $TIMEOUT ]; do
+
+      while [ $ELAPSED -le $TIMEOUT ]; do
         ARGOCD_APP_STATUS=$(argocd app get "${{ inputs.app_name }}" -o json | jq -r '.status.health.status')
         echo "Current status: $ARGOCD_APP_STATUS"
 
-        if [ "$ARGOCD_APP_STATUS" == "Healthy" ]; then
+        if [ -n "$ARGOCD_APP_STATUS" && "$ARGOCD_APP_STATUS" == "Healthy" ]; then
           echo "App is healthy."
           break
         fi
@@ -166,8 +167,6 @@ runs:
         echo "argocd_app_details<<EOF" >> $GITHUB_OUTPUT
         echo "$ARGOCD_APP_DETAILS" >> $GITHUB_OUTPUT
         echo "EOF" >> $GITHUB_OUTPUT
-        # ensure output is flushed before exiting
-        # sync
         exit 1
       fi
 
@@ -186,7 +185,8 @@ runs:
     id: setup_teleport
     uses: teleport-actions/setup@v1
     with:
-      version: 17.2.3
+      # renovate: datasource=docker depName=public.ecr.aws/gravitational/teleport-ent-distroless
+      version: 17.2.8
   - name: Authenticate with Teleport
     if: failure() && steps.setup_teleport.outcome == 'success'
     id: auth_teleport

--- a/preview-env/create/action.yml
+++ b/preview-env/create/action.yml
@@ -44,7 +44,7 @@ inputs:
   github_token:
     description: |-
       GitHub token is used to authenticate with Teleport.
-      It needs to have an "id-token: write" permission.
+      It needs to have `contents: read`, `deployments:write` and `id-token:write` permissions.
       If the token is present, the Kubernetes events get added to the troubleshooting information.
     required: false
 

--- a/preview-env/create/action.yml
+++ b/preview-env/create/action.yml
@@ -39,7 +39,7 @@ inputs:
   argocd_wait_for_sync_timeout:
     description: The time (in seconds) that the action waits for the app to become healthy
     required: false
-    default: "1200" # wait for up to 20 minutes
+    default: "1800" # wait for up to 30 minutes
 runs:
   using: composite
   steps:
@@ -112,13 +112,11 @@ runs:
       ARGOCD_AUTH_TOKEN: ${{ inputs.argocd_token }}
       ARGOCD_OPTS: "--grpc-web"
       ARGOCD_SERVER: ${{ inputs.argocd_server }}
-  - name: Wait for sync (up to 30 minutes)
-    id: wait-for-sync
+  - name: Wait for sync
+    id: wait_for_sync
     shell: bash
     run: |-
       echo "::group::wait for sync"
-      # argocd app wait ${{ inputs.app_name }} --timeout 1200 --health
-      # echo "::endgroup::"
 
       TIMEOUT=${{ inputs.argocd_wait_for_sync_timeout }}
       INTERVAL=30   # Interval between retries in seconds
@@ -139,26 +137,25 @@ runs:
 
       echo "::endgroup::"
 
-      # collect application details for troubleshooting
-      ARGOCD_APP_DETAILS=$(cat <<EOF
-      App health: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.health.status')
-      App sync: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.sync.status')
-      App conditions: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.conditions')
-      State of the latest operation phase: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.operationState.phase')
-      Message from the latest operation phase: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.operationState.message')
-      Sync results:
-      $(argocd app get ${{ inputs.app_name }} -o json | jq '.status.operationState.syncResult[]')
-      EOF
-      )
-      echo "argocd_app_details<<EOF" >> $GITHUB_OUTPUT
-      echo "$ARGOCD_APP_DETAILS" >> $GITHUB_OUTPUT
-      echo "EOF" >> $GITHUB_OUTPUT
-
       if [ "$ARGOCD_APP_STATUS" == "Healthy" ]; then
         echo "Application reached healthy state."
         exit 0
       else
-        echo "Timeout reached. The application did not become healthy."
+        echo "Timeout reached. The application did not become healthy. Collecting troubleshhoting information."
+        # collect application details for troubleshooting if it didn't reach the healthy status
+        ARGOCD_APP_DETAILS=$(cat <<EOF
+        App health: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.health.status')
+        App sync: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.sync.status')
+        App conditions: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.conditions')
+        State of the latest operation phase: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.operationState.phase')
+        Message from the latest operation phase: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.operationState.message')
+        Sync results:
+        $(argocd app get ${{ inputs.app_name }} -o json | jq '.status.operationState.syncResult[]')
+        EOF
+        )
+        echo "argocd_app_details<<EOF" >> $GITHUB_OUTPUT
+        echo "$ARGOCD_APP_DETAILS" >> $GITHUB_OUTPUT
+        echo "EOF" >> $GITHUB_OUTPUT
         exit 1
       fi
 
@@ -166,6 +163,43 @@ runs:
       ARGOCD_AUTH_TOKEN: ${{ inputs.argocd_token }}
       ARGOCD_OPTS: "--grpc-web"
       ARGOCD_SERVER: ${{ inputs.argocd_server  }}
+
+    #########################################################################
+    # Get additional troubleshooting information from Kubernetes events
+    # in case of the app didn't reach healthy state
+  - name: Setup Teleport
+    if: failure()
+    id: setup_teleport
+    uses: teleport-actions/setup@v1
+    with:
+      version: 17.2.3
+  - name: Authenticate with Teleport
+    if: success() && steps.setup_teleport.outcome == 'success'
+    id: auth_teleport
+    uses: teleport-actions/auth-k8s@v2
+    with:
+      proxy: camunda.teleport.sh:443
+      token: infra-ci-prod-github-action-preview-env-infra
+      kubernetes-cluster: camunda-ci-prod
+  - name: Get Kubernetes events
+    if: success() && steps.auth_teleport.outcome == 'success'
+    id: get_k8s_events
+    shell: bash
+    run: |
+      kubectl auth whoami
+      kubectl get ns ${{ inputs.app_name }}
+      KUBERNETES_EVENTS=$(cat <<EOF
+      Kubernetes events
+      -----------------
+      $(kubectl get event -n ${{inputs.app_name }} -o json | \
+        jq -r '.items[] | select(.type == "Warning") | {time: .lastTimestamp, message: .message} | @json' | \
+        jq -s 'sort_by(.time) | reverse | .[] | "\(.time) \(.message)"')
+      EOF
+      )
+      echo "kubernetes_events<<EOF" >> $GITHUB_OUTPUT
+      echo "$KUBERNETES_EVENTS" >> $GITHUB_OUTPUT
+      echo "EOF" >> $GITHUB_OUTPUT
+
     #########################################################################
     # Update the deployment status so we can see the result in the Pull Request
     # or in the list of environments.
@@ -194,6 +228,7 @@ runs:
       REPO: ${{ github.repository }}
       RUN_ID: ${{ github.run_id }}
       ARGOCD_APP_DETAILS: ${{ steps.wait-for-sync.outputs.argocd_app_details }}
+      KUBERNETES_EVENTS: ${{ steps.get_k8s_events.outputs.kubernetes_events }}
     run: |
       template=$(envsubst < ${{ github.action_path }}/templates/comment-${{ github.action_status }}.md)
       echo "$template" > status_${{ inputs.app_name }}.md

--- a/preview-env/create/action.yml
+++ b/preview-env/create/action.yml
@@ -125,7 +125,7 @@ runs:
       EOF
       )
 
-      echo $ARGOCD_APP_STATUS
+      echo $ARGOCD_APP_DETAILS
 
       # echo "::group::get app status details"
       # echo "App health: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.health.status')"

--- a/preview-env/create/action.yml
+++ b/preview-env/create/action.yml
@@ -148,10 +148,9 @@ runs:
 
       if [ "$ARGOCD_APP_STATUS" == "Healthy" ]; then
         echo "Application reached healthy state."
-        exit 0
+        FAILURE=0 
       else
         echo "Timeout reached. The application did not become healthy. Collecting troubleshooting information."
-        # collect application details for troubleshooting if it didn't reach the healthy status
         ARGOCD_APP_DETAILS=$(cat <<EOF
       ArgoCD App details
       ------------------
@@ -167,10 +166,10 @@ runs:
         echo "argocd_app_details<<EOF" >> $GITHUB_OUTPUT
         echo "$ARGOCD_APP_DETAILS" >> $GITHUB_OUTPUT
         echo "EOF" >> $GITHUB_OUTPUT
-        # ensure output is flushed before exiting
-        sync
-        exit 1
+        FAILURE=1 
       fi
+
+      exit $FAILURE
 
     env:
       ARGOCD_AUTH_TOKEN: ${{ inputs.argocd_token }}

--- a/preview-env/create/action.yml
+++ b/preview-env/create/action.yml
@@ -108,6 +108,7 @@ runs:
       ARGOCD_OPTS: "--grpc-web"
       ARGOCD_SERVER: ${{ inputs.argocd_server }}
   - name: Wait for sync (up to 20 minutes)
+    id: wait-for-sync
     shell: bash
     run: |-
       echo "::group::wait for sync"
@@ -125,7 +126,7 @@ runs:
       EOF
       )
 
-      echo $ARGOCD_APP_DETAILS
+      echo "argocd_app_details=${ARGOCD_APP_DETAILS}" >> $GITHUB_OUTPUT
 
       # echo "::group::get app status details"
       # echo "App health: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.health.status')"
@@ -167,6 +168,7 @@ runs:
       ARGOCD_SERVER: ${{ inputs.argocd_server }}
       REPO: ${{ github.repository }}
       RUN_ID: ${{ github.run_id }}
+      ARGOCD_APP_DETAILS: ${{ steps.wait-for-sync.outputs.argocd_app_details }}
     run: |
       template=$(envsubst < ${{ github.action_path }}/templates/comment-${{ github.action_status }}.md)
       echo "$template" > status_${{ inputs.app_name }}.md

--- a/preview-env/create/action.yml
+++ b/preview-env/create/action.yml
@@ -149,7 +149,7 @@ runs:
       echo "$ARGOCD_APP_DETAILS" >> $GITHUB_OUTPUT
       echo "EOF" >> $GITHUB_OUTPUT
 
-      if [ "$APP_HEALTH_STATUS" == "Healthy" ]; then
+      if [ "$ARGOCD_APP_STATUS" == "Healthy" ]; then
         echo "Application reached healthy state."
         exit 0
       else

--- a/preview-env/create/action.yml
+++ b/preview-env/create/action.yml
@@ -123,57 +123,61 @@ runs:
   - name: Wait for sync
     id: wait_for_sync
     shell: bash
-    run: |-
-      echo "::group::wait for sync"
-
-      TIMEOUT=${{ inputs.argocd_wait_for_sync_timeout }}
-      INTERVAL=30   # Interval between retries in seconds
-      ELAPSED=0
-
-      while [ $ELAPSED -le $TIMEOUT ]; do
-        ARGOCD_APP_STATUS=$(argocd app get "${{ inputs.app_name }}" -o json | jq -r '.status.health.status')
-        echo "Current status: $ARGOCD_APP_STATUS"
-
-        if [ -n "$ARGOCD_APP_STATUS" && "$ARGOCD_APP_STATUS" == "Healthy" ]; then
-          echo "App is healthy."
-          break
-        fi
-
-        echo "App is not healthy yet. Retrying in $INTERVAL seconds..."
-        sleep $INTERVAL
-        ELAPSED=$((ELAPSED + INTERVAL))
-        echo "Elapsed time is $ELAPSED seconds."
-      done
-
-      echo "::endgroup::"
-
-      if [ "$ARGOCD_APP_STATUS" == "Healthy" ]; then
-        echo "Application reached healthy state."
-        exit 0
-      else
-        echo "Timeout reached. The application did not become healthy. Collecting troubleshooting information."
-        ARGOCD_APP_DETAILS=$(cat <<EOF
-      ArgoCD App details
-      ------------------
-      App health: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.health.status')
-      App sync: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.sync.status')
-      App conditions: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.conditions')
-      State of the latest operation phase: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.operationState.phase')
-      Message from the latest operation phase: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.operationState.message')
-      Sync results:
-      $(argocd app get ${{ inputs.app_name }} -o json | jq '.status.operationState.syncResult[]')
-      EOF
-        )
-        echo "argocd_app_details<<EOF" >> $GITHUB_OUTPUT
-        echo "$ARGOCD_APP_DETAILS" >> $GITHUB_OUTPUT
-        echo "EOF" >> $GITHUB_OUTPUT
-        exit 1
-      fi
-
     env:
       ARGOCD_AUTH_TOKEN: ${{ inputs.argocd_token }}
       ARGOCD_OPTS: "--grpc-web"
       ARGOCD_SERVER: ${{ inputs.argocd_server  }}
+      TIMEOUT: ${{ inputs.argocd_wait_for_sync_timeout }}
+      APP_NAME: ${{ inputs.app_name }}
+    run: |
+      bash ${{ github.action_path }}/app-sync-status.sh
+
+      # echo "::group::wait for sync"
+
+      # TIMEOUT=${{ inputs.argocd_wait_for_sync_timeout }}
+      # INTERVAL=30   # Interval between retries in seconds
+      # ELAPSED=0
+      #
+      # while [ $ELAPSED -le $TIMEOUT ]; do
+      #   ARGOCD_APP_STATUS=$(argocd app get "${{ inputs.app_name }}" -o json | jq -r '.status.health.status')
+      #   echo "Current status: $ARGOCD_APP_STATUS"
+      #
+      #   if [ -n "$ARGOCD_APP_STATUS" && "$ARGOCD_APP_STATUS" == "Healthy" ]; then
+      #     echo "App is healthy."
+      #     break
+      #   fi
+      #
+      #   echo "App is not healthy yet. Retrying in $INTERVAL seconds..."
+      #   sleep $INTERVAL
+      #   ELAPSED=$((ELAPSED + INTERVAL))
+      #   echo "Elapsed time is $ELAPSED seconds."
+      # done
+      #
+      # echo "::endgroup::"
+      #
+      # if [ "$ARGOCD_APP_STATUS" == "Healthy" ]; then
+      #   echo "Application reached healthy state."
+      #   exit 0
+      # else
+      #   echo "Timeout reached. The application did not become healthy. Collecting troubleshooting information."
+      #   ARGOCD_APP_DETAILS=$(cat <<EOF
+      # ArgoCD App details
+      # ------------------
+      # App health: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.health.status')
+      # App sync: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.sync.status')
+      # App conditions: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.conditions')
+      # State of the latest operation phase: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.operationState.phase')
+      # Message from the latest operation phase: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.operationState.message')
+      # Sync results:
+      # $(argocd app get ${{ inputs.app_name }} -o json | jq '.status.operationState.syncResult[]')
+      # EOF
+      #   )
+      #   echo "argocd_app_details<<EOF" >> $GITHUB_OUTPUT
+      #   echo "$ARGOCD_APP_DETAILS" >> $GITHUB_OUTPUT
+      #   echo "EOF" >> $GITHUB_OUTPUT
+      #   exit 1
+      # fi
+
 
     #########################################################################
     # Get additional troubleshooting information from Kubernetes events

--- a/preview-env/create/action.yml
+++ b/preview-env/create/action.yml
@@ -55,6 +55,8 @@ runs:
       ARGOCD_AUTH_TOKEN: ${{ inputs.argocd_token }}
       ARGOCD_OPTS: "--grpc-web"
       ARGOCD_SERVER: ${{ inputs.argocd_server }}
+  - name: Ensure that jq is available
+    uses: dcarbone/install-jq-action@v3.0.1
     #########################################################################
     # Create a GitHub deployment that points to the URL we're going to deploy to.
     # If a Pull Request exists, it will show the status of this deployment.
@@ -110,6 +112,22 @@ runs:
     run: |-
       echo "::group::wait for sync"
       argocd app wait ${{ inputs.app_name }} --timeout 1200 --health
+      echo "::endgroup::"
+    env:
+      ARGOCD_AUTH_TOKEN: ${{ inputs.argocd_token }}
+      ARGOCD_OPTS: "--grpc-web"
+      ARGOCD_SERVER: ${{ inputs.argocd_server  }}
+  - name: Get app status details
+    shell: bash
+    run: |-
+      echo "::group::get app status details"
+      echo "App health: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.health.status')"
+      echo "App sync: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.sync.status')"
+      echo "App conditions: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.conditions')"
+      echo "State of the latest operation phase: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.operationState.phase')"
+      echo "Message from the lastest operation phase: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.operationState.message')"
+      echo "Sync results: $(argocd app get ${{ inputs.app_name }} -o json | jq '.status.operationState.syncResult[]')"
+      # echo "Kubernetes warnings (if any): $()"
       echo "::endgroup::"
     env:
       ARGOCD_AUTH_TOKEN: ${{ inputs.argocd_token }}

--- a/preview-env/create/action.yml
+++ b/preview-env/create/action.yml
@@ -40,6 +40,14 @@ inputs:
     description: The time (in seconds) that the action waits for the app to become healthy
     required: false
     default: "1800" # wait for up to 30 minutes
+
+  github_token:
+    description: |-
+      GitHub token is used to authenticate with Teleport.
+      It needs to have an "id-token: write" permission.
+      If the token is present, the Kubernetes events get added to the troubleshooting information.
+    required: false
+
 runs:
   using: composite
   steps:
@@ -166,9 +174,11 @@ runs:
 
     #########################################################################
     # Get additional troubleshooting information from Kubernetes events
-    # in case of the app didn't reach healthy state
+    # in case of the app didn't reach healthy state.
+    # Events only get requested if a GitHub token with appropriate rights
+    # is passed from the caller workflow.
   - name: Setup Teleport
-    if: failure()
+    if: failure() && inputs.github_token != ''
     id: setup_teleport
     uses: teleport-actions/setup@v1
     with:
@@ -176,6 +186,8 @@ runs:
   - name: Authenticate with Teleport
     if: failure() && steps.setup_teleport.outcome == 'success'
     id: auth_teleport
+    env:
+      GITHUB_TOKEN: ${{ inputs.github_token }}
     uses: teleport-actions/auth-k8s@v2
     with:
       proxy: camunda.teleport.sh:443

--- a/preview-env/create/action.yml
+++ b/preview-env/create/action.yml
@@ -107,15 +107,34 @@ runs:
       ARGOCD_AUTH_TOKEN: ${{ inputs.argocd_token }}
       ARGOCD_OPTS: "--grpc-web"
       ARGOCD_SERVER: ${{ inputs.argocd_server }}
-  - name: Wait for sync (up to 20 minutes)
+  - name: Wait for sync (up to 30 minutes)
     id: wait-for-sync
     shell: bash
     run: |-
       echo "::group::wait for sync"
-      argocd app wait ${{ inputs.app_name }} --timeout 1200 --health --sync
+      # argocd app wait ${{ inputs.app_name }} --timeout 1200 --health
+      # echo "::endgroup::"
+
+      TIMEOUT=1800  # Total timeout in seconds
+      INTERVAL=30   # Interval between retries in seconds
+      ELAPSED=0
+      while [ $ELAPSED -lt $TIMEOUT ]; do
+        ARGOCD_APP_STATUS=$(argocd app get "${{ inputs.app_name }}" -o json | jq -r '.status.health.status')
+        echo "Current status: $ARGOCD_APP_STATUS"
+
+        if [ "$ARGOCD_APP_STATUS" == "Healthy" ]; then
+          echo "App is healthy."
+          break
+        fi
+
+        echo "App is not healthy yet. Retrying in $INTERVAL seconds..."
+        sleep $INTERVAL
+        ELAPSED=$((ELAPSED + INTERVAL))
+      done
+
       echo "::endgroup::"
 
-      # collect application details from ArgoCD for troubleshooting
+      # collect application details for troubleshooting
       ARGOCD_APP_DETAILS=$(cat <<EOF
       App health: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.health.status')
       App sync: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.sync.status')
@@ -129,6 +148,14 @@ runs:
       echo "argocd_app_details<<EOF" >> $GITHUB_OUTPUT
       echo "$ARGOCD_APP_DETAILS" >> $GITHUB_OUTPUT
       echo "EOF" >> $GITHUB_OUTPUT
+
+      if [ "$APP_HEALTH_STATUS" == "Healthy" ]; then
+        echo "Application reached healthy state."
+        exit 0
+      else
+        echo "Timeout reached. The application did not become healthy."
+        exit 1
+      fi
 
     env:
       ARGOCD_AUTH_TOKEN: ${{ inputs.argocd_token }}

--- a/preview-env/create/action.yml
+++ b/preview-env/create/action.yml
@@ -141,6 +141,7 @@ runs:
         echo "App is not healthy yet. Retrying in $INTERVAL seconds..."
         sleep $INTERVAL
         ELAPSED=$((ELAPSED + INTERVAL))
+        echo "Elapsed time is $ELAPSED seconds."
       done
 
       echo "::endgroup::"
@@ -152,6 +153,8 @@ runs:
         echo "Timeout reached. The application did not become healthy. Collecting troubleshooting information."
         # collect application details for troubleshooting if it didn't reach the healthy status
         ARGOCD_APP_DETAILS=$(cat <<EOF
+      ArgoCD App details
+      ------------------
       App health: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.health.status')
       App sync: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.sync.status')
       App conditions: $(argocd app get ${{ inputs.app_name }} -o json | jq -r '.status.conditions')
@@ -164,6 +167,8 @@ runs:
         echo "argocd_app_details<<EOF" >> $GITHUB_OUTPUT
         echo "$ARGOCD_APP_DETAILS" >> $GITHUB_OUTPUT
         echo "EOF" >> $GITHUB_OUTPUT
+        # ensure output is flushed before exiting
+        sync
         exit 1
       fi
 

--- a/preview-env/create/app-sync-status.sh
+++ b/preview-env/create/app-sync-status.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+## app-sync-status.sh
+##
+## The script waits for an ArgoCD app to be synced and reports the results back
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# ensure TIMEOUT is set and not empty
+: "${TIMEOUT:?argocd_wait_for_sync_timeout variable is required but not set}"
+
+# ensure TIMEOUT is a valid positive integer
+if ! [[ "$TIMEOUT" =~ ^[0-9]+$ ]]; then
+  echo "Error: argocd_wait_for_sync_timeout must be a non-negative integer. Got: '$TIMEOUT'"
+  exit 1
+fi
+
+INTERVAL=30   # interval between retries in seconds
+ELAPSED=0
+
+echo "::group::wait for sync"
+
+while [ "$ELAPSED" -le "$TIMEOUT" ]; do
+    ARGOCD_APP_STATUS=$(argocd app get "$APP_NAME" -o json | jq -r '.status.health.status')
+    echo "Current status: $ARGOCD_APP_STATUS"
+
+    if [ "$ARGOCD_APP_STATUS" == "Healthy" ]; then
+        echo "App is healthy."
+        break
+    fi
+
+    echo "App is not healthy yet. Retrying in $INTERVAL seconds..."
+    sleep $INTERVAL
+    ELAPSED=$((ELAPSED + INTERVAL))
+    echo "Elapsed time is $ELAPSED seconds."
+done
+
+echo "::endgroup::"
+
+if [ "$ARGOCD_APP_STATUS" == "Healthy" ]; then
+    echo "Application reached healthy state."
+    exit 0
+else
+    echo "Timeout reached. The application did not become healthy. Collecting troubleshooting information."
+    ARGOCD_APP_DETAILS=$(cat <<EOF
+ArgoCD App details
+------------------
+App health: $(argocd app get "$APP_NAME" -o json | jq -r '.status.health.status')
+App sync: $(argocd app get "$APP_NAME" -o json | jq -r '.status.sync.status')
+App conditions: $(argocd app get "$APP_NAME" -o json | jq -r '.status.conditions')
+State of the latest operation phase: $(argocd app get "$APP_NAME" -o json | jq -r '.status.operationState.phase')
+Message from the latest operation phase: $(argocd app get "$APP_NAME" -o json | jq -r '.status.operationState.message')
+Sync results:
+$(argocd app get "$APP_NAME" -o json | jq '.status.operationState.syncResult[]')
+EOF
+    )
+    echo "argocd_app_details<<EOF" >> "$GITHUB_OUTPUT"
+    echo "$ARGOCD_APP_DETAILS" >> "$GITHUB_OUTPUT"
+    echo "EOF" >> "$GITHUB_OUTPUT"
+    exit 1
+fi

--- a/preview-env/create/app-sync-status.sh
+++ b/preview-env/create/app-sync-status.sh
@@ -56,6 +56,7 @@ Sync results:
 $(argocd app get "$APP_NAME" -o json | jq '.status.operationState.syncResult[]')
 EOF
     )
+    # shellcheck disable=SC2129
     echo "argocd_app_details<<EOF" >> "$GITHUB_OUTPUT"
     echo "$ARGOCD_APP_DETAILS" >> "$GITHUB_OUTPUT"
     echo "EOF" >> "$GITHUB_OUTPUT"

--- a/preview-env/create/templates/comment-failure.md
+++ b/preview-env/create/templates/comment-failure.md
@@ -2,7 +2,11 @@
 * __Status:__ :x:
 * __ArgoCD:__ :link: [Link](https://${ARGOCD_SERVER}/applications/argocd/${APP_NAME}?view=tree&resource=)([degraded resources](https://${ARGOCD_SERVER}/applications/argocd/${APP_NAME}?view=tree&resource=health%3ADegraded))
 * __Deployment Jobs:__ :clipboard: [Link](https://github.com/${REPO}/actions/runs/${RUN_ID})
-* __ArgoCD App Details:__ :ring_buoy:
+* __Details for Troubleshooting:__ :ring_buoy:
 ```
 ${ARGOCD_APP_DETAILS}
+```
+
+```
+${KUBERNETES_EVENTS}
 ```

--- a/preview-env/create/templates/comment-failure.md
+++ b/preview-env/create/templates/comment-failure.md
@@ -6,9 +6,16 @@
 ```
 Typical Errors
 --------------
-ErrImagePull / ImagePullBackOff - The CI hasn't finished building the image yet -> increase "argocd_wait_for_sync_timeout"
-Readiness / Liveness probe failed - The container is not fully functional yet -> increase "argocd_wait_for_sync_timeout"
-
+- ErrImagePull / ImagePullBackOff - The CI hasn't finished building the image yet or the image build has failed
+  - Check whether the build is still in progress
+    - If it is then increase "argocd_wait_for_sync_timeout"
+    - If the build has failed then check the CI for the possible cause of the error
+- Readiness / Liveness probe failed - The container is not fully functional yet
+  - There could be many causes for this error, so there's no a single good solution for the problem
+    - The best generic approach is to check the ArgoCD App for the underlying problems using the link above
+      - Click on the problematic component and investigate "EVENTS" and "LOGS" tabs for clues
+    - It could also be simply happening because, although everything seems to be correct, the app is not fully functional yet
+      - In this case simply increase "argocd_wait_for_sync_timeout" value
 ```
 * __Details for Troubleshooting:__ :ring_buoy:
 ```

--- a/preview-env/create/templates/comment-failure.md
+++ b/preview-env/create/templates/comment-failure.md
@@ -2,3 +2,7 @@
 * __Status:__ :x:
 * __ArgoCD:__ :link: [Link](https://${ARGOCD_SERVER}/applications/argocd/${APP_NAME}?view=tree&resource=)([degraded resources](https://${ARGOCD_SERVER}/applications/argocd/${APP_NAME}?view=tree&resource=health%3ADegraded))
 * __Deployment Jobs:__ :clipboard: [Link](https://github.com/${REPO}/actions/runs/${RUN_ID})
+* __ArgoCD App Details:__ :ring_buoy:
+```
+${ARGOCD_APP_DETAILS}
+```

--- a/preview-env/create/templates/comment-failure.md
+++ b/preview-env/create/templates/comment-failure.md
@@ -2,11 +2,19 @@
 * __Status:__ :x:
 * __ArgoCD:__ :link: [Link](https://${ARGOCD_SERVER}/applications/argocd/${APP_NAME}?view=tree&resource=)([degraded resources](https://${ARGOCD_SERVER}/applications/argocd/${APP_NAME}?view=tree&resource=health%3ADegraded))
 * __Deployment Jobs:__ :clipboard: [Link](https://github.com/${REPO}/actions/runs/${RUN_ID})
+* __Troubleshooting Tips:__ :spanner:
+```
+Typical Errors
+--------------
+ErrImagePull / ImagePullBackOff - The CI hasn't finished building the image yet -> increase "argocd_wait_for_sync_timeout"
+Readiness / Liveness probe failed - The container is not fully functional yet -> increase "argocd_wait_for_sync_timeout"
+
+```
 * __Details for Troubleshooting:__ :ring_buoy:
 ```
-${ARGOCD_APP_DETAILS}
+${KUBERNETES_EVENTS}
 ```
 
 ```
-${KUBERNETES_EVENTS}
+${ARGOCD_APP_DETAILS}
 ```

--- a/preview-env/create/templates/comment-failure.md
+++ b/preview-env/create/templates/comment-failure.md
@@ -2,7 +2,7 @@
 * __Status:__ :x:
 * __ArgoCD:__ :link: [Link](https://${ARGOCD_SERVER}/applications/argocd/${APP_NAME}?view=tree&resource=)([degraded resources](https://${ARGOCD_SERVER}/applications/argocd/${APP_NAME}?view=tree&resource=health%3ADegraded))
 * __Deployment Jobs:__ :clipboard: [Link](https://github.com/${REPO}/actions/runs/${RUN_ID})
-* __Troubleshooting Tips:__ :spanner:
+* __Troubleshooting Tips:__ :ring_buoy:
 ```
 Typical Errors
 --------------

--- a/preview-env/create/templates/comment-success.md
+++ b/preview-env/create/templates/comment-success.md
@@ -3,3 +3,7 @@
 * __URL:__ :globe_with_meridians: [Link](${APP_URL})
 * __ArgoCD:__ :link: [Link](https://${ARGOCD_SERVER}/applications/argocd/${APP_NAME}?view=tree&resource=)
 * __Deployment Jobs:__ :clipboard: [Link](https://github.com/${REPO}/actions/runs/${RUN_ID})
+* __ArgoCD App Details__ :ring_buoy:
+```
+${ARGOCD_APP_DETAILS}
+```

--- a/preview-env/create/templates/comment-success.md
+++ b/preview-env/create/templates/comment-success.md
@@ -3,7 +3,3 @@
 * __URL:__ :globe_with_meridians: [Link](${APP_URL})
 * __ArgoCD:__ :link: [Link](https://${ARGOCD_SERVER}/applications/argocd/${APP_NAME}?view=tree&resource=)
 * __Deployment Jobs:__ :clipboard: [Link](https://github.com/${REPO}/actions/runs/${RUN_ID})
-* __ArgoCD App Details:__ :ring_buoy:
-```
-${ARGOCD_APP_DETAILS}
-```

--- a/preview-env/create/templates/comment-success.md
+++ b/preview-env/create/templates/comment-success.md
@@ -3,7 +3,7 @@
 * __URL:__ :globe_with_meridians: [Link](${APP_URL})
 * __ArgoCD:__ :link: [Link](https://${ARGOCD_SERVER}/applications/argocd/${APP_NAME}?view=tree&resource=)
 * __Deployment Jobs:__ :clipboard: [Link](https://github.com/${REPO}/actions/runs/${RUN_ID})
-* __ArgoCD App Details__ :ring_buoy:
+* __ArgoCD App Details:__ :ring_buoy:
 ```
 ${ARGOCD_APP_DETAILS}
 ```


### PR DESCRIPTION
# Automatic troubleshooting mode for the Preview Environments

Enrich the `preview-env/create` action with additional information that could help troubleshooting if anything goes wrong in a deployment.

Related: https://github.com/camunda/team-infrastructure/issues/521