### PR TITLE
chore(deps): enable renovate automerge for teleport-ent-distroless

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -62,6 +62,7 @@
       matchPackageNames: [
         "/actionlint/",
         "argoproj/argo-cd",
+        "gravitational/teleport-ent-distroless",
       ],
       addLabels: ["automerge"],
       automerge: true,


### PR DESCRIPTION
Enable Renovate automerge for `gravitational/teleport-ent-distroless` patch releases.

Related: https://github.com/camunda/infra-global-github-actions/pull/362