### PR TITLE
feat(vault): add OIDC/JWT auth support to vault composites

### DIFF
--- a/generate-github-app-token-from-vault-secrets/README.md
+++ b/generate-github-app-token-from-vault-secrets/README.md
@@ -13,15 +13,20 @@ This composite GHA can be used in any repository.
 | github-app-id-vault-path            | The path of the Vault secret storing the ID of the GitHub App           |
 | github-app-private-key-vault-key    | The key of the Vault secret storing the private key of the GitHub App   |
 | github-app-private-key-vault-path   | The path of the Vault secret storing the private key of the GitHub App  |
-| vault-auth-method                   | The method to use to authenticate with Vault (*)                        |
-| vault-auth-role-id                  | The Role Id for (Vault) App Role authentication                         |
-| vault-auth-secret-id                | The Secret Id for (Vault) App Role authentication                       |
+| vault-auth-method                   | The method to use to authenticate with Vault: `approle` or `jwt` (*)    |
+| vault-auth-role-id                  | The Role Id for (Vault) App Role authentication (required when `vault-auth-method=approle`) |
+| vault-auth-secret-id                | The Secret Id for (Vault) App Role authentication (required when `vault-auth-method=approle`) |
+| vault-auth-jwt-path                 | The auth backend path for (Vault) JWT authentication (required when `vault-auth-method=jwt`) |
+| vault-auth-jwt-role                 | The role for (Vault) JWT authentication (required when `vault-auth-method=jwt`) |
+| vault-auth-jwt-audience             | The GitHub OIDC audience for (Vault) JWT authentication (required when `vault-auth-method=jwt`) |
 | vault-url                           | The URL for the Vault endpoint                                          |
 | skip-token-revoke                   | If truthy, the token will not be revoked when the current job is complete (optional) |
 | owner                               | The owner of the GitHub App installation (defaults to current repository owner, optional). |
 | repositories                        | Comma or newline-separated list of repositories for which the GitHub app token will be valid for(defaults to current repository if owner is unset, optional). If you want to generate a token that has access to all repositories of the owner, set this to `!all` and explicitely set an `owner`. |
 
-> (*) The above Vault properties only support App Role authentication (`vault-auth-method=approle`) for now. New inputs may be added in the future to support other authentication methods.
+> (*) Supports both App Role (`vault-auth-method=approle`) and GitHub OIDC/JWT
+> (`vault-auth-method=jwt`) authentication. When using `jwt`, the calling job
+> must grant `id-token: write` permission so GitHub can mint the OIDC token.
 
 ### Outputs
 | Output name      | Description                       |
@@ -53,6 +58,33 @@ jobs:
         skip-token-revoke: false  # Optional, defaults to false if omitted
         owner: ${{ github.repository_owner }}  # Optional, defaults to current repository owner
         repositories: ${{ github.repository }}  # Optional, defaults to current repository
