### PR TITLE
feat: add renovate-pr-maintainer action

### DIFF
--- a/renovate-pr-maintainer/README.md
+++ b/renovate-pr-maintainer/README.md
@@ -1,0 +1,114 @@
+# Renovate PR maintainer
+
+Keeps open [Renovate](https://docs.renovatebot.com/) PRs **fresh** and **unstuck** on
+repositories that adopt `rebaseWhen: "conflicted"`, without reintroducing the per-push
+"rebase storm" of Renovate's default `rebaseWhen: "behind-base-branch"`.
+
+Background and rationale: [camunda/team-infrastructure#1053](https://github.com/camunda/team-infrastructure/issues/1053).
+
+## Why
+
+With `rebaseWhen: "conflicted"`, Renovate stops rebasing PRs on every base-branch push — which
+saves a large amount of CI — but two things can regress on busy repositories:
+
+1. PRs drift far behind `main` and only get refreshed when they conflict.
+2. PRs that hit a flaky required check never get retried, so they stop auto-merging.
+
+This action runs on a schedule and, for each in-scope Renovate PR, takes the **minimum** action
+needed: request a one-off Renovate rebase for stale PRs, or re-run failed jobs (within a budget)
+for PRs whose required checks are red.
+
+## Decision model
+
+For every open, non-draft Renovate PR that does not carry an excluded label:
+
+| `mergeable_state` | Condition | Action |
+|:------------------|:----------|:-------|
+| `dirty` | merge conflict | **skip** — Renovate rebases conflicts itself |
+| `behind` | "require up to date" blocks merge | **rebase** |
+| `blocked` / `unstable` | a **required** check is failing, run attempt ≤ `rerun-budget` | **rerun** the failed run(s) |
+| `blocked` / `unstable` | no required rerun candidate, but PR is stale | **rebase** |
+| `clean` (and others) | PR is stale | **rebase** |
+| any | otherwise | **none** |
+
+"Stale" is the OR of two stateless signals, both reset by a rebase:
+
+```text
+behind_by >= behind-threshold   OR   age_since_head >= stale-hours
+```
+
+- **rebase** = add the Renovate `rebase` label. Renovate performs the real rebase on its next
+  run (re-running the package manager, regenerating lockfiles, pushing a fresh SHA). This action
+  **never pushes commits itself**.
+- **rerun** = re-run the failed workflow run(s) in place (increments
+  `run_attempt`, no new SHA). Only runs that produced a **failing required check** are
+  rerun: the action discovers required check contexts from the repository rulesets targeting
+  the PR base branch, finds failing required check-runs on the head SHA, and maps them to
+  their workflow runs via the shared check suite. Non-required (non-blocking) failures are
+  never rerun. The budget is derived from `run_attempt`, so a new head SHA naturally
+  refreshes it — no state is persisted.
+
+## Usage
+
+```yaml
+# .github/workflows/renovate-pr-maintainer.yml
+name: Renovate PR maintainer
+
+on:
+  schedule:
+    - cron: "0 6 * * *" # daily, off-peak; scheduled runs are always dry-run
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Run without modifying any PR"
+        type: boolean
+        default: true
+
+permissions:
+  issues: write        # apply the rebase label (Issues Labels API)
+  pull-requests: read  # read PR metadata / mergeable_state
+  actions: write       # re-run failed jobs
+  checks: read         # read check/run state
+  contents: read       # read compare/commit state
+
+jobs:
+  maintain:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: camunda/infra-global-github-actions/renovate-pr-maintainer@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Scheduled runs stay dry-run; manual runs honor the dispatch input.
+          dry-run: ${{ github.event_name == 'schedule' || inputs.dry-run }}
+```
+
+Going live is a deliberate, auditable action: trigger the workflow manually
+(`workflow_dispatch`) with `dry-run: false`. Scheduled runs never mutate PRs.
+
+## Inputs
+
+| Input | Default | Description |
+|:------|:--------|:------------|
+| `github-token` | — (required) | Token with `issues: write`, `pull-requests: read`, `actions: write`, `checks: read`, `contents: read`. |
+| `repository` | `${{ github.repository }}` | Target repository (`owner/name`). |
+| `renovate-author` | `renovate[bot]` | PR author login identifying Renovate PRs. |
+| `exclude-labels` | `keep-updated,stop-updating` | Comma-separated labels that take a PR out of scope. |
+| `behind-threshold` | `60` | Rebase when at least this many commits behind base (`B`). |
+| `stale-hours` | `24` | Rebase when the PR head is at least this many hours old (`C`). |
+| `rerun-budget` | `1` | Max workflow-run attempts per head SHA before reruns stop (`N`). |
+| `batch-size` | `10` | Max PRs acted on per run (blast-radius cap). |
+| `base-branch` | `""` | Optional exact base-branch filter; empty means all. |
+| `rebase-label` | `rebase` | Renovate one-off rebase label to apply. |
+| `dry-run` | `true` | When true, classify and log only; never modify any PR. |
+
+## Scope and limitations (v1)
+
+- **Rebases are requested via the Renovate `rebase` label, never `update-branch`.** This ensures
+  lockfiles are regenerated against the new base and CI is re-triggered by Renovate.
+- **Reruns are scoped to required checks discovered from rulesets.** Required contexts are read
+  from repository **rulesets** targeting the PR base branch (classic branch protection is not
+  inspected, mirroring the `wait-for-required-checks` action). On a repo with no matching
+  rulesets, no required checks are found and the action will not rerun anything — only the
+  staleness rebase path applies.
+- **No persisted state.** Both staleness and rerun budget are derived from GitHub data, so the
+  action is safe to run on any cadence and resets correctly on every new head SHA.

--- a/renovate-pr-maintainer/action.yml
+++ b/renovate-pr-maintainer/action.yml
@@ -1,0 +1,79 @@
+---
+name: Renovate PR maintainer
+description: >
+  Keeps open Renovate PRs fresh and unstuck on repositories that use
+  `rebaseWhen: "conflicted"`, without the per-push rebase storm of the default
+  Renovate behavior. On a schedule it inspects in-scope Renovate PRs and either
+  requests a one-off Renovate rebase (via the rebase label) for stale PRs, or
+  re-runs failed jobs (within a budget) for PRs whose required checks are red.
+
+inputs:
+  github-token:
+    description: >
+      Token used for all API calls. Needs `issues: write` (apply the rebase
+      label via the Issues Labels API), `actions: write` (re-run failed jobs),
+      `pull-requests: read`, `checks: read` and `contents: read` (read PR/commit/
+      compare state).
+    required: true
+  repository:
+    description: "Target repository (owner/name)."
+    required: false
+    default: ${{ github.repository }}
+  exclude-labels:
+    description: >
+      Comma-separated labels that take a PR out of scope. `keep-updated` is
+      excluded because Renovate already keeps those continuously rebased.
+    required: false
+    default: "keep-updated,stop-updating"
+  behind-threshold:
+    description: "Rebase when the PR is at least this many commits behind base (B)."
+    required: false
+    default: "60"
+  stale-hours:
+    description: "Rebase when the PR head is at least this many hours old (C)."
+    required: false
+    default: "24"
+  rerun-budget:
+    description: "Max workflow-run attempts per head SHA before reruns stop (N)."
+    required: false
+    default: "1"
+  batch-size:
+    description: "Max number of PRs acted on per run (blast-radius cap)."
+    required: false
+    default: "10"
+  base-branch:
+    description: "Optional exact base-branch filter; empty means all base branches."
+    required: false
+    default: ""
+  dry-run:
+    description: "When true, classify and log only; never modify any PR."
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Classify in-scope Renovate PRs (read-only)
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        REPOSITORY: ${{ inputs.repository }}
+        RENOVATE_AUTHOR: "renovate[bot]"
+        EXCLUDE_LABELS: ${{ inputs.exclude-labels }}
+        BEHIND_THRESHOLD: ${{ inputs.behind-threshold }}
+        STALE_HOURS: ${{ inputs.stale-hours }}
+        RERUN_BUDGET: ${{ inputs.rerun-budget }}
+        BASE_BRANCH: ${{ inputs.base-branch }}
+        PLAN_FILE: ${{ runner.temp }}/renovate-pr-maintainer-plan.json
+      run: bash "$GITHUB_ACTION_PATH/classify.sh"
+
+    - name: Apply maintenance plan
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        REPOSITORY: ${{ inputs.repository }}
+        BATCH_SIZE: ${{ inputs.batch-size }}
+        DRY_RUN: ${{ inputs.dry-run }}
+        REBASE_LABEL: "rebase"
+        PLAN_FILE: ${{ runner.temp }}/renovate-pr-maintainer-plan.json
+      run: bash "$GITHUB_ACTION_PATH/apply.sh"

--- a/renovate-pr-maintainer/apply.sh
+++ b/renovate-pr-maintainer/apply.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Apply the maintenance plan produced by classify.sh.
+#
+# This is the ONLY script that mutates PRs. When DRY_RUN=true it performs no
+# writes and only logs what it would do. Actionable items (rebase/rerun) are
+# capped at BATCH_SIZE per invocation as a blast-radius limiter.
+#
+# - rebase: add the Renovate rebase label; Renovate performs the actual rebase
+#           on its next run (regenerating lockfiles and pushing a fresh SHA).
+#           We never push commits ourselves.
+# - rerun:  re-run failed jobs of the failing workflow run(s) in place
+#           (increments run_attempt; no new SHA).
+set -euo pipefail
+
+: "${REPOSITORY:?REPOSITORY is required (owner/name)}"
+: "${PLAN_FILE:?PLAN_FILE is required}"
+BATCH_SIZE="${BATCH_SIZE:-10}"
+DRY_RUN="${DRY_RUN:-true}"
+REBASE_LABEL="${REBASE_LABEL:-rebase}"
+
+if [ ! -f "$PLAN_FILE" ]; then
+  echo "No plan file at ${PLAN_FILE}; nothing to do."
+  exit 0
+fi
+
+if [ "$DRY_RUN" = "true" ]; then
+  echo "DRY-RUN enabled: no PR will be modified."
+fi
+echo "Batch size: ${BATCH_SIZE}"
+
+applied=0
+while read -r item; do
+  [ -z "$item" ] && continue
+  action=$(echo "$item" | jq -r '.action')
+  num=$(echo "$item" | jq -r '.number')
+
+  case "$action" in
+    none|skip) continue ;;
+  esac
+
+  if [ "$applied" -ge "$BATCH_SIZE" ]; then
+    echo "Batch cap (${BATCH_SIZE}) reached; deferring remaining actions to the next run."
+    break
+  fi
+
+  case "$action" in
+    rebase)
+      if [ "$DRY_RUN" = "true" ]; then
+        echo "[dry-run] PR #${num}: would add '${REBASE_LABEL}' label"
+      else
+        if gh api -X POST "repos/${REPOSITORY}/issues/${num}/labels" \
+          -f "labels[]=${REBASE_LABEL}" >/dev/null 2>&1; then
+          echo "PR #${num}: added '${REBASE_LABEL}' label"
+        else
+          echo "::warning::PR #${num}: failed to add '${REBASE_LABEL}' label"
+        fi
+      fi
+      applied=$((applied + 1))
+      ;;
+    rerun)
+      mapfile -t rids < <(echo "$item" | jq -r '.run_ids[]')
+      for rid in "${rids[@]}"; do
+        [ -z "$rid" ] && continue
+        if [ "$DRY_RUN" = "true" ]; then
+          echo "[dry-run] PR #${num}: would rerun failed jobs of run ${rid}"
+        else
+          if gh api -X POST "repos/${REPOSITORY}/actions/runs/${rid}/rerun-failed-jobs" >/dev/null 2>&1; then
+            echo "PR #${num}: reran failed jobs of run ${rid}"
+          else
+            echo "::warning::PR #${num}: failed to rerun run ${rid}"
+          fi
+        fi
+      done
+      applied=$((applied + 1))
+      ;;
+    *)
+      echo "::warning::PR #${num}: unknown action '${action}', skipping"
+      ;;
+  esac
+done < <(jq -c '.[]' "$PLAN_FILE")
+
+echo "Actionable PRs processed this run: ${applied}"

