### PR TITLE
feat(actionlint): enable optional use of shellcheck

### DIFF
--- a/actionlint/README.md
+++ b/actionlint/README.md
@@ -13,6 +13,7 @@ You can see the list of checks supported by `actionlint` [here](https://github.c
 |-------------------------|---------------|-------------------------------------------------------------------------|
 | `version`               | "1.7.4"       | Actionlint version that will be downloaded  |
 | `ignore`                |               | Multiline field. Allow you to customized ignored errors using regular expression. One ignore pattern per line |
+| `use_shellcheck`        | "false"       | Enable actionlint to use shellcheck for all shell scripts in the repository. |
 
 ## Customizations
 

--- a/actionlint/action.yml
+++ b/actionlint/action.yml
@@ -33,8 +33,7 @@ runs:
     #     else
     #       echo "shellcheck is already installed."
     #     fi
-
-        shellcheck --version
+    #     shellcheck --version
 
     - name: Check workflow files
       env:

--- a/actionlint/action.yml
+++ b/actionlint/action.yml
@@ -22,19 +22,6 @@ runs:
     - run: echo "::add-matcher::${{ github.action_path }}/actionlint-matcher.json"
       shell: bash
 
-    # - name: Install shellcheck if needed
-    #   if: inputs.use_shellcheck == 'true'
-    #   shell: bash
-    #   run: |
-    #     if ! command -v shellcheck &> /dev/null; then
-    #       echo "Installing shellcheck..."
-    #       sudo apt-get update
-    #       sudo apt-get install -y shellcheck
-    #     else
-    #       echo "shellcheck is already installed."
-    #     fi
-    #     shellcheck --version
-
     - name: Check workflow files
       env:
         ACTIONLINT_VERSION: ${{ inputs.version }}

--- a/actionlint/action.yml
+++ b/actionlint/action.yml
@@ -26,7 +26,7 @@ runs:
       env:
         ACTIONLINT_VERSION: ${{ inputs.version }}
         IGNORE_MESSAGES: ${{ inputs.ignore }}
-        USE_SHELLCHHECK: ${{ inputs.use_shellcheck }}
+        USE_SHELLCHECK: ${{ inputs.use_shellcheck }}
         DEFAULT_CONFIG_FILE: ${{ github.action_path }}/actionlint.yaml
         REPOSITORY_ADDITIONAL_CONFIG_FILE: ${{ github.action_path }}/custom/${{ github.repository }}/actionlint.yaml
       run: |
@@ -54,7 +54,7 @@ runs:
         _args+=(-pyflakes=)
 
         # Configure shellcheck
-        if [[ "$USE_SHELLCHHECK" == "false" ]]; then
+        if [[ "$USE_SHELLCHECK" == "false" ]]; then
           _args+=(-shellcheck=)
         fi
 

--- a/actionlint/action.yml
+++ b/actionlint/action.yml
@@ -9,6 +9,10 @@ inputs:
     default: "1.7.4"
   ignore:
     description: Multiline; Ignore errors by messaging using regular expression.
+  use_shellcheck:
+    description: Enable shellcheck validation in actionlint
+    default: "false"
+    required: false
 
 runs:
   using: composite
@@ -18,10 +22,25 @@ runs:
     - run: echo "::add-matcher::${{ github.action_path }}/actionlint-matcher.json"
       shell: bash
 
+    - name: Install shellcheck if needed
+      if: inputs.use_shellcheck == 'true'
+      shell: bash
+      run: |
+        if ! command -v shellcheck &> /dev/null; then
+          echo "Installing shellcheck..."
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+        else
+          echo "shellcheck is already installed."
+        fi
+
+        shellcheck --version
+
     - name: Check workflow files
       env:
         ACTIONLINT_VERSION: ${{ inputs.version }}
         IGNORE_MESSAGES: ${{ inputs.ignore }}
+        USE_SHELLCHHECK: ${{ inputs.use_shellcheck }}
         DEFAULT_CONFIG_FILE: ${{ github.action_path }}/actionlint.yaml
         REPOSITORY_ADDITIONAL_CONFIG_FILE: ${{ github.action_path }}/custom/${{ github.repository }}/actionlint.yaml
       run: |
@@ -45,9 +64,15 @@ runs:
         # Set config file
         _args+=(-config-file "$CONFIG_FILE")
 
-        # Exclude shellcheck and pyflakes
-        _args+=(-shellcheck)
+        # Exclude pyflakes
         _args+=(-pyflakes)
+
+        # Configure shellcheck
+        if [[ "$USE_SHELLCHHECK" == "true" ]]; then
+          _args+=(-shellcheck shellcheck)
+        else
+          _args+=(-shellcheck)
+        fi
 
         # Ignore error messages
         if [[ -n "$IGNORE_MESSAGES" ]]; then

--- a/actionlint/action.yml
+++ b/actionlint/action.yml
@@ -22,17 +22,17 @@ runs:
     - run: echo "::add-matcher::${{ github.action_path }}/actionlint-matcher.json"
       shell: bash
 
-    - name: Install shellcheck if needed
-      if: inputs.use_shellcheck == 'true'
-      shell: bash
-      run: |
-        if ! command -v shellcheck &> /dev/null; then
-          echo "Installing shellcheck..."
-          sudo apt-get update
-          sudo apt-get install -y shellcheck
-        else
-          echo "shellcheck is already installed."
-        fi
+    # - name: Install shellcheck if needed
+    #   if: inputs.use_shellcheck == 'true'
+    #   shell: bash
+    #   run: |
+    #     if ! command -v shellcheck &> /dev/null; then
+    #       echo "Installing shellcheck..."
+    #       sudo apt-get update
+    #       sudo apt-get install -y shellcheck
+    #     else
+    #       echo "shellcheck is already installed."
+    #     fi
 
         shellcheck --version
 
@@ -68,7 +68,7 @@ runs:
         _args+=(-pyflakes=)
 
         # Configure shellcheck
-        if [[ "$USE_SHELLCHHECK" != "true" ]]; then
+        if [[ "$USE_SHELLCHHECK" == "false" ]]; then
           _args+=(-shellcheck=)
         fi
 

--- a/actionlint/action.yml
+++ b/actionlint/action.yml
@@ -69,9 +69,9 @@ runs:
 
         # Configure shellcheck
         if [[ "$USE_SHELLCHHECK" == "true" ]]; then
-          _args+=(-shellcheck shellcheck)
+          _args+=(-shellcheck "shellcheck")
         else
-          _args+=(-shellcheck)
+          _args+=(-shellcheck "")
         fi
 
         # Ignore error messages

--- a/actionlint/action.yml
+++ b/actionlint/action.yml
@@ -65,7 +65,7 @@ runs:
         _args+=(-config-file "$CONFIG_FILE")
 
         # Exclude pyflakes
-        _args+=(-pyflakes)
+        _args+=(-pyflakes "")
 
         # Configure shellcheck
         if [[ "$USE_SHELLCHHECK" == "true" ]]; then

--- a/actionlint/action.yml
+++ b/actionlint/action.yml
@@ -65,13 +65,11 @@ runs:
         _args+=(-config-file "$CONFIG_FILE")
 
         # Exclude pyflakes
-        _args+=(-pyflakes "")
+        _args+=(-pyflakes=)
 
         # Configure shellcheck
-        if [[ "$USE_SHELLCHHECK" == "true" ]]; then
-          _args+=(-shellcheck "shellcheck")
-        else
-          _args+=(-shellcheck "")
+        if [[ "$USE_SHELLCHHECK" != "true" ]]; then
+          _args+=(-shellcheck=)
         fi
 
         # Ignore error messages


### PR DESCRIPTION
Add an optional input variable to the composite workflow that enables `actionlint` to use `shellcheck`.

Related: https://github.com/camunda/camunda/issues/31046