### PR TITLE
feat: Refactoring submit-test-status workflow to also accept files

### DIFF
--- a/submit-test-status/README.md
+++ b/submit-test-status/README.md
@@ -9,15 +9,26 @@ This composite GHA can be used in any repository that was set up to provide cred
 
 ### Inputs
 
-| Input name           | Description                                        |
-|----------------------|----------------------------------------------------|
-| test_event_record    | Multi-line string that contains the details of the test events in [JSONL format](https://jsonlines.org). One test event per line. |
-| job_name_override    | Optional string being used for the `job_name` field instead of the default `$GITHUB_JOB`, useful e.g. for matrix builds |
-| gcp_credentials_json | Credentials for a Google Cloud ServiceAccount allowed to publish to Big Query formatted as contents of credentials.json file |
+| Input name             | Description                                        | Required |
+|------------------------|----------------------------------------------------|----------|
+| test_results_file_path | Path to a test results file containing test events in [JSONL format](https://jsonlines.org). Each line must contain at least `test_name` and `test_status` keys. | No |
+| test_event_record      | Multi-line string that contains the details of the test events in [JSONL format](https://jsonlines.org). One test event per line. Alternative to `test_results_file_path`. | No |
+| job_name_override      | Optional string being used for the `job_name` field instead of the default `$GITHUB_JOB`, useful e.g. for matrix builds | No |
+| gcp_credentials_json   | Credentials for a Google Cloud ServiceAccount allowed to publish to Big Query formatted as contents of credentials.json file | Yes |
+| big_query_table_name   | BigQuery table name for testing purposes. Defaults to production table. | No |
+
+**Note**: Either `test_results_file_path` OR `test_event_record` must be provided.
 
 Please check out Camunda's [Github Actions Recipes](https://github.com/camunda/github-actions-recipes#secrets=) for how to retrieve secrets from Vault.
 
-Input details for `test_event_record`
+## Input Methods
+
+This action supports two ways to provide test data:
+
+1. **File Path**: Use `test_results_file_path` to point to an existing JSONL file containing test results
+2. **Inline Data**: Use `test_event_record` to provide test data directly as a multi-line string
+
+Input details for test data format (applies to both methods)
 
 | Field Name                       | Field Type | Field Mode | Description/Purpose |
 |----------------------------------|------------|------------|---------------------|
@@ -59,7 +70,9 @@ The scope of the `submit-test-status` action is to load the  *user-provided* tes
 
 It is the task of the user to integrate this action into their GHA workflows by invoking it at all suitable places and providing the desired inputs.
 
-### A sample workflow
+### Sample workflows
+
+#### Method 1: -- DEPRECATED -- Using inline test data
 
 ```yaml
 name: sample workflow to upload test data to CI Analytics
@@ -80,4 +93,35 @@ jobs:
           {"test_name":"test 99","test_status":"success"}
           {"test_name":"test 999","test_status":"failed"}
           {"test_name":"test 9999","test_duration_milliseconds":1234,"test_class_name":"9","test_status":"flaky"}
+```
+
+#### Method 2: Using a test results file
+
+```yaml
+name: sample workflow to upload test results file to CI Analytics
+on:
+  workflow_dispatch: {}
+
+jobs:
+  upload-test-file:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Generate test results file
+      run: |
+        # Example: convert JUnit XML to JSONL (replace with your actual command if needed)
+
+        TEST_RESULTS_FILE=$(mktemp --suffix=.jsonl)
+        echo "test_results_file=${TEST_RESULTS_FILE}" >> $GITHUB_OUTPUT
+        find . -iname 'TEST-*.xml' | python3 .ci/scripts/ci/observe-build-status/junit-test-results-to-jsonl.py > "${TEST_RESULTS_FILE}"
+
+        echo "Generated $(wc -l < "${TEST_RESULTS_FILE}") test results"
+      id: run-tests
+
+    - name: upload test results to CI Analytics
+      uses: camunda/infra-global-github-actions/submit-test-status@main
+      with:
+        gcp_credentials_json: ${{ secrets.YOUR_GCP_CREDENTIALS }}
+        test_results_file_path: "${{ steps.run-tests.outputs.test_results_file }}"
 ```

--- a/submit-test-status/action.yml
+++ b/submit-test-status/action.yml
@@ -6,7 +6,11 @@ description: Submits test status records from a GHA workflow job to CI Analytics
 inputs:
   test_event_record:
     description: Test event(s) in JSONL format. Required keys are test_name and test_status.
-    required: true
+    required: false
+
+  test_results_file_path:
+    description: Test results file in containing test events in JSONL format. Each line must contain at least `test_name` and `test_status` keys.
+    required: false
 
   gcp_credentials_json:
     description: Credentials for a Google Cloud ServiceAccount allowed to publish to Big Query formatted as contents of credentials.json file.
@@ -28,11 +32,48 @@ runs:
   steps:
   - name: Echo inputs
     shell: bash
+    env:
+      INPUT_FILE: "${{ (inputs.test_results_file_path != '') && inputs.test_results_file_path || (inputs.test_event_record != '') && '${{ runner.temp }}/sts/input_test_event_record.jsonl' || '' }}"
     run: |
       echo "Inputs"
       echo "-----"
       echo "Job name override: ${{ inputs.job_name_override }} (default job name: $GITHUB_JOB)"
       echo "BQ table name (for testing): ${{ inputs.big_query_table_name }}"
+      echo "Test results file path: ${{ inputs.test_results_file_path }}"
+      echo "INPUT_FILE: $INPUT_FILE"
+      echo "INPUT_FILE=$INPUT_FILE" >> $GITHUB_ENV
+      echo "-----"
+
+  - name: Early validation - check if input is provided
+    shell: bash
+    run: |
+      if [ -z "$INPUT_FILE" ]; then
+      echo "ERROR: No input provided. Please provide either 'test_results_file_path' or 'test_event_record'."
+        exit 1
+      fi
+
+  - name: ensure that jq is available
+    uses: dcarbone/install-jq-action@v3.2.0
+
+  - name: load input
+    if: ${{ inputs.test_event_record != '' }}
+    shell: bash
+    run: |
+      mkdir -p "$(dirname "$INPUT_FILE")"
+      cat <<EOF > $INPUT_FILE
+      ${{ inputs.test_event_record }}
+      EOF
+
+  - name: validate input for file format
+    shell: bash
+    run: |
+      # validate input for the presence of mandatory keys
+      INVALID_LINES=$(jq -c 'select((has("test_name") and has("test_status")) | not)' "$INPUT_FILE")
+      if [ -n "$INVALID_LINES" ]; then
+        echo "JSONL input validation failed. The following lines are invalid:"
+        echo "$INVALID_LINES"
+        exit 1
+      fi
 
   - name: login to Google Cloud
     id: auth
@@ -48,41 +89,16 @@ runs:
     run: |
       gcloud info
 
-  - name: ensure that jq is available
-    uses: dcarbone/install-jq-action@v3.2.0
-
   - name: download table schema from CI Analytics
     shell: bash
     env:
       BQ_COMMAND: "${{ (runner.os == 'Windows') && 'bq.cmd' || 'bq' }}"
     run: |
-      mkdir ${{ runner.temp }}/sts
+      mkdir -p ${{ runner.temp }}/sts
       $BQ_COMMAND show \
         --format prettyjson \
         "${{ inputs.big_query_table_name }}" \
       | jq '.schema.fields' > ${{ runner.temp }}/sts/table_schema.json
-
-  - name: load input
-    shell: bash
-    env:
-      TEMP_DIR: ${{ runner.temp }}/sts
-    run: |
-      cat <<EOF > $TEMP_DIR/input_test_event_record.json
-      ${{ inputs.test_event_record }}
-      EOF
-
-  - name: validate input
-    shell: bash
-    env:
-      TEMP_DIR: ${{ runner.temp }}/sts
-    run: |
-      # validate input for the presence of mandatory keys
-      INVALID_LINES=$(jq -c 'select((has("test_name") and has("test_status")) | not)' "$TEMP_DIR/input_test_event_record.json")
-      if [ -n "$INVALID_LINES" ]; then
-        echo "JSONL input validation failed. The following lines are invalid:"
-        echo "$INVALID_LINES"
-        exit 1
-      fi
 
   - name: submit to CI Analytics
     shell: bash
@@ -98,7 +114,7 @@ runs:
         --arg BUILD_ID "$GITHUB_RUN_ID/$GITHUB_RUN_ATTEMPT" \
         --arg JOB_NAME "${{ (inputs.job_name_override == '') && '$GITHUB_JOB' || inputs.job_name_override }}" \
         '. + {"report_time": $REPORT_TIME} + {"ci_url": $CI_URL} + {"build_id": $BUILD_ID} + {"job_name": $JOB_NAME}' \
-        $TEMP_DIR/input_test_event_record.json > $TEMP_DIR/test_event_record.json
+         "$INPUT_FILE" > $TEMP_DIR/enriched_test_event_records.jsonl
 
       # upload data to CI Analytics
       BQ_TABLE=$(echo "${{ inputs.big_query_table_name }}" | cut -d':' -f2)
@@ -106,5 +122,5 @@ runs:
         --source_format=NEWLINE_DELIMITED_JSON \
         --project_id=$GCP_PROJECT \
         $BQ_TABLE \
-        $TEMP_DIR/test_event_record.json \
+        $TEMP_DIR/enriched_test_event_records.jsonl \
         $TEMP_DIR/table_schema.json


### PR DESCRIPTION
Updating the submit workflow status to expect and handle `jsonl` file instead of stdout