+```
+
+#### Using GitHub OIDC/JWT authentication
+
+```yaml
+---
+name: example
+on:
+  pull_request:
+jobs:
+  configure-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # mint GitHub OIDC token for Vault JWT auth
+    steps:
+    - uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
+      with:
+        github-app-id-vault-key: THE_KEY_NAME_OF_THE_VAULT_SECRET_STORING_THE_APP_ID
+        github-app-id-vault-path: the/path/of/the/vault/secret/storing/the/app/id
+        github-app-private-key-vault-key: THE_KEY_NAME_OF_THE_VAULT_SECRET_STORING_THE_APP_PRIVATE_KEY
+        github-app-private-key-vault-path: the/path/of/the/vault/secret/storing/the/app/private/key
+        vault-auth-method: jwt
+        vault-auth-jwt-path: ${{ secrets.VAULT_JWT_PATH }}
+        vault-auth-jwt-role: ${{ secrets.VAULT_JWT_ROLE }}
+        vault-auth-jwt-audience: ${{ secrets.VAULT_JWT_AUDIENCE }}
+        vault-url: ${{ secrets.VAULT_ADDR }}
 ```
 
 ### Token Generation

--- a/generate-github-app-token-from-vault-secrets/action.yml
+++ b/generate-github-app-token-from-vault-secrets/action.yml
@@ -20,16 +20,33 @@ inputs:
     required: true
     type: string
   vault-auth-method:
-    description: The method to use to authenticate with Vault
+    description: The method to use to authenticate with Vault (`approle` or `jwt`)
     required: true
     type: string
   vault-auth-role-id:
-    description: The Role Id for (Vault) App Role authentication
-    required: true
+    description: The Role Id for (Vault) App Role authentication (required when `vault-auth-method` is `approle`)
+    required: false
+    default: ""
     type: string
   vault-auth-secret-id:
-    description: The Secret Id for (Vault) App Role authentication
-    required: true
+    description: The Secret Id for (Vault) App Role authentication (required when `vault-auth-method` is `approle`)
+    required: false
+    default: ""
+    type: string
+  vault-auth-jwt-path:
+    description: The auth backend path for (Vault) JWT authentication (required when `vault-auth-method` is `jwt`)
+    required: false
+    default: ""
+    type: string
+  vault-auth-jwt-role:
+    description: The role for (Vault) JWT authentication (required when `vault-auth-method` is `jwt`)
+    required: false
+    default: ""
+    type: string
+  vault-auth-jwt-audience:
+    description: The GitHub OIDC audience for (Vault) JWT authentication (required when `vault-auth-method` is `jwt`)
+    required: false
+    default: ""
     type: string
   vault-url:
     description: The URL for the Vault endpoint
@@ -65,6 +82,47 @@ outputs:
 runs:
   using: composite
   steps:
+  - name: Validate Vault authentication inputs
+    shell: bash
+    env:
+      VAULT_AUTH_METHOD: ${{ inputs.vault-auth-method }}
+      VAULT_AUTH_ROLE_ID: ${{ inputs.vault-auth-role-id }}
+      VAULT_AUTH_SECRET_ID: ${{ inputs.vault-auth-secret-id }}
+      VAULT_AUTH_JWT_PATH: ${{ inputs.vault-auth-jwt-path }}
+      VAULT_AUTH_JWT_ROLE: ${{ inputs.vault-auth-jwt-role }}
+      VAULT_AUTH_JWT_AUDIENCE: ${{ inputs.vault-auth-jwt-audience }}
+    run: |
+      missing=()
+      conflicting=()
+      case "${VAULT_AUTH_METHOD}" in
+        approle)
+          [[ -z "${VAULT_AUTH_ROLE_ID}" ]] && missing+=("vault-auth-role-id")
+          [[ -z "${VAULT_AUTH_SECRET_ID}" ]] && missing+=("vault-auth-secret-id")
+          [[ -n "${VAULT_AUTH_JWT_PATH}" ]] && conflicting+=("vault-auth-jwt-path")
+          [[ -n "${VAULT_AUTH_JWT_ROLE}" ]] && conflicting+=("vault-auth-jwt-role")
+          [[ -n "${VAULT_AUTH_JWT_AUDIENCE}" ]] && conflicting+=("vault-auth-jwt-audience")
+          ;;
+        jwt)
+          [[ -z "${VAULT_AUTH_JWT_PATH}" ]] && missing+=("vault-auth-jwt-path")
+          [[ -z "${VAULT_AUTH_JWT_ROLE}" ]] && missing+=("vault-auth-jwt-role")
+          [[ -z "${VAULT_AUTH_JWT_AUDIENCE}" ]] && missing+=("vault-auth-jwt-audience")
+          [[ -n "${VAULT_AUTH_ROLE_ID}" ]] && conflicting+=("vault-auth-role-id")
+          [[ -n "${VAULT_AUTH_SECRET_ID}" ]] && conflicting+=("vault-auth-secret-id")
+          ;;
+        *)
+          echo "::error::Unsupported vault-auth-method '${VAULT_AUTH_METHOD}' (expected 'approle' or 'jwt')"
+          exit 1
+          ;;
+      esac
+      if [[ ${#missing[@]} -gt 0 ]]; then
+        echo "::error::Missing required input(s) for vault-auth-method='${VAULT_AUTH_METHOD}': ${missing[*]}"
+        exit 1
+      fi
+      if [[ ${#conflicting[@]} -gt 0 ]]; then
+        echo "::error::Conflicting input(s) for vault-auth-method='${VAULT_AUTH_METHOD}': ${conflicting[*]} must not be set (provide only the inputs for the selected auth method)"
+        exit 1
+      fi
+
   - name: Import the GitHub App ID from vault
     id: app-id
     uses: hashicorp/vault-action@v4.0.0
@@ -73,6 +131,9 @@ runs:
       method: ${{ inputs.vault-auth-method }}
       roleId: ${{ inputs.vault-auth-role-id }}
       secretId: ${{ inputs.vault-auth-secret-id }}
+      path: ${{ inputs.vault-auth-jwt-path }}
+      role: ${{ inputs.vault-auth-jwt-role }}
+      jwtGithubAudience: ${{ inputs.vault-auth-jwt-audience }}
       exportEnv: false
       secrets: >
         ${{
@@ -91,6 +152,9 @@ runs:
       method: ${{ inputs.vault-auth-method }}
       roleId: ${{ inputs.vault-auth-role-id }}
       secretId: ${{ inputs.vault-auth-secret-id }}
+      path: ${{ inputs.vault-auth-jwt-path }}
+      role: ${{ inputs.vault-auth-jwt-role }}
+      jwtGithubAudience: ${{ inputs.vault-auth-jwt-audience }}
       exportEnv: false
       secrets: >
         ${{

--- a/rerun-failed-run/README.md
+++ b/rerun-failed-run/README.md
@@ -16,8 +16,12 @@ Retriggers failed GitHub Actions workflows, with optional error message filterin
 | `run-id` | Yes | - | Workflow run ID to retry |
 | `repository` | Yes | - | Repository in `owner/repo` format |
 | `vault-addr` | Yes | - | Vault URL |
-| `vault-role-id` | Yes | - | Vault role ID |
-| `vault-secret-id` | Yes | - | Vault secret ID |
+| `vault-auth-method` | No | `approle` | Vault auth method: `approle` or `jwt` |
+| `vault-role-id` | No | `''` | Vault role ID (required when `vault-auth-method=approle`) |
+| `vault-secret-id` | No | `''` | Vault secret ID (required when `vault-auth-method=approle`) |
+| `vault-jwt-path` | No | `''` | Vault JWT auth backend path (required when `vault-auth-method=jwt`) |
+| `vault-jwt-role` | No | `''` | Vault JWT role (required when `vault-auth-method=jwt`) |
+| `vault-jwt-audience` | No | `''` | GitHub OIDC audience (required when `vault-auth-method=jwt`) |
 | `error-messages` | No | `''` | Error messages to check for (one per line). Empty = retry immediately |
 | `notify-back-on-error` | No | `false` | Notify when errors don't match |
 | `rerun-whole-workflow` | No | `false` | Retry entire workflow vs failed jobs only |
@@ -47,6 +51,22 @@ Retriggers failed GitHub Actions workflows, with optional error message filterin
     vault-addr: ${{ secrets.VAULT_ADDR }}
     vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
     vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+```
