### PR TITLE
feat: add CPU and memory utilization measurement in CI analytics

### DIFF
--- a/monitor-start/action.yml
+++ b/monitor-start/action.yml
@@ -9,7 +9,7 @@ runs:
   - name: Start resource monitor
     shell: bash
     run: |
-      INTERVAL=10
+      INTERVAL=5
       LOG_FILE=/tmp/_monitor_vmstat.log
       PID_FILE=/tmp/_monitor_vmstat.pid
       START_FILE=/tmp/_monitor_vmstat_start

--- a/monitor-start/action.yml
+++ b/monitor-start/action.yml
@@ -1,0 +1,25 @@
+---
+name: Monitor Start
+
+description: Starts a background CPU/memory monitor for the current job. Used in conjunction with submit-build-status, which auto-detects and includes the metrics when this action ran before it.
+
+runs:
+  using: composite
+  steps:
+  - name: Start resource monitor
+    shell: bash
+    run: |
+      INTERVAL=10
+      LOG_FILE=/tmp/_monitor_vmstat.log
+      PID_FILE=/tmp/_monitor_vmstat.pid
+      START_FILE=/tmp/_monitor_vmstat_start
+
+      # Record start time in seconds since epoch
+      date +%s > "$START_FILE"
+
+      # Start vmstat in background, skip the two header lines on first iteration
+      # -n: only print header once; output goes to log file
+      vmstat -n "$INTERVAL" > "$LOG_FILE" 2>&1 &
+      echo $! > "$PID_FILE"
+
+      echo "Resource monitor started (PID=$(cat $PID_FILE), interval=${INTERVAL}s, log=$LOG_FILE)"

