### PR TITLE
fix: uses quotes to deal with spaces and special characters in labels

### DIFF
--- a/teams/infra/configure-maintenance-pull-request/action.yml
+++ b/teams/infra/configure-maintenance-pull-request/action.yml
@@ -34,8 +34,8 @@ runs:
         # Get the action type of the event
         echo action=${{ github.event.action }}
 
-        # Get labels if any
-        echo labels=${{ format('{0}', join(github.event.pull_request.labels.*.name)) }}
+        # Get labels if any, use '' to avoid problems with special characters like spaces, &, etc.
+        echo labels='${{ format('{0}', join(github.event.pull_request.labels.*.name)) }}'
 
         # Identify the vendor from the branch prefix
         echo vendor=${{


### PR DESCRIPTION
This pull request includes a minor change to the `action.yml` file for the `infra` team's maintenance configuration. The change ensures that pull request labels are safely handled by enclosing them in single quotes to prevent issues with special characters like spaces or `&`.

* [`teams/infra/configure-maintenance-pull-request/action.yml`](diffhunk://#diff-b156498aa8c7085584cbaefeef35641dc1296c41d715d50aa31e56a0ba014a11L37-R38): Updated the `labels` echo command to wrap the output in single quotes for better handling of special characters.

This should solve this ask-infra question: 
- https://camunda.slack.com/archives/C5AHF1D8T/p1754056901425069

Some tests have been done on the infra-github-demo repository:
- Original behavior, workflow fails when reading the labels: https://github.com/camunda/infra-github-demo/actions/runs/16679093431/job/47213063563
- Updated workflow, without the `dependency-upgrade` label is working: https://github.com/camunda/infra-github-demo/actions/runs/16679148660
- Updated workflow, with the `dependency-upgrade` label still working, but failing due to fake credentials used to contact both GitHub and Slack: https://github.com/camunda/infra-github-demo/actions/runs/16679166807