### PR TITLE
feat(pr): validated PR titles

### DIFF
--- a/teams/infra/pull-request/README.md
+++ b/teams/infra/pull-request/README.md
@@ -3,6 +3,31 @@ This collection of github actions is currently intended to enable `Auto-Releases
 
 If applied correctly, every commit to the mainline branch of a repository will be [added to a Release PR](./release/README.md) which then can be [automerged](./automerge/README.md) on a schedule.
 
+## Available Actions
+
+This package contains three complementary actions for pull request management:
+
+* **[Release](./release/README.md)** - Automated release PR creation and management based on conventional commits
+* **[Automerge](./automerge/README.md)** - Automated merging of release PRs on a schedule
+* **[Validate Title](./validate-title/README.md)** - Validates PR titles against conventional commit format (recommended for side projects)
+
+## PR Title Validation for Side Projects
+
+⚠️ **Important for Side Projects**: If your repository uses the release action and "Squash & Merge" strategy, it's highly recommended to also use the [validate-title](./validate-title/README.md) action. This prevents broken releases when PR titles don't follow conventional commit format.
+
+```yaml
+# .github/workflows/validate-pr-title.yml
+name: Validate PR Title
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+jobs:
+  validate-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: camunda/infra-global-github-actions/teams/infra/pull-request/validate-title@main
+```
+
 ## Architecture
 The `release` action leverages the [release-please-action](https://github.com/googleapis/release-please-action) to manage these release PRs.
 It is handling the creation and updates of mentioned release PRs and the "bumping" of versions based on conventional commits. When a release PR gets merged release-please handles the creation of a new Github Release, the respective tag and a the management of the changelog file.
@@ -27,5 +52,7 @@ Once everything got merged, you'll see a new release PR which you can merge dire
 * Simple release: https://github.com/camunda/infra-k8s-webhook/pull/86
 * Monorepo Example: https://github.com/camunda/camunda-docker-ci-postgresql/pull/29
 
-## Pre-Commit Hook
+## Pre-Commit Hook & PR Title Validation
 Since release-please depends on [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to bump versions appropriately it's required to enforce the usage of these by pre-commit hooks. Just look at one of the above's examples to see how it's done.
+
+For repositories using "Squash & Merge", it's also recommended to use the [validate-title](./validate-title/README.md) action to ensure PR titles follow conventional commit format, as the PR title becomes the commit message during squash merging.

--- a/teams/infra/pull-request/validate-title/README.md
+++ b/teams/infra/pull-request/validate-title/README.md
@@ -1,0 +1,60 @@
+# Validate PR Title GitHub Action
+
+This GitHub Action validates pull request titles against conventional commit format. It's specifically designed for side projects that use the release-please action to ensure PR titles comply with conventional commit standards when using "Squash & Merge".
+
+## Problem Statement
+
+When using "Squash & Merge" on GitHub, the PR title becomes the commit message. If the PR title doesn't follow conventional commit format, it can break the release-please workflow, preventing new release PRs from being created.
+
+## Features
+
+- Validates PR titles against conventional commit format
+- Configurable commit types (feat, fix, docs, etc.)
+- Subject pattern validation (e.g., no uppercase first letter)
+- Support for ignoring specific labels (like release PRs)
+- Validates single commit PRs when using squash merge
+
+## Usage
+
+### Basic Usage
+
+Add this to your workflow file (e.g., `.github/workflows/validate-pr-title.yml`):
+
+```yaml
+---
+name: Validate PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  validate-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR title
+        uses: camunda/infra-global-github-actions/teams/infra/pull-request/validate-title@main
+```
+
+## Inputs
+
+| Input Name | Required | Default | Description |
+|------------|----------|---------|-------------|
+| `github-token` | No | `${{ github.token }}` | GitHub token with read access to pull requests |
+| `types` | No | Standard types | List of allowed conventional commit types |
+| `subject-pattern` | No | `^(?![A-Z]).+$` | Regex pattern for subject validation |
+
+## Examples of Valid PR Titles
+
+- `feat: add new user authentication`
+- `fix: resolve memory leak in data processing`
+- `docs: update installation instructions`
+- `chore: upgrade dependencies to latest versions`
+- `refactor: simplify error handling logic`
+
+## Examples of Invalid PR Titles
+
+- `Add new feature` (missing type)
+- `feat: Add new feature` (subject starts with uppercase)
+- `Feature: add authentication` (invalid type)
+- `fix` (missing subject)

--- a/teams/infra/pull-request/validate-title/action.yml
+++ b/teams/infra/pull-request/validate-title/action.yml
@@ -1,0 +1,47 @@
+---
+name: Validate PR Title
+description: |
+  Validates pull request titles against conventional commit format.
+  This action helps ensure that PR titles follow conventional commit standards,
+  which is critical for side projects using release-please when using
+  "Squash & Merge".
+
+inputs:
+  github-token:
+    description: 'GitHub token with read access to pull requests'
+    required: false
+    default: ${{ github.token }}
+  types:
+    description: |
+      List of allowed commit types.
+      Defaults to common conventional commit types.
+    required: false
+    default: |
+      feat
+      fix
+      docs
+      style
+      refactor
+      test
+      build
+      ci
+      chore
+      revert
+  subject-pattern:
+    description: |
+      Regex pattern for the subject line.
+      Default ensures subject doesn't start with uppercase.
+    required: false
+    default: '^(?![A-Z]).+$'
+
+runs:
+  using: composite
+  steps:
+    - name: Validate PR title
+      uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      with:
+        types: ${{ inputs.types }}
+        subjectPattern: ${{ inputs.subject-pattern }}
+        validateSingleCommit: true


### PR DESCRIPTION
Adds an action which can validate PR titles against conventional commit format.
This is important for projects which use release-please to manage releases.

* related: camunda/team-infrastructure#813

:alembic: tested successfully with [this side project](https://github.com/camunda/infra-actions-runner/pull/77)