--- a/start-build-monitor/README.md
+++ b/start-build-monitor/README.md
@@ -1,0 +1,55 @@
+# start-build-monitor
+
+This composite GitHub Action starts a lightweight background CPU and memory monitor at the beginning of a job. When used together with [`submit-build-status`](../submit-build-status/), resource utilization metrics are automatically included at the end in the [CI Analytics](https://confluence.camunda.com/display/HAN/CI+Analytics) record for that job.
+
+## Usage
+
+Add `start-build-monitor` as the **first step** of any job that already uses `submit-build-status` (or the `observe-build-status` wrapper). No inputs are required.
+
+```yaml
+jobs:
+  my-job:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
+
+      - uses: actions/checkout@v4
+      # ... all other job steps unchanged ...
+
+      # Always submit build status to CI Analytics as usual, unchanged
+      - uses: camunda/infra-global-github-actions/submit-build-status@main
+        if: always()  # run even in case of failures
+        continue-on-error: true  # prevent failure here of marking the job as failed
+        with:
+          build_status: "${{ job.status }}"
+          gcp_credentials_json: "${{ secrets.YOUR_GCP_CREDENTIALS }}"
+```
+
+Jobs that do **not** include `start-build-monitor` are unaffected — `submit-build-status` simply omits the resource fields, which appear as `NULL` in BigQuery like any other optional field.
+
+## Behavior
+
+Starts a polling loop in the background (interval: 5s) that samples CPU and memory usage once per interval until `submit-build-status` stops it at job end.
+
+### Metric sources
+
+Metrics are sourced from cgroup interfaces where available, so they reflect the build job container's usage rather than the shared host node. This is correct for self-hosted Kubernetes runners with a fallback for GitHub-hosted runners.
+
+| Source | CPU | Memory |
+|--------|-----|--------|
+| cgroup v2 (default on Ubuntu 22.04+) | `cpu.stat usage_usec` delta | `memory.current` |
+| cgroup v1 | `cpuacct.usage` delta | `memory.usage_in_bytes` |
+| Fallback (bare VM, no cgroup) | `/proc/stat` jiffies delta | `/proc/meminfo` |
+
+CPU usage is normalized to the container's CPU limit (from `cpu.max` / `cfs_quota_us`), so 1.0 means the full CPU allocation is saturated. The same scaling applies to memory usage, so CI Analytics contains relative informations only - useful for right-sizing containers.
+
+### Fields added to CI Analytics
+
+The following fields are added to the `build_status_v2` BigQuery table (`FLOAT64`, `NULLABLE`, range 0.0–1.0):
+
+| Field | Description |
+|-------|-------------|
+| `cpu_usage_ratio_avg` | Average CPU utilization over the job |
+| `cpu_usage_ratio_p95` | 95th percentile of CPU utilization (robust against short spikes) |
+| `memory_usage_ratio_avg` | Average RAM memory utilization over the job |
+| `memory_usage_ratio_p95` | 95th percentile of RAM memory utilization |

--- a/start-build-monitor/action.yml
+++ b/start-build-monitor/action.yml
@@ -1,0 +1,12 @@
+---
+name: Start Build Monitor
+
+description: Starts a background CPU/memory monitor for the current job. Used in conjunction with submit-build-status, which auto-detects and includes the metrics when this action ran before it.
+
+runs:
+  using: composite
+  steps:
+  - name: Start resource monitor
+    shell: bash
+    run: |
+      bash "$GITHUB_ACTION_PATH/start-build-monitor.sh"

--- a/start-build-monitor/start-build-monitor.sh
+++ b/start-build-monitor/start-build-monitor.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+
+INTERVAL=5  # seconds
+# NOTE: these paths are shared with the monitor stop script(s) — if changed, update both
+LOG_FILE=/tmp/_monitor-start.log
+PID_FILE=/tmp/_monitor-start.pid
+
+# CPU and memory cgroup controllers are independently enabled, so detect them separately.
+# Cgroup-based metrics are scoped to this container — unaffected by other pods on the node.
+
+# CPU source
+if [ -f /sys/fs/cgroup/cpu.stat ]; then
+  CPU_SOURCE="cgroupv2"
+elif [ -f /sys/fs/cgroup/cpuacct/cpuacct.usage ]; then
+  CPU_SOURCE="cgroupv1"
+else
+  CPU_SOURCE="proc"
+fi
+
+# Memory source
+if [ -f /sys/fs/cgroup/memory.current ]; then
+  MEM_SOURCE="cgroupv2"
+elif [ -f /sys/fs/cgroup/memory/memory.usage_in_bytes ]; then
+  MEM_SOURCE="cgroupv1"
+else
+  MEM_SOURCE="proc"
+fi
+
+# CPU limit in cores — used to express usage as % of the container's allocation.
+CPU_LIMIT_CORES=$(nproc)
+if [ "$CPU_SOURCE" = "cgroupv2" ] && [ -f /sys/fs/cgroup/cpu.max ]; then
+  read -r _QUOTA _PERIOD < /sys/fs/cgroup/cpu.max
+  if [ "${_QUOTA:-max}" != "max" ] && [ "${_PERIOD:-0}" -gt 0 ] 2>/dev/null; then
+    CPU_LIMIT_CORES=$(awk "BEGIN {printf \"%.4f\", $_QUOTA / $_PERIOD}")
+  fi
+elif [ "$CPU_SOURCE" = "cgroupv1" ]; then
+  _QUOTA=$(cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us 2>/dev/null || echo -1)
+  _PERIOD=$(cat /sys/fs/cgroup/cpu/cpu.cfs_period_us 2>/dev/null || echo 100000)
+  if [ "$_QUOTA" != "-1" ] && [ "$_QUOTA" -gt 0 ] 2>/dev/null; then
+    CPU_LIMIT_CORES=$(awk "BEGIN {printf \"%.4f\", $_QUOTA / $_PERIOD}")
+  fi
+fi
+
+# Memory total in kB — Cgroup limit gives the container's budget; /proc/meminfo fallback for bare VMs.
+CGROUP_MEM_BYTES=$(cat /sys/fs/cgroup/memory.max 2>/dev/null || cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2>/dev/null || echo "max")
+if [ "$CGROUP_MEM_BYTES" != "max" ] && [ "$CGROUP_MEM_BYTES" -gt 0 ] 2>/dev/null; then
+  MEM_TOTAL_KB=$(( CGROUP_MEM_BYTES / 1024 ))
+else
+  MEM_TOTAL_KB=$(awk '/^MemTotal:/ {print $2}' /proc/meminfo)
+fi
+
+INTERVAL_US=$(( INTERVAL * 1000000 ))
+
+(
+  echo "# cpu_source=${CPU_SOURCE} mem_source=${MEM_SOURCE} cpu_limit_cores=${CPU_LIMIT_CORES} mem_total_kb=${MEM_TOTAL_KB} interval=${INTERVAL}"
+
+  # Seed the initial CPU counter before the first sleep
+  case "$CPU_SOURCE" in
+    cgroupv2) PREV_CPU=$(awk '/^usage_usec/ {print $2}' /sys/fs/cgroup/cpu.stat) ;;
+    cgroupv1) PREV_CPU=$(( $(cat /sys/fs/cgroup/cpuacct/cpuacct.usage) / 1000 )) ;;  # ns → us
+    proc)     read -r PREV_IDLE PREV_TOTAL < <(awk '/^cpu / {idle=$5; tot=0; for(i=2;i<=NF;i++) tot+=$i; print idle, tot}' /proc/stat) ;;
+  esac
+
+  while true; do
+    sleep "$INTERVAL"
+
+    # CPU: delta of the cgroup cumulative counter, expressed as ratio of container allocation.
+    # Bare-VM fallback uses /proc/stat jiffies (aggregate across all host cores).
+    case "$CPU_SOURCE" in
+      cgroupv2)
+        CURR_CPU=$(awk '/^usage_usec/ {print $2}' /sys/fs/cgroup/cpu.stat)
+        DELTA_US=$(( CURR_CPU - PREV_CPU ))
+        CPU_RATIO=$(awk "BEGIN {r=$DELTA_US/($INTERVAL_US*$CPU_LIMIT_CORES); if(r>1)r=1; if(r<0)r=0; printf \"%.4f\",r}")
+        PREV_CPU=$CURR_CPU
+        ;;
+      cgroupv1)
+        CURR_CPU=$(( $(cat /sys/fs/cgroup/cpuacct/cpuacct.usage) / 1000 ))
+        DELTA_US=$(( CURR_CPU - PREV_CPU ))
+        CPU_RATIO=$(awk "BEGIN {r=$DELTA_US/($INTERVAL_US*$CPU_LIMIT_CORES); if(r>1)r=1; if(r<0)r=0; printf \"%.4f\",r}")
+        PREV_CPU=$CURR_CPU
+        ;;
+      proc)
+        read -r CURR_IDLE CURR_TOTAL < <(awk '/^cpu / {idle=$5; tot=0; for(i=2;i<=NF;i++) tot+=$i; print idle, tot}' /proc/stat)
+        DELTA_IDLE=$(( CURR_IDLE - PREV_IDLE ))
+        DELTA_TOTAL=$(( CURR_TOTAL - PREV_TOTAL ))
+        CPU_RATIO=$(awk "BEGIN {r=($DELTA_TOTAL>0)?(1-$DELTA_IDLE/$DELTA_TOTAL):0; if(r>1)r=1; if(r<0)r=0; printf \"%.4f\",r}")
+        PREV_IDLE=$CURR_IDLE
+        PREV_TOTAL=$CURR_TOTAL
+        ;;
+    esac
+
+    # Memory: current usage divided by total, expressed as ratio of container allocation.
+    case "$MEM_SOURCE" in
+      cgroupv2) MEM_USED_KB=$(( $(cat /sys/fs/cgroup/memory.current) / 1024 )) ;;
+      cgroupv1) MEM_USED_KB=$(( $(cat /sys/fs/cgroup/memory/memory.usage_in_bytes) / 1024 )) ;;
+      proc)     MEM_USED_KB=$(awk '/^MemTotal:/{t=$2}/^MemFree:/{f=$2}/^Cached:/{c=$2} END{print t-f-c}' /proc/meminfo) ;;
+    esac
+    MEM_RATIO=$(awk "BEGIN {r=$MEM_USED_KB/$MEM_TOTAL_KB; if(r>1)r=1; if(r<0)r=0; printf \"%.4f\",r}")
+
+    # One data line per sample: cpu_ratio mem_ratio
+    echo "$CPU_RATIO $MEM_RATIO"
+  done
+) >> "$LOG_FILE" 2>&1 &
+
+echo $! > "$PID_FILE"
+echo "Resource monitor started (PID=$(cat $PID_FILE), cpu=${CPU_SOURCE}(${CPU_LIMIT_CORES} cores) mem=${MEM_SOURCE}(${MEM_TOTAL_KB}KB), interval=${INTERVAL}s)"

--- a/submit-build-status/action.yml
+++ b/submit-build-status/action.yml
@@ -119,20 +119,20 @@ runs:
               if (idx > n) idx = n
               return sorted[idx]
             }
