### PR TITLE
chore: use slurpfile to avoid jq error 'too many arguments'

### DIFF
--- a/preview-env/clean/cleanup.sh
+++ b/preview-env/clean/cleanup.sh
@@ -254,14 +254,14 @@ function cleanup_inconsistent_comments {
   comment_tag_warning=${3:-<!-- preview-env:type:warning -->}
 
   # Get OPEN pull requests (with their comments)
-  open_pull_requests_tmp_file=$(mktemp open_prs.XXXXXX.json)
+  open_pull_requests_tmp_file=$(mktemp)
   get_pull_requests_by_states_with_last_100_comments OPEN >"$open_pull_requests_tmp_file"
 
   # Get CLOSED or MERGED pull requests (with their comments)
   # Limit to the last 100 pull requests as there is no need to scan and process the entire history at each iteration.
   # Considering the pull request closing frequency and the cleanup job execution frequency, each pull request should be processed at least once.
   # Given the frequency with which pull requests are closed and the frequency with which cleanup jobs are executed, each pull request should be processed at least once.
-  closed_merged_pull_requests_tmp_file=$(mktemp closed_merged_prs.XXXXXX.json)
+  closed_merged_pull_requests_tmp_file=$(mktemp)
   get_pull_requests_by_states_with_last_100_comments CLOSED,MERGED false >"$closed_merged_pull_requests_tmp_file"
 
   # If pull request is in MERGED or CLOSED state, any warning or shutdown comments can be safely removed.


### PR DESCRIPTION
This pull request refactors how pull request data is handled in the `cleanup_inconsistent_comments` function within `preview-env/clean/cleanup.sh`. The main improvement is switching from passing large JSON objects directly in shell variables to using temporary files for storing and processing pull request data. This change enhances reliability and scalability, especially when dealing with large datasets that could cause issues with the arg size.

Purpose of this is to close https://github.com/camunda/team-infrastructure/issues/886

**Improvements to data handling and reliability:**

* Pull request data for both open and closed/merged states is now written to temporary files using `mktemp`, instead of being stored in shell variables. This prevents issues with large JSON data in environment variables and improves script robustness.
* The `jq` command now uses the `--slurpfile` option to read pull request data from these temporary files, ensuring more reliable and scalable processing of comments for cleanup.

## Tests
I've created a simplified version of the `cleanup.sh` script with both the fixed version and the original version of the function.
I was able to reproduce the issue we are currently seeing in the `camunda/camunda` repository, and the new approach doesn't stop the run, while the old one actually does.
Here the workflow run on infra-github-demo
- https://github.com/camunda/infra-github-demo/actions/runs/17132510824