+
+### Using GitHub OIDC/JWT authentication
+
+The calling job must grant `id-token: write` so GitHub can mint the OIDC token.
+
+```yaml
+- uses: camunda/infra-global-github-actions/rerun-failed-run@main
+  with:
+    run-id: ${{ github.run_id }}
+    repository: ${{ github.repository }}
+    vault-addr: ${{ secrets.VAULT_ADDR }}
+    vault-auth-method: jwt
+    vault-jwt-path: ${{ secrets.VAULT_JWT_PATH }}
+    vault-jwt-role: ${{ secrets.VAULT_JWT_ROLE }}
+    vault-jwt-audience: ${{ secrets.VAULT_JWT_AUDIENCE }}
 ```
 
 ## How It Works

--- a/rerun-failed-run/action.yml
+++ b/rerun-failed-run/action.yml
@@ -23,12 +23,30 @@ inputs:
   vault-addr:
     description: The Vault URL for fetching secrets
     required: true
+  vault-auth-method:
+    description: The method to use to authenticate with Vault (`approle` or `jwt`)
+    required: false
+    default: approle
   vault-role-id:
-    description: The Vault role ID for fetching secrets
-    required: true
+    description: The Vault role ID for fetching secrets (required when `vault-auth-method` is `approle`)
+    required: false
+    default: ""
   vault-secret-id:
-    description: The Vault secret ID for fetching secrets
-    required: true
+    description: The Vault secret ID for fetching secrets (required when `vault-auth-method` is `approle`)
+    required: false
+    default: ""
+  vault-jwt-path:
+    description: The auth backend path for (Vault) JWT authentication (required when `vault-auth-method` is `jwt`)
+    required: false
+    default: ""
+  vault-jwt-role:
+    description: The role for (Vault) JWT authentication (required when `vault-auth-method` is `jwt`)
+    required: false
+    default: ""
+  vault-jwt-audience:
+    description: The GitHub OIDC audience for (Vault) JWT authentication (required when `vault-auth-method` is `jwt`)
+    required: false
+    default: ""
   notify-back-on-error:
     description: |
       When the error message does not match the expected one,
