### PR TITLE
chore: ignore generated agentic workflows from actionlint

### DIFF
--- a/actionlint/custom/camunda/camunda/actionlint.yaml
+++ b/actionlint/custom/camunda/camunda/actionlint.yaml
@@ -30,3 +30,7 @@ config-variables: null
 paths:
 #  .github/workflows/**/*.yml:
 #    ignore: []
+  # Exclude generated agentic workflow lock files from linting
+  .github/workflows/*.lock.yml:
+    ignore:
+      - ".*"


### PR DESCRIPTION
Necessary because https://github.github.com/gh-aw/ generates GHA workflow YAML that we cannot influence and might break our best practices.