### PR TITLE
feat(fossa): add fallback to recent commits on base ref if first commit has no FOSSA scan

### DIFF
--- a/fossa/info/action.yml
+++ b/fossa/info/action.yml
@@ -2,6 +2,12 @@ name: fossa info
 
 description: Provides context info required for other FOSSA composite actions.
 
+inputs:
+  github-token:
+    description: |
+      The GitHub token to use for API calls.
+    default: ${{ github.token }}
+
 outputs:
   is-pull-request:
     description: |
@@ -18,6 +24,12 @@ outputs:
       Empty if not a pull request.
       Generally used to find (via diff) new license issues introduced by a PR.
     value: ${{ steps.info.outputs.base-revision }}
+  base-revision-most-recent-with-scanning-results:
+    description: |
+      The latest base branch revision (commit SHA) with FOSSA scanning results.
+      Useful when the base revision has no scanning results, such as after a manual merge commit that did not trigger a workflow (and so a scan).
+      Empty if none found.
+    value: ${{ steps.info-pr.outputs.base-ref-with-scanning-results }}
   head-ref:
     description: |
       The HEAD ref (name) of the branch to be analyzed by FOSSA, determined based on the context of the event.
@@ -66,4 +78,48 @@ runs:
         echo "head-ref=${HEAD_REF}"
         echo "head-revision=${HEAD_REVISION}"
       } >> $GITHUB_OUTPUT
+    shell: bash
+  - name: Get additional PR info
+    if: ${{ steps.info.outputs.is-pull-request == 'true' }}
+    id: info-pr
+    env:
+      BASE_REF: ${{ steps.info.outputs.base-ref }}
+      BASE_REVISION: ${{ steps.info.outputs.base-revision }}
+      GH_TOKEN: ${{ inputs.github-token }}
+      WORKFLOW_NAME: ${{ github.workflow }}
+    run: |
+      # Check recent commits of the base commit for existing scanning results
+      # history depth to search for scanning results
+      depth=5
+
+      # Ensure history is available for the base branch up to the specified depth
+      git fetch origin "${BASE_REF}" --depth=200
+      # If not enough, fetch more
+      git rev-parse "${BASE_REVISION}~$((depth-1))" >/dev/null 2>&1 || \
+        git fetch origin "${BASE_REF}" --unshallow
+
+      # Check if the base branch or its recent parents have scanning results
+      base_ref_with_scanning_results=""
+      for i in $(seq 0 $((depth-1))); do
+        commit=$(git rev-parse "${BASE_REVISION}~$i" 2>/dev/null || true)
+        # Check if a workflow run of "Check Licenses" succeeded for the commit
+        if gh run list \
+          --limit 1000 \
+          --commit "$commit" \
+          --json workflowName,conclusion \
+          --jq '[.[] | select(.workflowName == "'"$WORKFLOW_NAME"'" and .conclusion == "success")] | any' | grep -q true; then
+          if [ "$i" -gt 0 ]; then
+             echo "Scanning result found for commit=$commit, which is $i commit(s) behind the base branch/ref."
+          fi
+          base_ref_with_scanning_results=$commit
+          break
+        fi
+      done
+      if [ -z "$base_ref_with_scanning_results" ]; then
+        echo "No scan results found for base branch '${BASE_REF}' (revision: ${BASE_REVISION}) or any of its recent ancestors."
+        echo "::warning::No commit in the recent history of the base branch has scan results available."
+        echo "This likely indicates that recent scans for the base branch have failed and need to be addressed."
+        echo "Scan results for the base branch are required to compute a diff and identify license issues introduced by this PR. Without it, license checks will likely fail."
+      fi
+      echo "base-ref-with-scanning-results=${base_ref_with_scanning_results}" >> $GITHUB_OUTPUT
     shell: bash

--- a/fossa/pr-check/action.yml
+++ b/fossa/pr-check/action.yml
@@ -50,7 +50,7 @@ runs:
       # Run fossa test
       results=$(fossa test "${DIRECTORY_PATH}" --config "${CONFIGURATION_FILE}" --diff "${BASE_REVISION}" --revision "${REVISION}" --format json || true)
 
-      # Exit if results is empty or not a valid JSON
+      # Fail if results is empty or not a valid JSON
       if [ -z "$results" ] || ! echo "$results" | jq empty > /dev/null 2>&1; then
         exit 1
       fi


### PR DESCRIPTION
Related to https://github.com/camunda/team-infrastructure/issues/752 and https://camunda.slack.com/archives/C5AHF1D8T/p1748855183016529.

The` fossa/pr-check `GitHub Action compares FOSSA scan results between the head and base branches of a pull request to detect newly introduced license issues. Sometimes, the first commit on the base ref may not have a FOSSA scan, for example, due to workflows not being triggered (e.g. if commit pushed from a workflow) or interrupted, outages, etc.

To handle this, the action now includes a fallback using a new output: `base-revision-most-recent-with-scanning-results`. If the first base commit lacks scan results, the action checks up to the 5 most recent commits on the base branch for the latest one with scan results. For merge commits, parent 1 (the branch that was merged into) is used to preserve context. If no commits are found, `base-revision-most-recent-with-scanning-results` returns empty.

In rare cases, this might misattribute existing (not resolved) license issues from the base branch to the PR. However, this risk is very low. This implementation let the user decide whether to use this new output (fallback) or not (I will update all repositories).

This also lays the groundwork for making the 5-commit threshold configurable in the future, if needed.

Please find below the different tests (PRs and workflow runs) on a demo repository:
- TEST [01](https://github.com/clementnero/fossa-demo-case-01/actions/runs/15399182930/job/43327383868?pr=8): The base ref has a FOSSA scan result, check-licenses.yml runs as expected
- TEST [02](https://github.com/clementnero/fossa-demo-case-01/actions/runs/15399461759/job/43328335694?pr=9): The base ref has no scan result, but a recent commit on the base branch does, `check-licenses.yml `falls back and runs as expected
- TEST [03](https://github.com/clementnero/fossa-demo-case-01/actions/runs/15399604762/job/43328968516?pr=10): Neither the base ref nor recent commits have scan results, `check-licenses.yml` fails as expected.
- TEST [04](https://github.com/clementnero/fossa-demo-case-01/pull/11/checks): For a merge commit with no workflow run (i.e., no license scan), the action successfully falls back to recent scanned commits (similar scenario as https://camunda.slack.com/archives/C5AHF1D8T/p1748855183016529)