### PR TITLE
fix: update actionlint runner labels from N1 to N2 pool names

### DIFF
--- a/actionlint/actionlint.yaml
+++ b/actionlint/actionlint.yaml
@@ -49,10 +49,10 @@ self-hosted-runner:
     - gcp-core-8-default
     - gcp-core-8-longrunning
     - gcp-core-8-release
-    - n1-standard-16-netssd-preempt
-    - n1-standard-32-netssd-preempt
-    - n1-standard-8-netssd-preempt
-    - n1-standard-8-netssd-preempt-quick
+    - n2-standard-16-netssd-preempt
+    - n2-standard-32-netssd-preempt
+    - n2-standard-8-netssd-preempt
+    - n2-standard-8-netssd-preempt-quick
 
 # Configuration variables in array of strings defined in your repository or
 # organization. `null` means disabling configuration variables check.


### PR DESCRIPTION
## Summary

Replace deprecated N1 node pool runner labels with N2 equivalents in the actionlint configuration.

## Changes

`actionlint/actionlint.yaml`: Update 4 runner labels:
- `n1-standard-8-netssd-preempt` → `n2-standard-8-netssd-preempt`
- `n1-standard-8-netssd-preempt-quick` → `n2-standard-8-netssd-preempt-quick`
- `n1-standard-16-netssd-preempt` → `n2-standard-16-netssd-preempt`
- `n1-standard-32-netssd-preempt` → `n2-standard-32-netssd-preempt`

## Context

Part of the GKE N1→N2/N2D migration tracked in https://github.com/camunda/team-infrastructure/issues/962.

The N1 pools have been removed from the camunda-ci cluster. These old labels in actionlint would incorrectly validate workflows referencing the new N2 pool names.