--- a/renovate-pr-maintainer/classify.sh
+++ b/renovate-pr-maintainer/classify.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# Classify in-scope Renovate PRs into maintenance actions.
+#
+# This script is READ-ONLY: it never mutates any PR. It inspects each in-scope
+# Renovate PR and decides one of: skip / rerun / rebase / none, then writes a
+# JSON plan to $PLAN_FILE which apply.sh consumes.
+#
+# Decision model:
+#   - dirty (merge conflict)                   -> skip   (Renovate rebases conflicts itself)
+#   - behind                                   -> rebase (apply the rebase label)
+#   - blocked/unstable (required checks red)   -> rerun  if a failed run still has budget,
+#                                                 else rebase if stale, else none
+#   - clean                                    -> rebase if stale, else none
+#
+# Staleness is OR of two stateless signals, both reset by a rebase:
+#   behind_by >= BEHIND_THRESHOLD   OR   age_since_head >= STALE_HOURS
+set -euo pipefail
+
+: "${REPOSITORY:?REPOSITORY is required (owner/name)}"
+: "${PLAN_FILE:?PLAN_FILE is required}"
+RENOVATE_AUTHOR="${RENOVATE_AUTHOR:-renovate[bot]}"
+EXCLUDE_LABELS="${EXCLUDE_LABELS:-keep-updated,stop-updating}"
+BEHIND_THRESHOLD="${BEHIND_THRESHOLD:-60}"
+STALE_HOURS="${STALE_HOURS:-24}"
+RERUN_BUDGET="${RERUN_BUDGET:-1}"
+BASE_BRANCH="${BASE_BRANCH:-}"
+
+MAX_API_RETRIES=3
+API_RETRY_DELAY=5
+NOW_EPOCH=$(date -u +%s)
+
+# gh api with bounded retries on transient failures. Prints body on success.
+gh_api() {
+  local attempt=1 out rc
+  while [ "$attempt" -le "$MAX_API_RETRIES" ]; do
+    set +e
+    out=$(gh api "$@" 2>&1)
+    rc=$?
+    set -e
+    if [ "$rc" -eq 0 ]; then
+      printf '%s' "$out"
+      return 0
+    fi
+    echo "::warning::gh api $* failed (attempt ${attempt}/${MAX_API_RETRIES}, exit ${rc})" >&2
+    attempt=$((attempt + 1))
+    [ "$attempt" -le "$MAX_API_RETRIES" ] && sleep "$API_RETRY_DELAY"
+  done
+  return 1
+}
+
+# Required status check contexts for a base branch, discovered from repository
+# rulesets targeting that branch. Newline-separated, cached per base branch.
+# NOTE: only rulesets are inspected (not classic branch protection), mirroring
+# the wait-for-required-checks action.
+DEFAULT_BRANCH=$(gh_api "repos/${REPOSITORY}" --jq '.default_branch' 2>/dev/null || echo "")
+declare -A REQUIRED_CACHE
+required_checks_for_base() {
+  local base="$1"
+  if [ -n "${REQUIRED_CACHE[$base]+x}" ]; then
+    printf '%s' "${REQUIRED_CACHE[$base]}"
+    return 0
+  fi
+
+  local target="refs/heads/${base}" checks="" ids id ruleset
+  ids=$(gh_api "repos/${REPOSITORY}/rulesets?per_page=100" --paginate --jq '.[].id' 2>/dev/null || echo "")
+  while IFS= read -r id; do
+    [ -z "$id" ] && continue
+    ruleset=$(gh_api "repos/${REPOSITORY}/rulesets/${id}" 2>/dev/null || echo "")
+    [ -z "$ruleset" ] && continue
+
+    # Does this ruleset target the base branch? Handles GitHub's special refs
+    # `~ALL` (every branch) and `~DEFAULT_BRANCH`, plus glob includes like
+    # `refs/heads/stable/**`. Glob match avoids regex injection.
+    local matches=false include
+    while IFS= read -r include; do
+      [ -z "$include" ] && continue
+      if [ "$include" = "~ALL" ]; then
+        matches=true; break
+      fi
+      if [ "$include" = "~DEFAULT_BRANCH" ]; then
+        [ -n "$DEFAULT_BRANCH" ] && [ "$base" = "$DEFAULT_BRANCH" ] && { matches=true; break; }
+        continue
+      fi
+      # shellcheck disable=SC2254
+      case "$target" in
+        $include) matches=true; break ;;
+      esac
+    done < <(echo "$ruleset" | jq -r '.conditions.ref_name.include[]? // empty')
+
+    if [ "$matches" = true ]; then
+      local c
+      while IFS= read -r c; do
+        [ -n "$c" ] && checks="${checks}${c}"$'\n'
+      done < <(echo "$ruleset" | jq -r '.rules[]? | select(.type == "required_status_checks") | .parameters.required_status_checks[].context')
+    fi
+  done <<< "$ids"
+
+  checks=$(printf '%s' "$checks" | sort -u | grep -v '^$' || true)
+  REQUIRED_CACHE[$base]="$checks"
+  printf '%s' "$checks"
+}
+
+echo "Scanning open PRs in ${REPOSITORY} authored by '${RENOVATE_AUTHOR}'"
+echo "Thresholds: behind_by>=${BEHIND_THRESHOLD}, age>=${STALE_HOURS}h, rerun-budget=${RERUN_BUDGET}"
+[ -n "$BASE_BRANCH" ] && echo "Base-branch filter: ${BASE_BRANCH}"
+
+# List open PRs (the list endpoint omits mergeable_state, so we only collect
+# cheap metadata here and fetch mergeable_state per-PR below).
+pulls_ndjson=$(gh_api "repos/${REPOSITORY}/pulls?state=open&per_page=100" --paginate \
+  --jq '.[] | {number, draft, base: .base.ref, head_sha: .head.sha, user: .user.login, labels: [.labels[].name]}') \
+  || { echo "::error::failed to list pull requests for ${REPOSITORY}"; exit 1; }
+
+candidates=$(printf '%s\n' "$pulls_ndjson" | jq -s \
+  --arg author "$RENOVATE_AUTHOR" --arg excl "$EXCLUDE_LABELS" --arg base "$BASE_BRANCH" '
+  ($excl | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))) as $ex
+  | map(select(
+      .user == $author
+      and .draft == false
+      and (((.labels // []) - $ex) == (.labels // []))
+      and ($base == "" or .base == $base)
+    ))')
+
+candidate_count=$(echo "$candidates" | jq 'length')
+echo "In-scope Renovate PRs: ${candidate_count}"
+
+entries=()
+
+while read -r cand; do
+  [ -z "$cand" ] && continue
+  num=$(echo "$cand" | jq -r '.number')
+  base=$(echo "$cand" | jq -r '.base')
+  head_sha=$(echo "$cand" | jq -r '.head_sha')
+
+  # mergeable_state is computed asynchronously; re-poll once if still unknown.
+  pr=$(gh_api "repos/${REPOSITORY}/pulls/${num}") || { echo "::warning::skip PR #${num}: GET failed"; continue; }
+  ms=$(echo "$pr" | jq -r '.mergeable_state // "unknown"')
+  if [ "$ms" = "unknown" ]; then
+    sleep 3
+    pr=$(gh_api "repos/${REPOSITORY}/pulls/${num}") || true
+    ms=$(echo "$pr" | jq -r '.mergeable_state // "unknown"')
+  fi
+
+  # Staleness inputs (stateless; both reset by a rebase).
+  # URL-encode '/' in the base ref so base branches like `stable/8.7` don't break the path.
+  base_enc="${base//\//%2F}"
+  behind_by=$(gh_api "repos/${REPOSITORY}/compare/${base_enc}...${head_sha}" --jq '.behind_by' 2>/dev/null || echo 0)
+  [ -z "$behind_by" ] && behind_by=0
+  head_date=$(gh_api "repos/${REPOSITORY}/commits/${head_sha}" --jq '.commit.committer.date' 2>/dev/null || echo "")
+  if [ -n "$head_date" ]; then
+    head_epoch=$(date -u -d "$head_date" +%s 2>/dev/null || echo "$NOW_EPOCH")
+  else
+    head_epoch=$NOW_EPOCH
+  fi
+  age_hours=$(( (NOW_EPOCH - head_epoch) / 3600 ))
+
+  stale=false
+  if [ "$behind_by" -ge "$BEHIND_THRESHOLD" ] || [ "$age_hours" -ge "$STALE_HOURS" ]; then
+    stale=true
+  fi
+
+  # Rerun eligibility, scoped to REQUIRED checks only:
+  #   failing required check-run -> its check suite -> the workflow run that produced it.
+  # This avoids rerunning non-required (non-blocking) workflows.
+  required_checks=$(required_checks_for_base "$base")
+  required_json=$(printf '%s\n' "$required_checks" | jq -R . | jq -s 'map(select(length > 0))')
+  required_count=$(echo "$required_json" | jq 'length')
+
+  # Check suites on the head SHA that contain a failing REQUIRED check-run.
+  checkruns_ndjson=$(gh_api "repos/${REPOSITORY}/commits/${head_sha}/check-runs?per_page=100" --paginate \
+    --jq '.check_runs[] | {name, conclusion, suite: .check_suite.id}' 2>/dev/null || echo "")
+  failing_suites=$(printf '%s\n' "$checkruns_ndjson" | jq -s --argjson req "$required_json" \
+    '[.[] | select(.conclusion == "failure" and ((.name as $n | $req | index($n)) != null)) | .suite] | unique' 2>/dev/null || echo "[]")
+
+  # Workflow runs whose suite has a failing required check, still within rerun budget.
+  runs_ndjson=$(gh_api "repos/${REPOSITORY}/actions/runs?head_sha=${head_sha}&per_page=100" --paginate \
+    --jq '.workflow_runs[] | {id, run_attempt, suite: .check_suite_id}' 2>/dev/null || echo "")
+  eligible_ids=$(printf '%s\n' "$runs_ndjson" | jq -s --argjson n "$RERUN_BUDGET" --argjson suites "$failing_suites" \
+    '[.[] | select(((.suite as $s | $suites | index($s)) != null) and .run_attempt <= $n) | .id] | unique' 2>/dev/null || echo "[]")
+  eligible_count=$(echo "$eligible_ids" | jq 'length' 2>/dev/null || echo 0)
+
+  action="none"
+  reason=""
+  case "$ms" in
+    dirty)
+      action="skip"; reason="merge conflict; Renovate owns the rebase" ;;
+    behind)
+      action="rebase"; reason="behind base (require-up-to-date blocks merge)" ;;
+    blocked|unstable)
+      if [ "$eligible_count" -gt 0 ]; then
+        action="rerun"; reason="failing required checks; rerun ${eligible_count} run(s) (budget left)"
+      elif [ "$stale" = "true" ]; then
+        action="rebase"; reason="checks failing, no required rerun left, stale -> fresh SHA"
+      else
+        action="none"; reason="checks failing, no required rerun candidate, not stale"
+      fi ;;
+    *)
+      if [ "$stale" = "true" ]; then
+        action="rebase"; reason="stale (behind_by>=${BEHIND_THRESHOLD} or age>=${STALE_HOURS}h)"
+      else
+        action="none"; reason="fresh & green"
+      fi ;;
+  esac
+
+  echo "PR #${num} [${ms}] behind_by=${behind_by} age=${age_hours}h required=${required_count} -> ${action} (${reason})"
+
+  entry=$(jq -nc \
+    --argjson num "$num" \
+    --arg state "$ms" \
+    --arg action "$action" \
+    --arg reason "$reason" \
+    --argjson rids "$eligible_ids" \
+    --argjson behind "$behind_by" \
+    --argjson age "$age_hours" \
+    '{number: $num, state: $state, action: $action, reason: $reason, run_ids: $rids, behind_by: $behind, age_hours: $age}')
+  entries+=("$entry")
+done < <(echo "$candidates" | jq -c '.[]')
+
+if [ "${#entries[@]}" -gt 0 ]; then
+  printf '%s\n' "${entries[@]}" | jq -s '.' > "$PLAN_FILE"
+else
+  echo '[]' > "$PLAN_FILE"
+fi
+
+# Optional human-readable summary.
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo "### Renovate PR maintainer — plan"
+    echo ""
+    echo "| PR | state | behind_by | age (h) | action | reason |"
+    echo "|---:|:------|----------:|--------:|:-------|:-------|"
+    jq -r '.[] | "| #\(.number) | \(.state) | \(.behind_by) | \(.age_hours) | \(.action) | \(.reason) |"' "$PLAN_FILE"
+  } >> "$GITHUB_STEP_SUMMARY"
+fi
+
+echo "Plan written to ${PLAN_FILE}"


### PR DESCRIPTION
# Description

Adds `renovate-pr-maintainer`, a composite action that keeps open Renovate PRs **fresh** and **unstuck** on repositories using `rebaseWhen: "conflicted"` — without the per-push rebase storm of Renovate's default behavior.

On a schedule it classifies each in-scope Renovate PR via GitHub's `mergeable_state` plus how far behind / how old it is, then takes the minimum action:

- **stale PR** → request a one-off Renovate rebase (apply the `rebase` label; Renovate regenerates lockfiles and pushes a fresh SHA — the action never pushes commits itself, and never uses `update-branch`).
- **failing required checks** → re-run failed jobs within a per-SHA budget, to absorb CI flakiness.

Read-only by default (**dry-run**): scheduled runs never mutate PRs; going live is a deliberate manual `workflow_dispatch`. Fully stateless — both staleness and the rerun budget are derived from GitHub data.

Validated with `shellcheck` and an end-to-end mock-`gh` test exercising every decision branch.

Related:
- camunda/team-infrastructure#1053