### PR TITLE
feat: add self-hosted runner type info in CI analytics

### DIFF
--- a/submit-build-status/action.yml
+++ b/submit-build-status/action.yml
@@ -89,9 +89,18 @@ runs:
       BUILD_BASE_REF: "${{ github.base_ref && format('refs/heads/{0}', github.base_ref) || github.event.merge_group.base_ref }}"
       BUILD_HEAD_REF: "${{ github.head_ref && format('refs/heads/{0}', github.head_ref) || github.event.merge_group.head_ref }}"
       ACCESS_TOKEN: "${{ steps.auth.outputs.access_token }}"
+      RUNNER_INFO_RUNS_ON_FILE: "/home/runner/.camunda-arc-runner-info/runs-on"
     run: |
       # ── Build monitor: get resource usage metrics (might be empty) ──
       MONITOR_FIELDS="${{ steps.monitor.outputs.monitor_fields }}"
+
+      # ── Read runs-on label info from self-hosted runner metadata (might be empty) ──
+      RUNNER_TYPE_FIELD=""
+      if [ -f "$RUNNER_INFO_RUNS_ON_FILE" ]; then
+        # The runs-on label from GHA jobs represents the runner type for self-hosted runners.
+        RUNS_ON=$(tr -cd '[:alnum:]_. -' < "$RUNNER_INFO_RUNS_ON_FILE")
+        RUNNER_TYPE_FIELD=$(printf ', "runner_type": "%s"' "$RUNS_ON")
+      fi
 
       # ── Parse BigQuery table name (format: project_id:dataset.table) ──
       TABLE_NAME="${{ inputs.big_query_table_name }}"
@@ -120,6 +129,7 @@ runs:
         ${{ (inputs.user_reason == '') && ' ' || format(', "user_reason": "{0}"', inputs.user_reason) }}
         ${{ (inputs.user_description == '') && ' ' || format(', "user_description": "{0}"', inputs.user_description) }}
         $MONITOR_FIELDS
+        $RUNNER_TYPE_FIELD
       }
       EOF
       )


### PR DESCRIPTION
This pull request enhances the `submit-build-status` GitHub Action to include metadata about the runner type when reporting build status. The main change is reading the runner type from a metadata file on self-hosted runners (needs https://github.com/camunda/infra-core/pull/12820) and including it in the status payload (needs https://github.com/camunda/infra-core/pull/12831)

**Enhancement to runner metadata reporting:**

* https://github.com/camunda/infra-core/pull/12820 lays a deterministic foundation for finding the `runs-on:` label info, not relying on heuristics to transform the K8s pod name into the label (which may change with future ARC updates)
* Added logic to read the runner type from `/home/runner/.camunda-arc-runner-info/runs-on` on self-hosted runners and include it as a `runner_type` field in the status payload.
* Updated the status payload construction to append the `runner_type` field when available.

Benefit: cost analysis and optimization scripts now have easier access to self-hosted runner type and can recommend different sizing, if needed.

**Testing:**

* Demo PR for showing E2E functionality: https://github.com/camunda/camunda/pull/53525
* Checked the collected data for consistency via `SELECT job_name, runner_name, runner_type FROM ci-30-162810.prod_ci_analytics.build_status_v2 WHERE runner_type IS NOT NULL`: 
<img width="959" height="323" alt="image" src="https://github.com/user-attachments/assets/fd073f1a-3713-45c8-9b72-9886606e4399" />