-        
+
             NR <= 2              { next }
             $15 !~ /^[0-9]+$/    { next }
             {
               cpu_used = 100 - $15
               mem_pct  = (mem_total_kb - $4 - $6) * 100 / mem_total_kb
-        
+
               cpu_sum += cpu_used
               mem_sum += mem_pct
               count++
-        
+
               cpu[count] = cpu_used
               mem[count] = mem_pct
-        
+
               if (count == 1 || cpu_used > cpu_max) cpu_max = cpu_used
               if (count == 1 || mem_pct  > mem_max) mem_max = mem_pct
             }
@@ -140,12 +140,12 @@ runs:
               if (count > 0) {
                 sort_num(cpu, count)
                 sort_num(mem, count)
-        
+
                 p90_cpu = pct(cpu, count, 0.90)
                 p95_cpu = pct(cpu, count, 0.95)
                 p90_mem = pct(mem, count, 0.90)
                 p95_mem = pct(mem, count, 0.95)
-        
+
                 printf "%.2f %d %.2f %.2f %.2f %.2f %.2f %.2f %d\n",
                   cpu_sum/count, cpu_max, p90_cpu, p95_cpu,
                   mem_sum/count, mem_max, p90_mem, p95_mem, count
@@ -155,7 +155,8 @@ runs:
         )
 
         if [ -n "$COUNT" ] && [ "$COUNT" -gt 0 ]; then
-          echo "CPU: avg=${AVG_CPU}%, max=${CPU_MAX}%, p90=${P90_CPU}%, p95=${P95_CPU}%  |  Mem: avg=${AVG_MEM}%, max=${MEM_MAX}%, p90=${P90_MEM}%, p95=${P95_MEM}%  (${COUNT} samples)"
+          echo "Total memory: $MEM_TOTAL_KB KiB"
+          echo "CPU: avg=${AVG_CPU}%, p90=${P90_CPU}%, p95=${P95_CPU}%, max=${CPU_MAX}%  |  Mem: avg=${AVG_MEM}%, p90=${P90_MEM}%, p95=${P95_MEM}%, max=${MEM_MAX}%  (${COUNT} samples)"
           MONITOR_FIELDS=$(printf ', "avg_cpu_pct": %s, "max_cpu_pct": %s, "avg_mem_pct": %s, "max_mem_pct": %s' \
             "$AVG_CPU" "$CPU_MAX" "$AVG_MEM" "$MEM_MAX")
         else

--- a/submit-build-status/action.yml
+++ b/submit-build-status/action.yml
@@ -97,15 +97,21 @@ runs:
         echo "Resource monitor stopped (PID=$VMSTAT_PID)"
         cat "$LOG_FILE"
 
-        # Read total memory (in kB): prefer cgroup limit (correct inside K8s/container runners),
-        # fall back to /proc/meminfo for bare VMs. Checks cgroup v2 first, then v1.
+        # vmstat's free/cache columns are always host-scoped, so use /proc/meminfo MemTotal
+        # as the denominator to keep the arithmetic self-consistent.
+        # If a cgroup memory limit exists (K8s runners), apply a scale factor afterwards:
+        #   mem_pct = (host_used_kb / host_total_kb) * (host_total_kb / cgroup_limit_kb)
+        #           = host_used_kb * 100 / cgroup_limit_kb
+        # This normalizes to % of the container's memory budget.
+        MEM_TOTAL_KB=$(awk '/^MemTotal:/ {print $2}' /proc/meminfo)
+        MEM_SCALE_FACTOR=1
         CGROUP_LIMIT_BYTES=$(cat /sys/fs/cgroup/memory.max 2>/dev/null || cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2>/dev/null || echo "max")
         if [ "$CGROUP_LIMIT_BYTES" != "max" ] && [ "$CGROUP_LIMIT_BYTES" -gt 0 ] 2>/dev/null; then
-          MEM_TOTAL_KB=$(( CGROUP_LIMIT_BYTES / 1024 ))
-          echo "Memory total: ${MEM_TOTAL_KB}KB (from cgroup limit)"
+          CGROUP_LIMIT_KB=$(( CGROUP_LIMIT_BYTES / 1024 ))
+          MEM_SCALE_FACTOR=$(awk "BEGIN {printf \"%.6f\", $MEM_TOTAL_KB / $CGROUP_LIMIT_KB}")
+          echo "Memory: ${MEM_TOTAL_KB}KB host total, ${CGROUP_LIMIT_KB}KB cgroup limit, mem_scale=${MEM_SCALE_FACTOR}"
         else
-          MEM_TOTAL_KB=$(awk '/^MemTotal:/ {print $2}' /proc/meminfo)
-          echo "Memory total: ${MEM_TOTAL_KB}KB (from /proc/meminfo)"
+          echo "Memory: ${MEM_TOTAL_KB}KB (no cgroup limit)"
         fi
 
         # CPU normalization: vmstat reports CPU as % of all host cores; inside a container
