### PR TITLE
fix: retry-worfklow-run report back to workflow file

### DIFF
--- a/.github/workflows/retry-worfklow-run.yml
+++ b/.github/workflows/retry-worfklow-run.yml
@@ -123,16 +123,18 @@ jobs:
           RUN_ID: ${{ inputs.run-id }}
         run: |
           # trigger a new run with error notification
-          workflow_name=$(
-            gh run view "${RUN_ID}" \
-              --json workflowName \
-              --jq '.workflowName'
-          )
+
+          path=$(gh api "/repos/${GH_REPO}/actions/runs/${RUN_ID}" \
+            --jq '.path'
+            )
+
+          workflow_name=$(basename "$path")
+
           if [ "${DRY_RUN}" = "true" ]; then
             echo "Skipping notify back since this is a dry-run ..."
           else
-            echo "notifying back to workflow=${workflow_name}.yml ..."
-            gh workflow run "${workflow_name}.yml" \
+            echo "notifying back to workflow=${workflow_name} ..."
+            gh workflow run "${workflow_name}" \
               --field notify_back_error_message="${NOTIFY_BACK_ERROR_MESSAGE}" \
               --ref="${notify-back-git-ref}"
           fi


### PR DESCRIPTION
This PR is just a proposal.
I did not check whether there are any other fixes required within the workflow. This is just for reporting back the error and not actually rerunning (which seems to work).

Before it was just taking the workflowName, which can be the correct file name if a user doesn't overwrite the name. In that case it will default to the file name. The likelihood of users not overwriting the name is quite slim.
Therefore, we need to get the correct file name somehow differently as the run itself doesn't contain that, we're parsing it via the API.

Related to following failed job: https://github.com/camunda/infra-global-github-actions/actions/runs/15091530730/job/42420711579

```
notifying back to workflow=Tests - Integration - AWS OpenShift ROSA HCP Dual Region.yml ...
HTTP 404: workflow Tests - Integration - AWS OpenShift ROSA HCP Dual Region.yml not found on the default branch 
```

Now it would properly use the file name `aws_openshift_rosa_hcp_dual_region_tests.yml`.