### PR TITLE
fix: replace deprecated app-id with client-id in create-github-app-token

### DIFF
--- a/generate-github-app-token-from-vault-secrets/action.yml
+++ b/generate-github-app-token-from-vault-secrets/action.yml
@@ -124,7 +124,7 @@ runs:
     id: github-token
     uses: actions/create-github-app-token@v3
     with:
-      app-id: ${{ steps.app-id.outputs.id }}
+      client-id: ${{ steps.app-id.outputs.id }}
       private-key: ${{ steps.app-private-key.outputs.private-key }}
       skip-token-revoke: ${{ inputs.skip-token-revoke }}
       owner: ${{ inputs.owner }}


### PR DESCRIPTION
## Summary

`actions/create-github-app-token@v3` deprecated the `app-id` input in favour of `client-id`. This causes a warning in every workflow that uses the `generate-github-app-token-from-vault-secrets` composite action:

```
Warning: Input 'app-id' has been deprecated with message: Use 'client-id' instead.
```

## Change

Replace `app-id` with `client-id` in the `Generate a Github App token` step of the composite action. The value being passed (`${{ steps.app-id.outputs.id }}`) remains unchanged.