### PR TITLE
fix(gha): default build docker file

### DIFF
--- a/build-docker-image/README.md
+++ b/build-docker-image/README.md
@@ -19,7 +19,7 @@ This composite GHA can be used in any non-public repository with a `Dockerfile` 
 | extra_tags                 | Allows defining extra tags according to the [metadata action](https://github.com/docker/metadata-action), supply as list with \| (pipe bar) |
 | force_push                 | Allows overwriting the image push behaviour, by setting to 'true' as input |
 | build_context              | Docker build context location                      |
-| build_docker_file          | Path to the Dockerfile (with the context)          |
+| build_docker_file          | Path to the Dockerfile relative to the build context (e.g., `{context}/Dockerfile`). If empty, defaults to "Dockerfile" in the build context |
 | build_allow                | Extra privilege entitlements to give builder       |
 | build_platforms            | List of [target platforms](https://docs.docker.com/engine/reference/commandline/buildx_build/#platform) for build        |
 | buildx_driver              | Driver to use for buildx builder                   |

--- a/build-docker-image/action.yml
+++ b/build-docker-image/action.yml
@@ -42,9 +42,8 @@ inputs:
     required: false
     default: '.'
   build_docker_file:
-    description: Path to the Dockerfile (with the context).
+    description: Path to the Dockerfile relative to the build context (e.g., {context}/Dockerfile). If empty, defaults to "Dockerfile" in the build context.
     required: false
-    default: "./Dockerfile"
   build_allow:
     description: Extra privilege entitlements to give builder.
     required: false


### PR DESCRIPTION
The previous implementation introduces an error when the dockerfile is not explicitely mentioned (https://github.com/camunda/infra-global-github-actions/pull/483)

This PR fix the behavior by making the value not required and empty by default

See:
- failing example: https://github.com/camunda/keycloak/actions/runs/17466148463/job/49602314484 (ERROR: failed to build: failed to solve: failed to read dockerfile: open Dockerfile: no such file or directory)
- fixed with this patch: https://github.com/camunda/keycloak/pull/423/commits/5e7becbdffdff70cdf78cb2d61887e1508856f59