### PR TITLE
ci(renovate): increase automerge rate for argocd

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -56,10 +56,12 @@
       addLabels: ["automerge"],
       automerge: true
     },
+    // Automerge Section
     {
       matchUpdateTypes: ["patch"],
       matchPackageNames: [
-        "/actionlint/"
+        "/actionlint/",
+        "argoproj/argo-cd",
       ],
       addLabels: ["automerge"],
       automerge: true,


### PR DESCRIPTION
ArgoCD patch releases should be automerged (see [this PR](https://github.com/camunda/infra-core/pull/9070) as reference).
Didn't happen though (see [this PR](https://github.com/camunda/infra-global-github-actions/pull/348)).

Adapted the config according to our [central one](https://github.com/camunda/infra-renovate-config/blob/main/default.json5#L232).

After merge I will retry the yet unmerged PR to validate.