### PR TITLE
fix(common-tooling): exporting build-essential env var

### DIFF
--- a/common-tooling/action.yml
+++ b/common-tooling/action.yml
@@ -200,7 +200,7 @@ runs:
 
       if ! $(dpkg -l | grep -q build-essential)
       then
-          echo "build_essential_missing=true"
+          echo "build_essential_missing=true" >> "$GITHUB_ENV"
       fi
 
   # For easier debugging which version is missing


### PR DESCRIPTION
A tiny fix where I missed exporting the build-essential env var 🙎‍♂️