### PR TITLE
chore: allow retry action and workflow to rerun whole workflow

### DIFF
--- a/.github/workflows/retry-worfklow-run.yml
+++ b/.github/workflows/retry-worfklow-run.yml
@@ -38,6 +38,14 @@ on:
           Needed by https://github.com/Codex-/return-dispatch as workaround for https://github.com/cli/cli/issues/4001
         required: false
         default: "not-set"
+      rerun-whole-workflow:
+        description: |
+          If set to true, the workflow will be re-triggered in its entirety.
+          This is useful when you want to retry the entire workflow instead of
+          just failed jobs.
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   retry:
@@ -100,13 +108,19 @@ jobs:
           GH_REPO: ${{ inputs.owner }}/${{ inputs.repository }}
           GH_TOKEN: ${{ steps.github-token.outputs.token }}
           RUN_ID: ${{ inputs.run-id }}
+          RERUN_WHOLE_WORKFLOW: ${{ inputs.rerun-whole-workflow }}
         run: |
           if [ "${DRY_RUN}" = "true" ]; then
             echo "Skipping retry since this is a dry-run ..."
           else
             echo "Triggering a new attempt of run-id=${RUN_ID} ..."
-            # Only retry failed jobs
-            gh run rerun "${RUN_ID}" --failed
+            if [ "${RERUN_WHOLE_WORKFLOW}" = "true" ]; then
+              echo "Rerunning the whole workflow ..."
+              gh run rerun "${RUN_ID}"
+            else
+              echo "Rerunning only failed jobs ..."
+              gh run rerun "${RUN_ID}" --failed
+            fi
           fi
         shell: bash
 

--- a/rerun-failed-run/README.md
+++ b/rerun-failed-run/README.md
@@ -22,6 +22,7 @@ If these secrets are not present, please contact the infrastructure team to set 
 | vault-role-id (required)   | The Vault Role ID.                                                                                                                           |
 | vault-secret-id (required) | The Vault Secret ID.                                                                                                                         |
 | notify-back-on-error       | When the error message does not match with the expected one, re-trigger the workflow with the parameter `notify_back_error_message`. Your calling workflow must implement the `notify_back_error_message` parameter and forward the error. This allows you to capture failures that are not related to a specific error. Default is `"false"`. |
+| rerun-whole-workflow       | If set to true, the workflow will be re-triggered in its entirety. This is useful when you want to retry the entire workflow instead of just failed jobs. Default is `"false"`. |
 
 ### Workflow Example without error propagation
 

--- a/rerun-failed-run/action.yml
+++ b/rerun-failed-run/action.yml
@@ -37,6 +37,12 @@ inputs:
       and forward the error.
       This allows you to capture failures that are not related to a specific error.
     default: "false"
+  rerun-whole-workflow:
+    description: |
+      If set to true, the workflow will be re-triggered in its entirety.
+      This is useful when you want to retry the entire workflow instead of
+      just failed jobs.
+    default: "false"
 
 runs:
   using: composite
@@ -100,7 +106,8 @@ runs:
             "notify-back-on-error": "${{ inputs.notify-back-on-error }}",
             "owner": "${{ steps.repository.outputs.owner }}",
             "repository": "${{ steps.repository.outputs.name }}",
-            "run-id": "${{ inputs.run-id }}"
+            "run-id": "${{ inputs.run-id }}",
+            "rerun-whole-workflow": "${{ inputs.rerun-whole-workflow }}"
           }
         workflow_timeout_seconds: 120
 


### PR DESCRIPTION
Hey Infra 👋,

I have a small suggestion: Allow the retry action/workflow to retrigger the whole workflow, not just the failed jobs.

We have a use case where it would be beneficial for us to rerun the whole workflow instead of just the failed jobs. Since we already have the functionality available, I thought to simply extend it instead of recreating it on our side.

For existing users nothing changes as the default is to retry the failed jobs.

Related [gh run rerun docs](https://cli.github.com/manual/gh_run_rerun).

> Rerun an entire run, only failed jobs, or a specific job from a run.

Let me know if names should be changed or implemented differently.
We could also approach it from a different side to say `rerun-failed-jobs` or similar and make it the default to be true and have something like `EXTRA_ARGS` that's passed in that's either empty or `failed` and maybe extensible as extra input to allow passing in anything from outside.