### PR TITLE
Revert "Revert "chore(deps): update pre-commit hook renovatebot/pre-commit-hooks to v40 (#396)" (#398)"

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -25,7 +25,7 @@
   customManagers: [
     {
       customType: "regex",
-      fileMatch: ["\.ya?ml$"],
+      managerFilePatterns: ["/.ya?ml$/"],
       matchStrings: [
         "renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.* (?<currentValue>.*)\\s"
       ],

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,8 +22,8 @@ repos:
       args: ["-config-file", "actionlint/actionlint.yaml"]
 
 - repo: https://github.com/renovatebot/pre-commit-hooks
-  rev: 39.259.0
+  rev: 40.3.1
   hooks:
   - id: renovate-config-validator
     args: ["--strict"]
-    language_version: 20.18.0 # temporary workaround to mitigate issue https://github.com/renovatebot/pre-commit-hooks/issues/2460
+    language_version: 22.15.0 # temporary workaround to mitigate issue https://github.com/renovatebot/pre-commit-hooks/issues/2460

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,4 +26,4 @@ repos:
   hooks:
   - id: renovate-config-validator
     args: ["--strict"]
-    language_version: 22.15.0 # temporary workaround to mitigate issue https://github.com/renovatebot/pre-commit-hooks/issues/2460
+    language_version: lts


### PR DESCRIPTION
Re-apply Renovate pre-commit hooks and config changes after the community instance is upgraded to v40.