@@ -47,14 +65,58 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Validate Vault authentication inputs
+      shell: bash
+      env:
+        VAULT_AUTH_METHOD: ${{ inputs.vault-auth-method }}
+        VAULT_ROLE_ID: ${{ inputs.vault-role-id }}
+        VAULT_SECRET_ID: ${{ inputs.vault-secret-id }}
+        VAULT_JWT_PATH: ${{ inputs.vault-jwt-path }}
+        VAULT_JWT_ROLE: ${{ inputs.vault-jwt-role }}
+        VAULT_JWT_AUDIENCE: ${{ inputs.vault-jwt-audience }}
+      run: |
+        missing=()
+        conflicting=()
+        case "${VAULT_AUTH_METHOD}" in
+          approle)
+            [[ -z "${VAULT_ROLE_ID}" ]] && missing+=("vault-role-id")
+            [[ -z "${VAULT_SECRET_ID}" ]] && missing+=("vault-secret-id")
+            [[ -n "${VAULT_JWT_PATH}" ]] && conflicting+=("vault-jwt-path")
+            [[ -n "${VAULT_JWT_ROLE}" ]] && conflicting+=("vault-jwt-role")
+            [[ -n "${VAULT_JWT_AUDIENCE}" ]] && conflicting+=("vault-jwt-audience")
+            ;;
+          jwt)
+            [[ -z "${VAULT_JWT_PATH}" ]] && missing+=("vault-jwt-path")
+            [[ -z "${VAULT_JWT_ROLE}" ]] && missing+=("vault-jwt-role")
+            [[ -z "${VAULT_JWT_AUDIENCE}" ]] && missing+=("vault-jwt-audience")
+            [[ -n "${VAULT_ROLE_ID}" ]] && conflicting+=("vault-role-id")
+            [[ -n "${VAULT_SECRET_ID}" ]] && conflicting+=("vault-secret-id")
+            ;;
+          *)
+            echo "::error::Unsupported vault-auth-method '${VAULT_AUTH_METHOD}' (expected 'approle' or 'jwt')"
+            exit 1
+            ;;
+        esac
+        if [[ ${#missing[@]} -gt 0 ]]; then
+          echo "::error::Missing required input(s) for vault-auth-method='${VAULT_AUTH_METHOD}': ${missing[*]}"
+          exit 1
+        fi
+        if [[ ${#conflicting[@]} -gt 0 ]]; then
+          echo "::error::Conflicting input(s) for vault-auth-method='${VAULT_AUTH_METHOD}': ${conflicting[*]} must not be set (provide only the inputs for the selected auth method)"
+          exit 1
+        fi
+
     - name: Import Secrets
       id: vault-secrets
       uses: hashicorp/vault-action@v4.0.0
       with:
         url: ${{ inputs.vault-addr }}
-        method: approle
+        method: ${{ inputs.vault-auth-method }}
         roleId: ${{ inputs.vault-role-id }}
         secretId: ${{ inputs.vault-secret-id }}
+        path: ${{ inputs.vault-jwt-path }}
+        role: ${{ inputs.vault-jwt-role }}
+        jwtGithubAudience: ${{ inputs.vault-jwt-audience }}
         secrets: |
           secret/data/products/infra/ci/retrigger-gha-workflow RETRIGGER_APP_ID;
           secret/data/products/infra/ci/retrigger-gha-workflow RETRIGGER_APP_KEY;


### PR DESCRIPTION
## Description

Related to https://github.com/camunda/team-infrastructure/issues/1035.

Adds GitHub OIDC/JWT authentication support to two Vault composite actions, alongside the existing AppRole method:

- `generate-github-app-token-from-vault-secrets`
- `rerun-failed-run`

This unblocks consumers migrating Vault auth from AppRole to GitHub OIDC/JWT.

Changes:
- New optional inputs for JWT auth (`*-jwt-path`, `*-jwt-role`, `*-jwt-audience`)
- Existing AppRole inputs made optional (kept working) → **backward compatible**
- `rerun-failed-run` gains a `vault-auth-method` input (defaults to `approle`)
- READMEs updated with JWT usage examples (note: callers must grant `id-token: write`)
