### PR TITLE
Install envsubst

### DIFF
--- a/preview-env/create/action.yml
+++ b/preview-env/create/action.yml
@@ -187,6 +187,13 @@ runs:
       env_url: ${{ inputs.app_url }}
       ref: ${{ inputs.revision }}
       env: ${{ inputs.app_name }}
+    # envsubst is not available on the self-hosted runners
+    # therefore the deployment status artifact step would fail
+  - name: Install envsubst
+    if: always()
+    shell: bash
+    run: |
+      sudo apt-get update && sudo apt-get install -y gettext-base
   - name: Create deployment status artifact
     if: always()
     shell: bash


### PR DESCRIPTION
Install `envsubst` binary for `preview-env/create` action. When the action is executed on a self-hosted runner then the deployment artifact create step would fail.

- Related
  - https://github.com/camunda/team-infrastructure/issues/521
  - https://camunda.slack.com/archives/C5AHF1D8T/p1740729769640149

- Tested on `web-modeler`
  - https://github.com/camunda/web-modeler/actions/runs/13586248134/job/37981769877?pr=12687#step:7:1391