### PR TITLE
chore: add fossa-related composite actions

### DIFF
--- a/fossa/analyze/action.yml
+++ b/fossa/analyze/action.yml
@@ -1,0 +1,40 @@
+name: fossa analyze
+
+description: Run FOSSA CLI analyze command
+
+inputs:
+  api-key:
+    description: The API key to access fossa.com
+    required: true
+  branch:
+    description: Name of the branch to be scanned
+    required: true
+  configuration-file:
+    description: Path to the FOSSA configuration file
+    required: false
+    default: .fossa.yml
+  path:
+    description: Path to the directory to be scanned
+    default: .
+    required: false
+  revision-id:
+    description: ID of the scanned revision
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Run FOSSA analyze
+      env:
+        BRANCH: ${{ inputs.branch }}
+        CONFIGURATION_FILE: ${{ inputs.configuration-file }}
+        DIRECTORY_PATH: ${{ inputs.path }}
+        FOSSA_API_KEY: ${{ inputs.api-key }}
+        REVISION_ID: ${{ inputs.revision-id }}
+      run: |
+        set -e # Exit on error
+        fossa analyze "${DIRECTORY_PATH}" \
+          --strict \
+          --config "${CONFIGURATION_FILE}" \
+          --branch "${BRANCH}" \
+          --revision "${REVISION_ID}"
+      shell: bash

--- a/fossa/setup/action.yml
+++ b/fossa/setup/action.yml
@@ -1,0 +1,29 @@
+name: fossa setup
+
+description: Install FOSSA CLI
+
+inputs:
+  version:
+    description: Version of the FOSSA CLI to install
+    # renovate: datasource=github-releases depName=fossas/fossa-cli
+    default: 3.10.5
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Install FOSSA CLI
+      env:
+        FOSSA_CLI_VERSION: ${{ inputs.version }}
+      run: |
+        if ! command -v fossa &> /dev/null
+        then
+          echo "FOSSA CLI not found, installing version=${FOSSA_CLI_VERSION}..."
+          curl \
+            -sSL \
+            -H 'Cache-Control: no-cache' \
+            https://github.com/fossas/fossa-cli/releases/download/v${FOSSA_CLI_VERSION}/fossa_${FOSSA_CLI_VERSION}_linux_amd64.tar.gz | \
+           sudo tar -xz -C /usr/local/bin
+        else
+          echo "FOSSA CLI is already installed"
+        fi
+      shell: bash


### PR DESCRIPTION
Related to https://github.com/camunda/team-infrastructure/issues/751.

Add new composite actions for FOSSA:
- `fossa/setup` to install the CLI
- `fossa/analyze` to run the analysis

The idea is to encapsulate interactions with the FOSSA CLI used in workflows across various product repositories. This approach simplifies maintenance (e.g., upgrading the CLI version) and abstracts unnecessary implementation details.