### PR TITLE
fix(gha): empty error-message throw error

### DIFF
--- a/.github/workflows/retry-worfklow-run.yml
+++ b/.github/workflows/retry-worfklow-run.yml
@@ -12,8 +12,8 @@ on:
         description: |
           Error messages to look for in annotations and logs.
           The workflow run is only retried if any of the error messages are found.
-          If this parameter is empty, the workflow will be retried without checking for specific error messages.
-        default: ''
+          If this parameter is an empty array ('[]'), the workflow will be retried without checking for specific error messages.
+        default: '[]'
       run-id:
         description: Id of the workflow run to retry
         required: true
@@ -84,7 +84,7 @@ jobs:
 
       - name: Check annotations and job logs for errors
         id: errors
-        if: inputs.error-messages != ''
+        if: inputs.error-messages != '[]'
         uses: ./rerun-failed-run/check-annotations-and-logs
         with:
           error-messages: ${{ inputs.error-messages }}
@@ -94,7 +94,7 @@ jobs:
           run-id: ${{ inputs.run-id }}
 
       - name: Retry worfklow run for repo=${{ inputs.owner }}/${{ inputs.repository }} and run-id=${{ inputs.run-id }}
-        if: steps.errors.outputs.found == 'true' || inputs.error-messages == ''
+        if: steps.errors.outputs.found == 'true' || inputs.error-messages == '[]'
         env:
           DRY_RUN: ${{ inputs.dry-run }}
           GH_REPO: ${{ inputs.owner }}/${{ inputs.repository }}

--- a/rerun-failed-run/README.md
+++ b/rerun-failed-run/README.md
@@ -16,7 +16,7 @@ If these secrets are not present, please contact the infrastructure team to set 
 | Input name                 | Description                                                                                                                                  |
 |----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
 | run-id (required)          | The ID of the failed workflow run to be retried.                                                                                             |
-| error-messages (required)  | Custom error messages to search for in the logs.                                                                                             |
+| error-messages  |       The error messages to check for in the workflow run logs. The workflow will be rerun only if at least one of the given messages is found in the logs of a failed job If not provided, the workflow will retry directly without checking the logs.                                                                                             |
 | repository (required)      | The name of the repository containing the workflow to be retried in the format ORG/REPO_NAME (example: `camunda/infra-global-github-action`) |
 | vault-addr (required)      | The Vault URL.                                                                                                                               |
 | vault-role-id (required)   | The Vault Role ID.                                                                                                                           |

--- a/rerun-failed-run/action.yml
+++ b/rerun-failed-run/action.yml
@@ -73,7 +73,6 @@ runs:
 
     - name: Convert error messages list to JSON
       id: error-messages
-      if: inputs.error-messages != ''
       env:
         ERROR_MESSAGES: ${{ inputs.error-messages }}
       run: |
@@ -96,7 +95,7 @@ runs:
         token: ${{ steps.github-token.outputs.token }}
         workflow_inputs: |
           {
-            "error-messages": ${{ steps.error-messages.outputs.json || '' }},
+            "error-messages": ${{ steps.error-messages.outputs.json }},
             "notify-back-git-ref": "${{ github.head_ref || github.ref_name }}",
             "notify-back-on-error": "${{ inputs.notify-back-on-error }}",
             "owner": "${{ steps.repository.outputs.owner }}",


### PR DESCRIPTION
This PR fixes empty error messages that creates an invalid json (example https://github.com/camunda/camunda-deployment-references/actions/runs/15194613324/job/42738277153?pr=336)

I've tested the behavior of the parsing input with an empty string, it creates an empty array ('[]') which is valid json.

Also fixing part of the README that was missed in
https://github.com/camunda/infra-global-github-actions/pull/410

Note for infraex: bump the version of the gha in all branches after merge