@@ -133,7 +139,7 @@ runs:
         # Parse vmstat log in one awk pass: skip 2 header lines, filter non-numeric rows.
         # awk columns (1-based): free=$4, cache=$6, idle=$15
         read -r AVG_CPU CPU_MAX P90_CPU P95_CPU AVG_MEM MEM_MAX P90_MEM P95_MEM COUNT < <(
-          awk -v mem_total_kb="$MEM_TOTAL_KB" -v cpu_norm="$CPU_NORM_FACTOR" '
+          awk -v mem_total_kb="$MEM_TOTAL_KB" -v mem_scale="$MEM_SCALE_FACTOR" -v cpu_norm="$CPU_NORM_FACTOR" '
             function ceil(x) { return (x == int(x)) ? x : int(x) + 1 }
             function sort_num(a, n,   i,j,tmp) {
               for (i = 1; i <= n; i++) {
@@ -155,7 +161,7 @@ runs:
             {
               cpu_used = (100 - $15) * cpu_norm
               if (cpu_used > 100) cpu_used = 100
-              mem_pct  = (mem_total_kb - $4 - $6) * 100 / mem_total_kb
+              mem_pct  = (mem_total_kb - $4 - $6) * 100 / mem_total_kb * mem_scale
 
               cpu_sum += cpu_used
               mem_sum += mem_pct

--- a/submit-build-status/action.yml
+++ b/submit-build-status/action.yml
@@ -84,7 +84,52 @@ runs:
       BUILD_HEAD_REF: "${{ github.head_ref && format('refs/heads/{0}', github.head_ref) || github.event.merge_group.head_ref }}"
       ACCESS_TOKEN: "${{ steps.auth.outputs.access_token }}"
     run: |
-      # Parse BigQuery table name (format: project_id:dataset.table)
+      # ── Resource monitor: stop vmstat and parse metrics if monitor-start ran ──
+      MONITOR_FIELDS=""
+      PID_FILE=/tmp/_monitor_vmstat.pid
+      LOG_FILE=/tmp/_monitor_vmstat.log
+
+      if [ -f "$PID_FILE" ]; then
+        VMSTAT_PID=$(cat "$PID_FILE")
+        kill "$VMSTAT_PID" 2>/dev/null || true
+        rm -f "$PID_FILE"
+        echo "Resource monitor stopped (PID=$VMSTAT_PID)"
+
+        # Read total memory once from /proc/meminfo (in kB)
+        MEM_TOTAL_KB=$(awk '/^MemTotal:/ {print $2}' /proc/meminfo)
+
+        # Parse vmstat log: skip the 2 header lines, then read data lines.
+        # Columns (0-based, whitespace-split): 3=free(KB), 5=cache(KB), 14=id(idle%)
+        CPU_SUM=0; CPU_MAX=0; MEM_SUM=0; MEM_MAX=0; COUNT=0
+        while IFS= read -r line; do
+          read -ra cols <<< "$line"
+          [ "${#cols[@]}" -lt 15 ] && continue
+          FREE_KB="${cols[3]}"; CACHE_KB="${cols[5]}"; IDLE="${cols[14]}"
+          # skip non-numeric lines (headers that sneak in on interval boundaries)
+          [[ "$IDLE" =~ ^[0-9]+$ ]] || continue
+          CPU_USED=$((100 - IDLE))
+          USED_KB=$(( MEM_TOTAL_KB - FREE_KB - CACHE_KB ))
+          MEM_PCT=$(echo "scale=2; $USED_KB * 100 / $MEM_TOTAL_KB" | bc)
+          CPU_SUM=$((CPU_SUM + CPU_USED))
+          MEM_SUM=$(echo "scale=2; $MEM_SUM + $MEM_PCT" | bc)
+          [ "$CPU_USED" -gt "$CPU_MAX" ] && CPU_MAX=$CPU_USED
+          MEM_MAX_CMP=$(echo "$MEM_PCT > $MEM_MAX" | bc)
+          [ "$MEM_MAX_CMP" -eq 1 ] && MEM_MAX=$MEM_PCT
+          COUNT=$((COUNT + 1))
+        done < <(tail -n +3 "$LOG_FILE")
+
+        if [ "$COUNT" -gt 0 ]; then
+          AVG_CPU=$(echo "scale=2; $CPU_SUM / $COUNT" | bc)
+          AVG_MEM=$(echo "scale=2; $MEM_SUM / $COUNT" | bc)
+          echo "CPU: avg=${AVG_CPU}%, max=${CPU_MAX}%  |  Mem: avg=${AVG_MEM}%, max=${MEM_MAX}%  (${COUNT} samples)"
+          MONITOR_FIELDS=$(printf ', "avg_cpu_pct": %s, "max_cpu_pct": %s, "avg_mem_pct": %s, "max_mem_pct": %s' \
+            "$AVG_CPU" "$CPU_MAX" "$AVG_MEM" "$MEM_MAX")
+        else
+          echo "Resource monitor log had no data rows — metrics omitted"
+        fi
+      fi
+
+      # ── Parse BigQuery table name (format: project_id:dataset.table) ──
       TABLE_NAME="${{ inputs.big_query_table_name }}"
       PROJECT_ID="${TABLE_NAME%%:*}"
       DATASET_TABLE="${TABLE_NAME#*:}"

--- a/submit-build-status/action.yml
+++ b/submit-build-status/action.yml
@@ -86,6 +86,7 @@ runs:
     run: |
       # ── Resource monitor: stop vmstat and parse metrics if monitor-start ran ──
       MONITOR_FIELDS=""
+      # TODO: avoid duplicate decleration
       PID_FILE=/tmp/_monitor_vmstat.pid
       LOG_FILE=/tmp/_monitor_vmstat.log
 
@@ -94,29 +95,67 @@ runs:
         kill "$VMSTAT_PID" 2>/dev/null || true
         rm -f "$PID_FILE"
         echo "Resource monitor stopped (PID=$VMSTAT_PID)"
+        cat "$LOG_FILE"
 
         # Read total memory once from /proc/meminfo (in kB)
         MEM_TOTAL_KB=$(awk '/^MemTotal:/ {print $2}' /proc/meminfo)
 
         # Parse vmstat log in one awk pass: skip 2 header lines, filter non-numeric rows.
         # awk columns (1-based): free=$4, cache=$6, idle=$15
-        read -r AVG_CPU CPU_MAX AVG_MEM MEM_MAX COUNT < <(
+        read -r AVG_CPU CPU_MAX P90_CPU P95_CPU AVG_MEM MEM_MAX P90_MEM P95_MEM COUNT < <(
           awk -v mem_total_kb="$MEM_TOTAL_KB" '
-            NR <= 2       { next }
-            $15 !~ /^[0-9]+$/ { next }
+            function ceil(x) { return (x == int(x)) ? x : int(x) + 1 }
+            function sort_num(a, n,   i,j,tmp) {
+              for (i = 1; i <= n; i++) {
+                for (j = i + 1; j <= n; j++) {
+                  if (a[i] > a[j]) { tmp = a[i]; a[i] = a[j]; a[j] = tmp }
+                }
+              }
+            }
+            function pct(sorted, n, p,   idx) {
+              # Nearest-rank method: rank = ceil(p * n)
+              idx = ceil(p * n)
+              if (idx < 1) idx = 1
+              if (idx > n) idx = n
+              return sorted[idx]
+            }
+        
+            NR <= 2              { next }
+            $15 !~ /^[0-9]+$/    { next }
             {
               cpu_used = 100 - $15
               mem_pct  = (mem_total_kb - $4 - $6) * 100 / mem_total_kb
-              cpu_sum += cpu_used; mem_sum += mem_pct; count++
-              if (cpu_used > cpu_max) cpu_max = cpu_used
-              if (mem_pct  > mem_max) mem_max = mem_pct
+        
+              cpu_sum += cpu_used
+              mem_sum += mem_pct
+              count++
+        
+              cpu[count] = cpu_used
+              mem[count] = mem_pct
+        
+              if (count == 1 || cpu_used > cpu_max) cpu_max = cpu_used
+              if (count == 1 || mem_pct  > mem_max) mem_max = mem_pct
             }
-            END { if (count > 0) printf "%.2f %d %.2f %.2f %d\n", cpu_sum/count, cpu_max, mem_sum/count, mem_max, count }
+            END {
+              if (count > 0) {
+                sort_num(cpu, count)
+                sort_num(mem, count)
+        
+                p90_cpu = pct(cpu, count, 0.90)
+                p95_cpu = pct(cpu, count, 0.95)
+                p90_mem = pct(mem, count, 0.90)
+                p95_mem = pct(mem, count, 0.95)
+        
+                printf "%.2f %d %.2f %.2f %.2f %.2f %.2f %.2f %d\n",
+                  cpu_sum/count, cpu_max, p90_cpu, p95_cpu,
+                  mem_sum/count, mem_max, p90_mem, p95_mem, count
+              }
+            }
           ' "$LOG_FILE"
         )
 
         if [ -n "$COUNT" ] && [ "$COUNT" -gt 0 ]; then
-          echo "CPU: avg=${AVG_CPU}%, max=${CPU_MAX}%  |  Mem: avg=${AVG_MEM}%, max=${MEM_MAX}%  (${COUNT} samples)"
+          echo "CPU: avg=${AVG_CPU}%, max=${CPU_MAX}%, p90=${P90_CPU}%, p95=${P95_CPU}%  |  Mem: avg=${AVG_MEM}%, max=${MEM_MAX}%, p90=${P90_MEM}%, p95=${P95_MEM}%  (${COUNT} samples)"
           MONITOR_FIELDS=$(printf ', "avg_cpu_pct": %s, "max_cpu_pct": %s, "avg_mem_pct": %s, "max_mem_pct": %s' \
             "$AVG_CPU" "$CPU_MAX" "$AVG_MEM" "$MEM_MAX")
         else

--- a/submit-build-status/action.yml
+++ b/submit-build-status/action.yml
@@ -98,29 +98,24 @@ runs:
         # Read total memory once from /proc/meminfo (in kB)
         MEM_TOTAL_KB=$(awk '/^MemTotal:/ {print $2}' /proc/meminfo)
 
-        # Parse vmstat log: skip the 2 header lines, then read data lines.
-        # Columns (0-based, whitespace-split): 3=free(KB), 5=cache(KB), 14=id(idle%)
-        CPU_SUM=0; CPU_MAX=0; MEM_SUM=0; MEM_MAX=0; COUNT=0
-        while IFS= read -r line; do
-          read -ra cols <<< "$line"
-          [ "${#cols[@]}" -lt 15 ] && continue
-          FREE_KB="${cols[3]}"; CACHE_KB="${cols[5]}"; IDLE="${cols[14]}"
-          # skip non-numeric lines (headers that sneak in on interval boundaries)
-          [[ "$IDLE" =~ ^[0-9]+$ ]] || continue
-          CPU_USED=$((100 - IDLE))
-          USED_KB=$(( MEM_TOTAL_KB - FREE_KB - CACHE_KB ))
-          MEM_PCT=$(echo "scale=2; $USED_KB * 100 / $MEM_TOTAL_KB" | bc)
-          CPU_SUM=$((CPU_SUM + CPU_USED))
-          MEM_SUM=$(echo "scale=2; $MEM_SUM + $MEM_PCT" | bc)
-          [ "$CPU_USED" -gt "$CPU_MAX" ] && CPU_MAX=$CPU_USED
-          MEM_MAX_CMP=$(echo "$MEM_PCT > $MEM_MAX" | bc)
-          [ "$MEM_MAX_CMP" -eq 1 ] && MEM_MAX=$MEM_PCT
-          COUNT=$((COUNT + 1))
-        done < <(tail -n +3 "$LOG_FILE")
+        # Parse vmstat log in one awk pass: skip 2 header lines, filter non-numeric rows.
+        # awk columns (1-based): free=$4, cache=$6, idle=$15
+        read -r AVG_CPU CPU_MAX AVG_MEM MEM_MAX COUNT < <(
+          awk -v mem_total_kb="$MEM_TOTAL_KB" '
+            NR <= 2       { next }
+            $15 !~ /^[0-9]+$/ { next }
+            {
+              cpu_used = 100 - $15
+              mem_pct  = (mem_total_kb - $4 - $6) * 100 / mem_total_kb
+              cpu_sum += cpu_used; mem_sum += mem_pct; count++
+              if (cpu_used > cpu_max) cpu_max = cpu_used
+              if (mem_pct  > mem_max) mem_max = mem_pct
+            }
+            END { if (count > 0) printf "%.2f %d %.2f %.2f %d\n", cpu_sum/count, cpu_max, mem_sum/count, mem_max, count }
+          ' "$LOG_FILE"
+        )
 
-        if [ "$COUNT" -gt 0 ]; then
-          AVG_CPU=$(echo "scale=2; $CPU_SUM / $COUNT" | bc)
-          AVG_MEM=$(echo "scale=2; $MEM_SUM / $COUNT" | bc)
+        if [ -n "$COUNT" ] && [ "$COUNT" -gt 0 ]; then
           echo "CPU: avg=${AVG_CPU}%, max=${CPU_MAX}%  |  Mem: avg=${AVG_MEM}%, max=${MEM_MAX}%  (${COUNT} samples)"
           MONITOR_FIELDS=$(printf ', "avg_cpu_pct": %s, "max_cpu_pct": %s, "avg_mem_pct": %s, "max_mem_pct": %s' \
             "$AVG_CPU" "$CPU_MAX" "$AVG_MEM" "$MEM_MAX")

--- a/submit-build-status/action.yml
+++ b/submit-build-status/action.yml
@@ -97,13 +97,43 @@ runs:
         echo "Resource monitor stopped (PID=$VMSTAT_PID)"
         cat "$LOG_FILE"
 
-        # Read total memory once from /proc/meminfo (in kB)
-        MEM_TOTAL_KB=$(awk '/^MemTotal:/ {print $2}' /proc/meminfo)
+        # Read total memory (in kB): prefer cgroup limit (correct inside K8s/container runners),
+        # fall back to /proc/meminfo for bare VMs. Checks cgroup v2 first, then v1.
+        CGROUP_LIMIT_BYTES=$(cat /sys/fs/cgroup/memory.max 2>/dev/null || cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2>/dev/null || echo "max")
+        if [ "$CGROUP_LIMIT_BYTES" != "max" ] && [ "$CGROUP_LIMIT_BYTES" -gt 0 ] 2>/dev/null; then
+          MEM_TOTAL_KB=$(( CGROUP_LIMIT_BYTES / 1024 ))
+          echo "Memory total: ${MEM_TOTAL_KB}KB (from cgroup limit)"
+        else
+          MEM_TOTAL_KB=$(awk '/^MemTotal:/ {print $2}' /proc/meminfo)
+          echo "Memory total: ${MEM_TOTAL_KB}KB (from /proc/meminfo)"
+        fi
+
+        # CPU normalization: vmstat reports CPU as % of all host cores; inside a container
+        # with a CPU limit this under-reports utilization — scale up to % of the pod's allocation.
+        # cgroup v2: cpu.max contains "quota period" or "max period"
+        # cgroup v1: cpu.cfs_quota_us / cpu.cfs_period_us  (-1 = unlimited)
+        HOST_CORES=$(nproc)
+        CPU_NORM_FACTOR=1
+        CGROUP_CPU_QUOTA=""; CGROUP_CPU_PERIOD=""
+        if [ -f /sys/fs/cgroup/cpu.max ]; then
+          read -r CGROUP_CPU_QUOTA CGROUP_CPU_PERIOD < /sys/fs/cgroup/cpu.max
+        elif [ -f /sys/fs/cgroup/cpu/cpu.cfs_quota_us ]; then
+          CGROUP_CPU_QUOTA=$(cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us)
+          CGROUP_CPU_PERIOD=$(cat /sys/fs/cgroup/cpu/cpu.cfs_period_us)
+        fi
+        if [ -n "$CGROUP_CPU_QUOTA" ] && [ "$CGROUP_CPU_QUOTA" != "max" ] && [ "$CGROUP_CPU_QUOTA" != "-1" ] \
+            && [ "${CGROUP_CPU_PERIOD:-0}" -gt 0 ] 2>/dev/null; then
+          CPU_NORM_FACTOR=$(awk "BEGIN {printf \"%.6f\", $HOST_CORES * $CGROUP_CPU_PERIOD / $CGROUP_CPU_QUOTA}")
+          CONTAINER_CPU_CORES=$(awk "BEGIN {printf \"%.2f\", $CGROUP_CPU_QUOTA / $CGROUP_CPU_PERIOD}")
+          echo "CPU: ${HOST_CORES} host cores, ${CONTAINER_CPU_CORES} container cores (cgroup), norm_factor=${CPU_NORM_FACTOR}"
+        else
+          echo "CPU: ${HOST_CORES} host cores, no cgroup CPU limit — no normalization"
+        fi
 
         # Parse vmstat log in one awk pass: skip 2 header lines, filter non-numeric rows.
         # awk columns (1-based): free=$4, cache=$6, idle=$15
         read -r AVG_CPU CPU_MAX P90_CPU P95_CPU AVG_MEM MEM_MAX P90_MEM P95_MEM COUNT < <(
-          awk -v mem_total_kb="$MEM_TOTAL_KB" '
+          awk -v mem_total_kb="$MEM_TOTAL_KB" -v cpu_norm="$CPU_NORM_FACTOR" '
             function ceil(x) { return (x == int(x)) ? x : int(x) + 1 }
             function sort_num(a, n,   i,j,tmp) {
               for (i = 1; i <= n; i++) {
@@ -123,7 +153,8 @@ runs:
             NR <= 2              { next }
             $15 !~ /^[0-9]+$/    { next }
             {
-              cpu_used = 100 - $15
+              cpu_used = (100 - $15) * cpu_norm
+              if (cpu_used > 100) cpu_used = 100
               mem_pct  = (mem_total_kb - $4 - $6) * 100 / mem_total_kb
 
               cpu_sum += cpu_used

--- a/submit-build-status/action.yml
+++ b/submit-build-status/action.yml
@@ -77,6 +77,12 @@ runs:
       credentials_json: '${{ inputs.gcp_credentials_json }}'
       token_format: 'access_token'
 
+  - name: Collect resource usage metrics
+    id: monitor
+    shell: bash
+    run: |
+      bash "$GITHUB_ACTION_PATH/stop-and-collect-build-monitor.sh" "$GITHUB_OUTPUT"
+
   - name: Submit build status to CI Analytics
     shell: bash
     env:
@@ -84,7 +90,10 @@ runs:
       BUILD_HEAD_REF: "${{ github.head_ref && format('refs/heads/{0}', github.head_ref) || github.event.merge_group.head_ref }}"
       ACCESS_TOKEN: "${{ steps.auth.outputs.access_token }}"
     run: |
-      # Parse BigQuery table name (format: project_id:dataset.table)
+      # ── Build monitor: get resource usage metrics (might be empty) ──
+      MONITOR_FIELDS="${{ steps.monitor.outputs.monitor_fields }}"
+
+      # ── Parse BigQuery table name (format: project_id:dataset.table) ──
       TABLE_NAME="${{ inputs.big_query_table_name }}"
       PROJECT_ID="${TABLE_NAME%%:*}"
       DATASET_TABLE="${TABLE_NAME#*:}"
@@ -110,6 +119,7 @@ runs:
         ${{ (inputs.build_duration_millis == '') && ' ' || format(', "build_duration_milliseconds": "{0}"', inputs.build_duration_millis) }}
         ${{ (inputs.user_reason == '') && ' ' || format(', "user_reason": "{0}"', inputs.user_reason) }}
         ${{ (inputs.user_description == '') && ' ' || format(', "user_description": "{0}"', inputs.user_description) }}
+        $MONITOR_FIELDS
       }
       EOF
       )

--- a/submit-build-status/stop-and-collect-build-monitor.sh
+++ b/submit-build-status/stop-and-collect-build-monitor.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+OUTPUT_FILE="$1"
+if [ -z "$OUTPUT_FILE" ]; then
+  echo "Usage: $0 <output-file>" >&2
+  exit 1
+fi
+
+MONITOR_FIELDS=""
+# NOTE: these paths are shared with start-build-monitor.sh -- if changed, update both
+PID_FILE=/tmp/_monitor-start.pid
+LOG_FILE=/tmp/_monitor-start.log
+
+if [ -f "$PID_FILE" ]; then
+  MONITOR_PID=$(cat "$PID_FILE")
+  kill "$MONITOR_PID" 2>/dev/null || true
+  rm -f "$PID_FILE"
+  echo "Resource monitor stopped (PID=$MONITOR_PID)"
+  echo "Raw monitor log values (CPU, memory usage ratio) per interval:"
+  echo "::group::Resource monitor raw log"
+  cat "$LOG_FILE"
+  echo "::endgroup::"
+
+  # Parse monitor log: header lines start with '#', data lines are "cpu_ratio mem_ratio".
+  # Both are already 0-1 ratios computed in start-build-monitor.
+  read -r AVG_CPU CPU_MAX P90_CPU P95_CPU AVG_MEM MEM_MAX P90_MEM P95_MEM COUNT < <(
+    awk '
+      function ceil(x) { return (x == int(x)) ? x : int(x) + 1 }
+      function sort_num(a, n,   i,j,tmp) {
+        for (i = 1; i <= n; i++)
+          for (j = i + 1; j <= n; j++)
+            if (a[i] > a[j]) { tmp = a[i]; a[i] = a[j]; a[j] = tmp }
+      }
+      function pctile(sorted, n, p,   idx) {
+        idx = ceil(p * n)
+        if (idx < 1) idx = 1
+        if (idx > n) idx = n
+        return sorted[idx]
+      }
+      /^#/   { next }
+      NF < 2 { next }
+      {
+        cv = $1 + 0; mv = $2 + 0
+        if (cv < 0) cv = 0; if (cv > 1) cv = 1
+        if (mv < 0) mv = 0; if (mv > 1) mv = 1
+        cpu_sum += cv; mem_sum += mv; count++
+        cpu[count] = cv; mem[count] = mv
+        if (count == 1 || cv > cpu_max) cpu_max = cv
+        if (count == 1 || mv > mem_max) mem_max = mv
+      }
+      END {
+        if (count > 0) {
+          sort_num(cpu, count); sort_num(mem, count)
+          printf "%.4f %.4f %.4f %.4f %.4f %.4f %.4f %.4f %d\n",
+            cpu_sum/count, cpu_max, pctile(cpu,count,0.90), pctile(cpu,count,0.95),
+            mem_sum/count, mem_max, pctile(mem,count,0.90), pctile(mem,count,0.95),
+            count
+        }
+      }
+    ' "$LOG_FILE"
+  ) || true  # read returns 1 when awk produces no output (empty log); || true prevents set -e from killing the step
+
+  if [ -n "$COUNT" ] && [ "$COUNT" -gt 0 ]; then
+    read -r _ac _cm _p90c _p95c _am _mm _p90m _p95m < <(awk "BEGIN {printf \"%.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f\\n\", $AVG_CPU*100,$CPU_MAX*100,$P90_CPU*100,$P95_CPU*100,$AVG_MEM*100,$MEM_MAX*100,$P90_MEM*100,$P95_MEM*100}") || true
+    echo "CPU: avg=${_ac}%, p90=${_p90c}%, p95=${_p95c}%, max=${_cm}%  |  Mem: avg=${_am}%, p90=${_p90m}%, p95=${_p95m}%, max=${_mm}%  (${COUNT} samples)"
+    MONITOR_FIELDS=$(printf ', "cpu_usage_ratio_avg": %s, "cpu_usage_ratio_p95": %s, "memory_usage_ratio_avg": %s, "memory_usage_ratio_p95": %s' \
+      "$AVG_CPU" "$P95_CPU" "$AVG_MEM" "$P95_MEM")
+  else
+    echo "Resource monitor log had no data rows -- metrics omitted"
+  fi
+fi
+
+printf 'monitor_fields=%s\n' "$MONITOR_FIELDS" >> "$OUTPUT_FILE"


### PR DESCRIPTION
## Core idea

The PR adds an **in-band, zero-configuration CPU and memory utilization measurement mechanism to the CI Analytics pipeline.** Every job that already sends a build status record to BigQuery can now include four additional metrics — without changing any job-level inputs. The caller contract is: add one `uses:` line as the first step, everything else is automatic.

This was a hackdays project motivated by https://github.com/camunda/team-infrastructure/issues/1051

### Job integration and runtime timeline

```mermaid
sequenceDiagram
    autonumber
    participant J as Job Steps
    participant M as Monitor (background)
    participant BQ as BigQuery

    J->>M: start-build-monitor — detect cgroup sources, read limits, seed baseline

    Note over J,M: checkout → build → test → ...

    loop every 5 s (concurrent with job steps)
        M->>M: sample cpu.stat and memory.current
        M->>M: compute cpu_ratio and mem_ratio, append to log
    end

    J->>M: submit-build-status — stop monitor
    Note over J: parse log — avg / p90 / p95 / max per metric
    J->>BQ: insert row with cpu_usage_ratio_avg, cpu_usage_ratio_p95,<br>memory_usage_ratio_avg, memory_usage_ratio_p95
```

---

## New action: `start-build-monitor`

A composite action consisting of a single step that launches a shell script (`start-build-monitor.sh`) as a background process.

**What the script does on startup:**

1. **Independently detects the CPU metric source** (checked in order):
   - cgroup v2: `/sys/fs/cgroup/cpu.stat` (Ubuntu 22.04+, K8s pods)
   - cgroup v1: `/sys/fs/cgroup/cpuacct/cpuacct.usage`
   - Fallback: `/proc/stat` jiffies (bare VMs of GH-hosted runners, no cgroup)

2. **Independently detects the memory metric source**:
   - cgroup v2: `/sys/fs/cgroup/memory.current` (K8s pods)
   - cgroup v1: `/sys/fs/cgroup/memory/memory.usage_in_bytes`
   - Fallback: `/proc/meminfo` (bare VMs of GH-hosted runners)

   The two detections are independent because cgroup controllers (cpu, memory) can be individually enabled/disabled.

3. **Reads the CPU limit** from `cpu.max` (cgroupv2) or `cfs_quota_us`/`cfs_period_us` (cgroupv1). Falls back to `nproc`. This is used to express CPU usage as a fraction of the container's allocated CPU budget, not raw core count.

4. **Reads the memory total** from the cgroup memory limit (`memory.max` / `memory.limit_in_bytes`) or `/proc/meminfo MemTotal`. This is the container's memory budget (K8s resource limit), not the host node's total RAM — critical correctness property for shared runners.

5. **Writes a comment header line** to `/tmp/_monitor-start.log` recording the detected sources and limits, for debugging:
   ```
   # cpu_source=cgroupv2 mem_source=cgroupv2 cpu_limit_cores=7.5000 mem_total_kb=26214400 interval=5
   ```

6. **Seeds the initial CPU counter** (before the first sleep) to avoid a cold-start measurement error on the first sample.

7. **Spawns a background polling loop** (5-second interval) that on each tick:
   - Reads the current CPU cumulative counter and computes `delta_us / (interval_us × cpu_limit_cores)` → 0–1 ratio, clamped
   - Reads current memory usage in kB and computes `mem_used_kb / mem_total_kb` → 0–1 ratio, clamped
   - Appends one line `cpu_ratio mem_ratio` to the log file

8. Writes the background PID to `/tmp/_monitor-start.pid` and prints a startup confirmation line to the job log.

**Why cgroup-scoped metrics matter:** on self-hosted K8s runners, many pods share the same node. vmstat and host-level `/proc/stat` would measure the aggregate of all pods, producing meaningless per-job data. Cgroup metrics are namespaced to the container, so they reflect the actual CPU and memory consumed by this specific job.

---

## Extended action: `submit-build-status`

A new step is inserted between the GCP auth step and the BigQuery submission step. It calls a new script `stop-and-collect-build-monitor.sh` (calculates aggregate metrics) and writes its output to `GITHUB_OUTPUT` (usable by BQ insert later).

The precondition is extended the BigQuery schema which happened in https://github.com/camunda/infra-core/pull/12662 (includes details on what changes were done).

**What the collection script does:**

1. Checks for `/tmp/_monitor-start.pid`. If it doesn't exist (monitor wasn't started), the script is a no-op and outputs an empty `monitor_fields`.

2. If the PID file exists:
   - Kills the background polling process
   - Prints the raw log (cpu/mem ratio pairs) into a collapsible `::group::` block in the job log for debugging
   - Parses all data rows using awk with an in-memory insertion sort
   - Computes per-sample aggregates: **avg**, **max**, **p90**, **p95** for both CPU and memory
   - Prints a human-readable debug summary: `CPU: avg=85.2%, p90=100.0%, p95=100.0%, max=100.0% | Mem: avg=31.2%, ...  (137 samples)`
   - Formats the four BigQuery fields as a JSON fragment string

3. Outputs `monitor_fields=<json_fragment>` to `GITHUB_OUTPUT`.

The BigQuery submission step reads `${{ steps.monitor.outputs.monitor_fields }}` and inlines it into the JSON row. When the monitor didn't run, `monitor_fields` is empty and the fields are absent from the row, landing as `NULL` in BigQuery (consistent with other optional fields).

---

## BigQuery schema additions

Four new `FLOAT64 NULLABLE` columns in `build_status_v2`, range 0.0–1.0:

| Column | Meaning |
|---|---|
| `cpu_usage_ratio_avg` | Mean CPU utilization across all samples |
| `cpu_usage_ratio_p95` | 95th percentile CPU — robust against isolated spikes |
| `memory_usage_ratio_avg` | Mean memory utilization across all samples |
| `memory_usage_ratio_p95` | 95th percentile memory |

Rationale for 0–1 ratios instead of percentages: Grafana natively renders ratios, and arithmetic (e.g. multiplying two ratios) works correctly without unit conversion. p95 was chosen as the primary stored statistic (over max) because `max` is sensitive to a single spike in a long run. p90 and max are still printed in the debug log for human review.

---

## Tests performed

No automated unit tests (shell PoC). Testing was done by integrating the actions into `camunda/camunda` CI on the companion PR https://github.com/camunda/camunda/pull/51730.

Plausibility was verified against a full `camunda/camunda` CI run ([#25435859055](https://github.com/camunda/camunda/actions/runs/25435859055)). Representative findings:

- **Java Checks** (7.5-core pod): CPU avg=85.2%, p95=100% — sustained at the allocation ceiling throughout Maven compilation, as expected
- **build-platform-frontend** (4-core GH-hosted VM): CPU avg=73.3%, p95=100% — webpack/vite bundle saturating available cores
- **Lint/Commitlint**: CPU avg=14.7% — very light, as expected for a Node.js script
- **Zeebe/Unit-Exporter**: memory max=55.9% of 50 GB pod (~28 GB) — flagged as unexpectedly higher than the QA integration tests that actually run Zeebe brokers
- **Zeebe QA-Update ITs**: memory avg=33.5%/max=50.5% on a 25 GB pod — tightest headroom relative to pod size

cgroup detection worked correctly: self-hosted K8s pods reported `mem_source=cgroupv2` (container-scoped limit), GitHub-hosted VMs reported `mem_source=proc` (full VM RAM, valid since VMs are single-tenant).

A synthetic single CPU and 50% memory benchmark confirmed we're measuring the right thing on all different runners:

* ✔️ `ubuntu-slim`: 100% of the 1 available CPU core [are reported as utilized](https://github.com/camunda/camunda/actions/runs/25504862383/job/74848254268?pr=51730#step:5:198)
* ✔️ `ubuntu-latest`: on average 50% of 2 available CPU cores [are reported as utilized](https://github.com/camunda/camunda/actions/runs/25504862383/job/74848254144?pr=51730#step:5:197)
* ✔️ `gcp-perf-core-8`: on average 13% of 7.5 available CPU cores [are reported as utilized](https://github.com/camunda/camunda/actions/runs/25504862383/job/74848254235?pr=51730#step:6:199)

---

## Conftest rule (`camunda/camunda`)

A companion Rego `deny` rule was added to `conftest-unified-ci-rules.rego` in the `camunda/camunda` repo to enforce that all Unified CI jobs include `start-build-monitor` as their **first** step. It checks `startswith(steps[0].uses, "camunda/infra-global-github-actions/start-build-monitor@")` and fires on any job missing it, with the standard exclusions for control-flow jobs (`detect-changes`, `check-results`, `utils-*`, `deploy-*`, etc.).

---

## Metric calculation details

**CPU (cgroupv2/v1):**
```
delta_us = cpu.stat[t] - cpu.stat[t-interval]
cpu_ratio = clamp(delta_us / (interval_us × cpu_limit_cores), 0, 1)
```
Where `cpu_limit_cores` is derived from `cfs_quota / cfs_period`. A value of 1.0 means the job's full CPU allocation was saturated during that interval.

**CPU (bare VM / proc fallback):**
```
cpu_ratio = clamp(1 - delta_idle_jiffies / delta_total_jiffies, 0, 1)
```
On GitHub-hosted runners (full VMs), this measures the entire VM's CPU, which is still meaningful since each VM runs only one job.

**Memory (cgroupv2/v1):**
```
mem_ratio = clamp(memory.current / memory.max, 0, 1)
```
Container-scoped: reflects the pod's RSS + cache within its cgroup budget.

**Memory (proc fallback):**
```
mem_ratio = clamp((MemTotal - MemFree - Cached) / MemTotal, 0, 1)
```