### PR TITLE
chore(submit-aborted-gha-status): determine repository automatically

### DIFF
--- a/submit-aborted-gha-status/action.yml
+++ b/submit-aborted-gha-status/action.yml
@@ -23,6 +23,7 @@ runs:
       echo "Inputs"
       echo "-----"
       echo "BQ table name (for testing): ${{ inputs.big_query_table_name }}"
+      echo "GitHub owner/repo: $GITHUB_REPOSITORY"
 
   - name: Login to Google Cloud
     id: auth
@@ -46,14 +47,14 @@ runs:
       BUILD_HEAD_REF: "${{ github.head_ref && format('refs/heads/{0}', github.head_ref) || github.event.merge_group.head_ref }}"
       GH_TOKEN: ${{ github.token }}
     run: |
-      gh api -X GET "repos/camunda/camunda/actions/runs/$GITHUB_RUN_ID/attempts/$GITHUB_RUN_ATTEMPT/jobs?per_page=100" --jq '.jobs[] | select(.conclusion=="failure") .id' | while read job_id; do
+      gh api -X GET "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/attempts/$GITHUB_RUN_ATTEMPT/jobs?per_page=100" --jq '.jobs[] | select(.conclusion=="failure") .id' | while read job_id; do
         echo "Checking failed job $job_id for abort due to runner problem..."
 
-        job_annotations=$(gh api -X GET "/repos/camunda/camunda/check-runs/$job_id/annotations" --jq '.[] | select(.message | contains("lost communication with the server") or contains("runner has received a shutdown signal"))')
+        job_annotations=$(gh api -X GET "/repos/$GITHUB_REPOSITORY/check-runs/$job_id/annotations" --jq '.[] | select(.message | contains("lost communication with the server") or contains("runner has received a shutdown signal"))')
 
         if echo "$job_annotations" | grep -q message; then
-          job_name=$(gh api "repos/camunda/camunda/actions/jobs/$job_id" --jq '.name')
-          runner_name=$(gh api "repos/camunda/camunda/actions/jobs/$job_id" --jq '.runner_name' | tr '[:upper:]' '[:lower:]')
+          job_name=$(gh api "repos/$GITHUB_REPOSITORY/actions/jobs/$job_id" --jq '.name')
+          runner_name=$(gh api "repos/$GITHUB_REPOSITORY/actions/jobs/$job_id" --jq '.runner_name' | tr '[:upper:]' '[:lower:]')
           if [ "$runner_name" == "" ]; then
             runner_name=$(echo "$job_annotations" | grep -oP '(?<=The self-hosted runner: )\S+')
           fi


### PR DESCRIPTION
Avoids hard-coding the URL which was an oversight and is not reusable.