### PR TITLE
chore: sync teleport-actions/setup image version to camunda teleport server version

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -32,6 +32,16 @@
       versioningTemplate: "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
     },
   ],
+  customDatasources: {
+    teleport: {
+      // Latest version for us == current one used in Camunda Teleport SaaS:
+      // curl -s https://camunda.teleport.sh/webapi/ping | jq -r '.server_version'
+      "defaultRegistryUrlTemplate": "https://camunda.teleport.sh/webapi/ping",
+      "transformTemplates": [
+        "{\"releases\": [{\"version\": $$.server_version}]}"
+      ]
+    }
+  },
   packageRules: [
     // limit the PR creation for the Renovate pre-commit hook (it's released very frequently)
     {

--- a/preview-env/create/action.yml
+++ b/preview-env/create/action.yml
@@ -141,7 +141,7 @@ runs:
     id: setup_teleport
     uses: teleport-actions/setup@v1
     with:
-      # renovate: datasource=docker depName=public.ecr.aws/gravitational/teleport-ent-distroless
+      # renovate: datasource=custom.teleport depName=public.ecr.aws/gravitational/teleport-ent-distroless
       version: 17.5.2
   - name: Authenticate with Teleport
     if: failure() && steps.setup_teleport.outcome == 'success'


### PR DESCRIPTION
With this configuration, we keep the teleport docker image used by `teleport-actions/setup` GitHub actions in sync with the Camunda Teleport server version to avoid issues with major updates bumps that aren't expected

This is also related to https://github.com/camunda/team-infrastructure/issues/895