### PR TITLE
feat(renovate-pr-maintainer): faster, safer, and tunable PR maintenance

### DIFF
--- a/renovate-pr-maintainer/README.md
+++ b/renovate-pr-maintainer/README.md
@@ -91,7 +91,6 @@ Going live is a deliberate, auditable action: trigger the workflow manually
 |:------|:--------|:------------|
 | `github-token` | — (required) | Token with `pull-requests: write`, `actions: write`, `checks: read`, `contents: read`. Labeling a PR via the Issues Labels API is authorized by the `pull-requests` scope, not `issues`. |
 | `repository` | `${{ github.repository }}` | Target repository (`owner/name`). |
-| `renovate-author` | `renovate[bot]` | PR author login identifying Renovate PRs. |
 | `exclude-labels` | `keep-updated,stop-updating` | Comma-separated labels that take a PR out of scope. |
 | `behind-threshold` | `60` | Rebase when at least this many commits behind base (`B`). |
 | `stale-hours` | `24` | Rebase when the PR head is at least this many hours old (`C`). |
@@ -101,8 +100,7 @@ Going live is a deliberate, auditable action: trigger the workflow manually
 | `extra-trusted-logins` | `""` | Comma- or newline-separated extra logins (author/committer) treated as Renovate-owned, so trusted bots like `github-actions[bot]` don't mark a branch as human-edited. |
 | `extra-rerun-checks` | `""` | Comma- or newline-separated check-run names to also treat as required for the rerun decision (unioned with ruleset-discovered checks). Use to retry a non-required/flaky check or one enforced via classic branch protection. |
 | `require-up-to-date` | `false` | Treat the `behind` state ("require branches up to date") as a merge blocker and rebase immediately. When `false`, that signal is ignored and behind PRs are decided by staleness. |
-| `rebase-label` | `rebase` | Renovate one-off rebase label to apply. |
-| `dry-run` | `true` | When true, classify and log only; never modify any PR. |
+| `dry-run` | `false` | When true, classify and log only; never modify any PR. |
 
 ## Scope and limitations (v1)
 

--- a/renovate-pr-maintainer/README.md
+++ b/renovate-pr-maintainer/README.md
@@ -25,7 +25,8 @@ For every open, non-draft Renovate PR that does not carry an excluded label:
 | `mergeable_state` | Condition | Action |
 |:------------------|:----------|:-------|
 | `dirty` | merge conflict | **skip** — Renovate rebases conflicts itself |
-| `behind` | "require up to date" blocks merge | **rebase** |
+| `behind` | "require up to date" blocks merge — with `require-up-to-date: true` | **rebase** |
+| `behind` | with `require-up-to-date: false` (default) | decided by staleness/rerun, like `blocked`/`unstable` |
 | `blocked` / `unstable` | a **required** check is failing, run attempt ≤ `rerun-budget` | **rerun** the failed run(s) |
 | `blocked` / `unstable` | no required rerun candidate, but PR is stale | **rebase** |
 | `clean` (and others) | PR is stale | **rebase** |
@@ -45,8 +46,8 @@ behind_by >= behind-threshold   OR   age_since_head >= stale-hours
   rerun: the action discovers required check contexts from the repository rulesets targeting
   the PR base branch, finds failing required check-runs on the head SHA, and maps them to
   their workflow runs via the shared check suite. Non-required (non-blocking) failures are
-  never rerun. The budget is derived from `run_attempt`, so a new head SHA naturally
-  refreshes it — no state is persisted.
+  never rerun unless their check name is listed in `extra-rerun-checks`. The budget is
+  derived from `run_attempt`, so a new head SHA naturally refreshes it — no state is persisted.
 
 ## Usage
 
@@ -95,9 +96,12 @@ Going live is a deliberate, auditable action: trigger the workflow manually
 | `exclude-labels` | `keep-updated,stop-updating` | Comma-separated labels that take a PR out of scope. |
 | `behind-threshold` | `60` | Rebase when at least this many commits behind base (`B`). |
 | `stale-hours` | `24` | Rebase when the PR head is at least this many hours old (`C`). |
-| `rerun-budget` | `1` | Max workflow-run attempts per head SHA before reruns stop (`N`). |
+| `rerun-budget` | `0` | Max workflow-run attempts per head SHA before reruns stop (`N`). `0` (default) disables reruns; set to `1`+ to enable. |
 | `batch-size` | `10` | Max PRs acted on per run (blast-radius cap). |
 | `base-branch` | `""` | Optional exact base-branch filter; empty means all. |
+| `extra-trusted-logins` | `""` | Comma- or newline-separated extra logins (author/committer) treated as Renovate-owned, so trusted bots like `github-actions[bot]` don't mark a branch as human-edited. |
+| `extra-rerun-checks` | `""` | Comma- or newline-separated check-run names to also treat as required for the rerun decision (unioned with ruleset-discovered checks). Use to retry a non-required/flaky check or one enforced via classic branch protection. |
+| `require-up-to-date` | `false` | Treat the `behind` state ("require branches up to date") as a merge blocker and rebase immediately. When `false`, that signal is ignored and behind PRs are decided by staleness. |
 | `rebase-label` | `rebase` | Renovate one-off rebase label to apply. |
 | `dry-run` | `true` | When true, classify and log only; never modify any PR. |
 

--- a/renovate-pr-maintainer/README.md
+++ b/renovate-pr-maintainer/README.md
@@ -66,11 +66,10 @@ on:
         default: true
 
 permissions:
-  issues: write        # apply the rebase label (Issues Labels API)
-  pull-requests: read  # read PR metadata / mergeable_state
-  actions: write       # re-run failed jobs
-  checks: read         # read check/run state
-  contents: read       # read compare/commit state
+  pull-requests: write  # apply the rebase label + read PR metadata / mergeable_state
+  actions: write        # re-run failed jobs
+  checks: read          # read check/run state
+  contents: read        # read compare/commit state
 
 jobs:
   maintain:
@@ -90,7 +89,7 @@ Going live is a deliberate, auditable action: trigger the workflow manually
 
 | Input | Default | Description |
 |:------|:--------|:------------|
-| `github-token` | — (required) | Token with `issues: write`, `pull-requests: read`, `actions: write`, `checks: read`, `contents: read`. |
+| `github-token` | — (required) | Token with `pull-requests: write`, `actions: write`, `checks: read`, `contents: read`. Labeling a PR via the Issues Labels API is authorized by the `pull-requests` scope, not `issues`. |
 | `repository` | `${{ github.repository }}` | Target repository (`owner/name`). |
 | `renovate-author` | `renovate[bot]` | PR author login identifying Renovate PRs. |
 | `exclude-labels` | `keep-updated,stop-updating` | Comma-separated labels that take a PR out of scope. |

--- a/renovate-pr-maintainer/README.md
+++ b/renovate-pr-maintainer/README.md
@@ -1,89 +1,46 @@
 # Renovate PR maintainer
 
-Keeps open [Renovate](https://docs.renovatebot.com/) PRs **fresh** and **unstuck** on
-repositories that adopt `rebaseWhen: "conflicted"`, without reintroducing the per-push
-"rebase storm" of Renovate's default `rebaseWhen: "behind-base-branch"`.
-
-Background and rationale: [camunda/team-infrastructure#1053](https://github.com/camunda/team-infrastructure/issues/1053).
-
-## Why
-
-With `rebaseWhen: "conflicted"`, Renovate stops rebasing PRs on every base-branch push — which
-saves a large amount of CI — but two things can regress on busy repositories:
-
-1. PRs drift far behind `main` and only get refreshed when they conflict.
-2. PRs that hit a flaky required check never get retried, so they stop auto-merging.
-
-This action runs on a schedule and, for each in-scope Renovate PR, takes the **minimum** action
-needed: request a one-off Renovate rebase for stale PRs, or re-run failed jobs (within a budget)
-for PRs whose required checks are red.
+Keeps open [Renovate](https://docs.renovatebot.com/) PRs fresh and unstuck on repositories using `rebaseWhen: "conflicted"` by taking the **minimum** action per PR — rebase stale PRs (via the Renovate `rebase` label) or re-run failed required jobs (within a budget). Background: [camunda/team-infrastructure#1053](https://github.com/camunda/team-infrastructure/issues/1053).
 
 ## Decision model
 
-For every open, non-draft Renovate PR that does not carry an excluded label:
+```mermaid
+stateDiagram-v2
+    state "head-ownership check" as owned
+    state "blocked / unstable" as red
+    state "clean / has_hooks" as green
 
-| `mergeable_state` | Condition | Action |
-|:------------------|:----------|:-------|
-| `dirty` | merge conflict | **skip** — Renovate rebases conflicts itself |
-| `behind` | "require up to date" blocks merge — with `require-up-to-date: true` | **rebase** |
-| `behind` | with `require-up-to-date: false` (default) | decided by staleness/rerun, like `blocked`/`unstable` |
-| `blocked` / `unstable` | a **required** check is failing, run attempt ≤ `rerun-budget` | **rerun** the failed run(s) |
-| `blocked` / `unstable` | no required rerun candidate, but PR is stale | **rebase** |
-| `clean` (and others) | PR is stale | **rebase** |
-| any | otherwise | **none** |
+    [*] --> classify: in-scope Renovate PR
 
-"Stale" is the OR of two stateless signals, both reset by a rebase:
+    classify --> report: carries rebase label
+    classify --> skip: dirty (merge conflict)
+    classify --> none: unknown (mergeability pending)
+    classify --> owned: behind / blocked / unstable / clean
 
-```text
-behind_by >= behind-threshold   OR   age_since_head >= stale-hours
+    owned --> skip: head edited by a human
+    owned --> behind: behind
+    owned --> red: blocked / unstable
+    owned --> green: clean / has_hooks
+
+    behind --> rebase: require-up-to-date = true
+    behind --> red: require-up-to-date = false
+
+    red --> rebase: stale
+    red --> rerun: else, required check failing & attempt ≤ rerun-budget
+    red --> none: otherwise
+
+    green --> rebase: stale
+    green --> none: fresh
+
+    note right of green
+        stale = behind_by ≥ behind-threshold
+                OR head age ≥ stale-hours
+    end note
 ```
 
-- **rebase** = add the Renovate `rebase` label. Renovate performs the real rebase on its next
-  run (re-running the package manager, regenerating lockfiles, pushing a fresh SHA). This action
-  **never pushes commits itself**.
-- **rerun** = re-run the failed workflow run(s) in place (increments
-  `run_attempt`, no new SHA). Only runs that produced a **failing required check** are
-  rerun: the action discovers required check contexts from the repository rulesets targeting
-  the PR base branch, finds failing required check-runs on the head SHA, and maps them to
-  their workflow runs via the shared check suite. Non-required (non-blocking) failures are
-  never rerun unless their check name is listed in `extra-rerun-checks`. The budget is
-  derived from `run_attempt`, so a new head SHA naturally refreshes it — no state is persisted.
-
-## Usage
-
-```yaml
-# .github/workflows/renovate-pr-maintainer.yml
-name: Renovate PR maintainer
-
-on:
-  schedule:
-    - cron: "0 6 * * *" # daily, off-peak; scheduled runs are always dry-run
-  workflow_dispatch:
-    inputs:
-      dry-run:
-        description: "Run without modifying any PR"
-        type: boolean
-        default: true
-
-permissions:
-  pull-requests: write  # apply the rebase label + read PR metadata / mergeable_state
-  actions: write        # re-run failed jobs
-  checks: read          # read check/run state
-  contents: read        # read compare/commit state
-
-jobs:
-  maintain:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: camunda/infra-global-github-actions/renovate-pr-maintainer@main
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          # Scheduled runs stay dry-run; manual runs honor the dispatch input.
-          dry-run: ${{ github.event_name == 'schedule' || inputs.dry-run }}
-```
-
-Going live is a deliberate, auditable action: trigger the workflow manually
-(`workflow_dispatch`) with `dry-run: false`. Scheduled runs never mutate PRs.
+- **rebase** — add the Renovate `rebase` label; Renovate does the real rebase (regenerates lockfiles, pushes a fresh SHA). This action never pushes commits.
+- **rerun** — re-run the failed required workflow run(s) in place, no new SHA; budget derives from `run_attempt`.
+- **skip · report · none** — no mutation (left for Renovate, a human, or the next run).
 
 ## Inputs
 
@@ -101,15 +58,3 @@ Going live is a deliberate, auditable action: trigger the workflow manually
 | `extra-rerun-checks` | `""` | Comma- or newline-separated check-run names to also treat as required for the rerun decision (unioned with ruleset-discovered checks). Use to retry a non-required/flaky check or one enforced via classic branch protection. |
 | `require-up-to-date` | `false` | Treat the `behind` state ("require branches up to date") as a merge blocker and rebase immediately. When `false`, that signal is ignored and behind PRs are decided by staleness. |
 | `dry-run` | `false` | When true, classify and log only; never modify any PR. |
-
-## Scope and limitations (v1)
-
-- **Rebases are requested via the Renovate `rebase` label, never `update-branch`.** This ensures
-  lockfiles are regenerated against the new base and CI is re-triggered by Renovate.
-- **Reruns are scoped to required checks discovered from rulesets.** Required contexts are read
-  from repository **rulesets** targeting the PR base branch (classic branch protection is not
-  inspected, mirroring the `wait-for-required-checks` action). On a repo with no matching
-  rulesets, no required checks are found and the action will not rerun anything — only the
-  staleness rebase path applies.
-- **No persisted state.** Both staleness and rerun budget are derived from GitHub data, so the
-  action is safe to run on any cadence and resets correctly on every new head SHA.

--- a/renovate-pr-maintainer/action.yml
+++ b/renovate-pr-maintainer/action.yml
@@ -10,10 +10,10 @@ description: >
 inputs:
   github-token:
     description: >
-      Token used for all API calls. Needs `issues: write` (apply the rebase
-      label via the Issues Labels API), `actions: write` (re-run failed jobs),
-      `pull-requests: read`, `checks: read` and `contents: read` (read PR/commit/
-      compare state).
+      Token used for all API calls. Needs `pull-requests: write` (apply the
+      rebase label; labeling a PR via the Issues Labels API is authorized by the
+      PR scope, not `issues`), `actions: write` (re-run failed jobs), and
+      `checks: read` + `contents: read` (read PR/commit/compare state).
     required: true
   repository:
     description: "Target repository (owner/name)."

--- a/renovate-pr-maintainer/action.yml
+++ b/renovate-pr-maintainer/action.yml
@@ -64,6 +64,7 @@ runs:
         STALE_HOURS: ${{ inputs.stale-hours }}
         RERUN_BUDGET: ${{ inputs.rerun-budget }}
         BASE_BRANCH: ${{ inputs.base-branch }}
+        REBASE_LABEL: "rebase"
         PLAN_FILE: ${{ runner.temp }}/renovate-pr-maintainer-plan.json
       run: bash "$GITHUB_ACTION_PATH/classify.sh"
 

--- a/renovate-pr-maintainer/action.yml
+++ b/renovate-pr-maintainer/action.yml
@@ -34,9 +34,12 @@ inputs:
     required: false
     default: "24"
   rerun-budget:
-    description: "Max workflow-run attempts per head SHA before reruns stop (N)."
+    description: >
+      Max workflow-run attempts per head SHA before reruns stop (N). 0 (the
+      default) disables reruns entirely; set to 1+ to re-run failed required
+      jobs within that per-SHA budget.
     required: false
-    default: "1"
+    default: "0"
   batch-size:
     description: "Max number of PRs acted on per run (blast-radius cap)."
     required: false
@@ -45,6 +48,34 @@ inputs:
     description: "Optional exact base-branch filter; empty means all base branches."
     required: false
     default: ""
+  extra-trusted-logins:
+    description: >
+      Comma- or newline-separated extra GitHub logins (author or committer) to
+      treat as Renovate-owned when detecting human-edited branches. Renovate's
+      own author and GitHub's signing committer (web-flow) are always trusted;
+      add logins here when trusted automation pushes follow-up commits to
+      Renovate branches under another identity (e.g. github-actions[bot]), so
+      those PRs are not skipped as edited.
+    required: false
+    default: ""
+  extra-rerun-checks:
+    description: >
+      Comma- or newline-separated check-run names to also treat as required when
+      deciding whether to rerun a failing PR, unioned with the contexts
+      discovered from rulesets. Use this to retry a check that is not a required
+      status check (e.g. a flaky job) or one enforced via classic branch
+      protection, which this action does not read. These are check-run names (the
+      job/context), not workflow names.
+    required: false
+    default: ""
+  require-up-to-date:
+    description: >
+      When true, treat the `behind` mergeable_state ("Require branches to be up
+      to date before merging") as a hard merge blocker and rebase the PR
+      immediately. When false (default), that signal is ignored and a behind PR
+      is decided purely by staleness, like any other PR.
+    required: false
+    default: "false"
   dry-run:
     description: "When true, classify and log only; never modify any PR."
     required: false
@@ -64,6 +95,9 @@ runs:
         STALE_HOURS: ${{ inputs.stale-hours }}
         RERUN_BUDGET: ${{ inputs.rerun-budget }}
         BASE_BRANCH: ${{ inputs.base-branch }}
+        REQUIRE_UP_TO_DATE: ${{ inputs.require-up-to-date }}
+        EXTRA_TRUSTED_LOGINS: ${{ inputs.extra-trusted-logins }}
+        EXTRA_RERUN_CHECKS: ${{ inputs.extra-rerun-checks }}
         REBASE_LABEL: "rebase"
         PLAN_FILE: ${{ runner.temp }}/renovate-pr-maintainer-plan.json
       run: bash "$GITHUB_ACTION_PATH/classify.sh"

--- a/renovate-pr-maintainer/apply.sh
+++ b/renovate-pr-maintainer/apply.sh
@@ -22,13 +22,11 @@ REBASE_LABEL="${REBASE_LABEL:-rebase}"
 MAX_API_RETRIES="${MAX_API_RETRIES:-3}"
 API_RETRY_DELAY="${API_RETRY_DELAY:-5}"
 
-# gh api write (POST ...) with bounded retries on transient failures, mirroring
-# classify.sh's gh_api. Retrying a write here is safe: re-adding the rebase label
-# is a no-op, and a rerun whose first POST already took effect just gets a 4xx on
-# retry (the run is no longer "completed"), so retries never double-act. On
-# success returns 0 and prints nothing; on final failure prints the last gh error
-# body to stdout and returns 1 so the caller can surface the reason. Per-attempt
-# failures are logged to stderr.
+# gh api write (POST) with bounded retries, mirroring classify.sh's gh_api.
+# Retrying is safe: re-adding the rebase label is a no-op, and a rerun whose POST
+# already took effect just 4xxs on retry, so writes never double-act. Returns 0
+# and prints nothing on success; on final failure prints the last gh error body
+# to stdout (per-attempt warnings go to stderr) so the caller can surface it.
 gh_api_write() {
   local attempt=1 out rc
   while [ "$attempt" -le "$MAX_API_RETRIES" ]; do

--- a/renovate-pr-maintainer/apply.sh
+++ b/renovate-pr-maintainer/apply.sh
@@ -10,6 +10,8 @@
 #           We never push commits ourselves.
 # - rerun:  re-run failed jobs of the failing workflow run(s) in place
 #           (increments run_attempt; no new SHA).
+# - none/skip/pending: no-op (pending = a rebase is already queued on the PR and
+#           awaiting Renovate, so the maintainer deliberately does nothing).
 set -euo pipefail
 
 : "${REPOSITORY:?REPOSITORY is required (owner/name)}"
@@ -35,7 +37,7 @@ while read -r item; do
   num=$(echo "$item" | jq -r '.number')
 
   case "$action" in
-    none|skip) continue ;;
+    none|skip|pending) continue ;;
   esac
 
   if [ "$applied" -ge "$BATCH_SIZE" ]; then

--- a/renovate-pr-maintainer/apply.sh
+++ b/renovate-pr-maintainer/apply.sh
@@ -19,6 +19,31 @@ set -euo pipefail
 BATCH_SIZE="${BATCH_SIZE:-10}"
 DRY_RUN="${DRY_RUN:-true}"
 REBASE_LABEL="${REBASE_LABEL:-rebase}"
+MAX_API_RETRIES="${MAX_API_RETRIES:-3}"
+API_RETRY_DELAY="${API_RETRY_DELAY:-5}"
+
+# gh api write (POST ...) with bounded retries on transient failures, mirroring
+# classify.sh's gh_api. Retrying a write here is safe: re-adding the rebase label
+# is a no-op, and a rerun whose first POST already took effect just gets a 4xx on
+# retry (the run is no longer "completed"), so retries never double-act. On
+# success returns 0 and prints nothing; on final failure prints the last gh error
+# body to stdout and returns 1 so the caller can surface the reason. Per-attempt
+# failures are logged to stderr.
+gh_api_write() {
+  local attempt=1 out rc
+  while [ "$attempt" -le "$MAX_API_RETRIES" ]; do
+    set +e
+    out=$(gh api "$@" 2>&1)
+    rc=$?
+    set -e
+    [ "$rc" -eq 0 ] && return 0
+    echo "::warning::gh api $* failed (attempt ${attempt}/${MAX_API_RETRIES}, exit ${rc})" >&2
+    attempt=$((attempt + 1))
+    [ "$attempt" -le "$MAX_API_RETRIES" ] && sleep "$API_RETRY_DELAY"
+  done
+  printf '%s' "$out"
+  return 1
+}
 
 if [ ! -f "$PLAN_FILE" ]; then
   echo "No plan file at ${PLAN_FILE}; nothing to do."
@@ -50,11 +75,11 @@ while read -r item; do
       if [ "$DRY_RUN" = "true" ]; then
         echo "[dry-run] PR #${num}: would add '${REBASE_LABEL}' label"
       else
-        if gh api -X POST "repos/${REPOSITORY}/issues/${num}/labels" \
-          -f "labels[]=${REBASE_LABEL}" >/dev/null 2>&1; then
+        if err=$(gh_api_write -X POST "repos/${REPOSITORY}/issues/${num}/labels" \
+          -f "labels[]=${REBASE_LABEL}"); then
           echo "PR #${num}: added '${REBASE_LABEL}' label"
         else
-          echo "::warning::PR #${num}: failed to add '${REBASE_LABEL}' label"
+          echo "::warning::PR #${num}: failed to add '${REBASE_LABEL}' label: ${err}"
         fi
       fi
       applied=$((applied + 1))
@@ -66,10 +91,10 @@ while read -r item; do
         if [ "$DRY_RUN" = "true" ]; then
           echo "[dry-run] PR #${num}: would rerun failed jobs of run ${rid}"
         else
-          if gh api -X POST "repos/${REPOSITORY}/actions/runs/${rid}/rerun-failed-jobs" >/dev/null 2>&1; then
+          if err=$(gh_api_write -X POST "repos/${REPOSITORY}/actions/runs/${rid}/rerun-failed-jobs"); then
             echo "PR #${num}: reran failed jobs of run ${rid}"
           else
-            echo "::warning::PR #${num}: failed to rerun run ${rid}"
+            echo "::warning::PR #${num}: failed to rerun run ${rid}: ${err}"
           fi
         fi
       done

--- a/renovate-pr-maintainer/classify.sh
+++ b/renovate-pr-maintainer/classify.sh
@@ -30,6 +30,17 @@ BASE_BRANCH="${BASE_BRANCH:-}"
 # on busy repos; poll a few times with backoff before giving up.
 MERGEABLE_MAX_POLLS="${MERGEABLE_MAX_POLLS:-5}"
 MERGEABLE_POLL_DELAY="${MERGEABLE_POLL_DELAY:-3}"
+# Per-PR classification is independent across PRs, so we fan out with a bounded
+# worker pool. Workers are bash forks that inherit the pre-warmed REQUIRED_CACHE
+# (read-only), so concurrency adds no extra ruleset discovery. Tunable; set to 1
+# to force fully serial execution.
+CLASSIFY_CONCURRENCY="${CLASSIFY_CONCURRENCY:-8}"
+# Guard against bad overrides: a non-integer or < 1 value would make the numeric
+# throttle test below fail under `set -e` or spin forever. Coerce to an int >= 1.
+if ! [[ "$CLASSIFY_CONCURRENCY" =~ ^[0-9]+$ ]] || [ "$CLASSIFY_CONCURRENCY" -lt 1 ]; then
+  echo "::warning::invalid CLASSIFY_CONCURRENCY='${CLASSIFY_CONCURRENCY}'; falling back to 1" >&2
+  CLASSIFY_CONCURRENCY=1
+fi
 
 MAX_API_RETRIES=3
 API_RETRY_DELAY=5
@@ -212,8 +223,13 @@ compute_rerun_eligibility() {
 
 entries=()
 
-while read -r cand; do
-  [ -z "$cand" ] && continue
+# Classify a single candidate PR and write its plan entry (one JSON object) to
+# <out_file>. Progress is logged to stderr. Designed to run as a background
+# worker: it only reads the pre-warmed REQUIRED_CACHE, never writes it, so it is
+# safe to fork. A PR that fails its initial GET writes nothing (skipped).
+classify_one_pr() {
+  local cand="$1" out_file="$2"
+  local num base head_sha ms
   num=$(echo "$cand" | jq -r '.number')
   base=$(echo "$cand" | jq -r '.base')
   head_sha=$(echo "$cand" | jq -r '.head_sha')
@@ -221,7 +237,7 @@ while read -r cand; do
   # mergeable_state is computed asynchronously and reset by base pushes; poll
   # with backoff. A residual "unknown" is handled conservatively in the case
   # statement below (deferred, never acted on).
-  ms=$(mergeable_state_for_pr "$num") || { echo "::warning::skip PR #${num}: GET failed"; continue; }
+  ms=$(mergeable_state_for_pr "$num") || { echo "::warning::skip PR #${num}: GET failed" >&2; return 0; }
 
   # Per-PR diagnostic/plan fields. Defaulted here, then filled lazily by the
   # case below — we only fetch what each state's decision actually needs:
@@ -232,15 +248,8 @@ while read -r cand; do
   # dirty/behind/unknown have a fixed action and fetch nothing further.
   # apply.sh consumes only number/action/run_ids, so the defaulted diagnostic
   # fields (behind_by/age_hours) on fixed-action states are cosmetic, not load-bearing.
-  behind_by=0
-  age_hours=0
-  required_count=0
-  eligible_ids="[]"
-  eligible_count=0
-  stale=false
-
-  action="none"
-  reason=""
+  local behind_by=0 age_hours=0 required_count=0 eligible_ids="[]" eligible_count=0 stale=false
+  local action="none" reason=""
   case "$ms" in
     dirty)
       action="skip"; reason="merge conflict; Renovate owns the rebase" ;;
@@ -273,9 +282,9 @@ while read -r cand; do
       action="none"; reason="indeterminate mergeable_state ('${ms}'); deferring to next run" ;;
   esac
 
-  echo "PR #${num} [${ms}] behind_by=${behind_by} age=${age_hours}h required=${required_count} -> ${action} (${reason})"
+  echo "PR #${num} [${ms}] behind_by=${behind_by} age=${age_hours}h required=${required_count} -> ${action} (${reason})" >&2
 
-  entry=$(jq -nc \
+  jq -nc \
     --argjson num "$num" \
     --arg state "$ms" \
     --arg action "$action" \
@@ -283,9 +292,33 @@ while read -r cand; do
     --argjson rids "$eligible_ids" \
     --argjson behind "$behind_by" \
     --argjson age "$age_hours" \
-    '{number: $num, state: $state, action: $action, reason: $reason, run_ids: $rids, behind_by: $behind, age_hours: $age}')
-  entries+=("$entry")
+    '{number: $num, state: $state, action: $action, reason: $reason, run_ids: $rids, behind_by: $behind, age_hours: $age}' \
+    > "$out_file"
+}
+
+# Fan out classification across a bounded pool of background workers. Each PR
+# writes its entry to a separate, index-named file so we can reassemble the plan
+# in stable (input) order regardless of completion order.
+work_dir=$(mktemp -d)
+trap 'rm -rf "$work_dir"' EXIT
+
+idx=0
+while read -r cand; do
+  [ -z "$cand" ] && continue
+  # Throttle: keep at most CLASSIFY_CONCURRENCY workers in flight.
+  while [ "$(jobs -rp | wc -l)" -ge "$CLASSIFY_CONCURRENCY" ]; do
+    wait -n 2>/dev/null || break
+  done
+  classify_one_pr "$cand" "$work_dir/$(printf '%05d' "$idx").json" &
+  idx=$((idx + 1))
 done < <(echo "$candidates" | jq -c '.[]')
+wait
+
+# Reassemble entries in stable order (skipped PRs simply have no file).
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  entries+=("$(cat "$f")")
+done < <(find "$work_dir" -type f -name '*.json' | sort)
 
 if [ "${#entries[@]}" -gt 0 ]; then
   printf '%s\n' "${entries[@]}" | jq -s '.' > "$PLAN_FILE"

--- a/renovate-pr-maintainer/classify.sh
+++ b/renovate-pr-maintainer/classify.sh
@@ -5,12 +5,13 @@
 # Renovate PR and decides one of: skip / rerun / rebase / none, then writes a
 # JSON plan to $PLAN_FILE which apply.sh consumes.
 #
-# Decision model:
-#   - dirty (merge conflict)                   -> skip   (Renovate rebases conflicts itself)
-#   - behind                                   -> rebase (apply the rebase label)
+# Decision model (see camunda/team-infrastructure#1053):
+#   - dirty (merge conflict)                  -> skip   (Renovate rebases conflicts itself)
+#   - behind (blocked by "require up to date") -> rebase (apply the rebase label)
 #   - blocked/unstable (required checks red)   -> rerun  if a failed run still has budget,
 #                                                 else rebase if stale, else none
-#   - clean                                    -> rebase if stale, else none
+#   - clean/has_hooks                          -> rebase if stale, else none
+#   - unknown (mergeability not yet computed)  -> none   (defer; never act on a guess)
 #
 # Staleness is OR of two stateless signals, both reset by a rebase:
 #   behind_by >= BEHIND_THRESHOLD   OR   age_since_head >= STALE_HOURS
@@ -24,6 +25,11 @@ BEHIND_THRESHOLD="${BEHIND_THRESHOLD:-60}"
 STALE_HOURS="${STALE_HOURS:-24}"
 RERUN_BUDGET="${RERUN_BUDGET:-1}"
 BASE_BRANCH="${BASE_BRANCH:-}"
+# Polling for GitHub's asynchronously-computed mergeable_state. Every push to
+# the base branch resets it to "unknown", so a single retry is often not enough
+# on busy repos; poll a few times with backoff before giving up.
+MERGEABLE_MAX_POLLS="${MERGEABLE_MAX_POLLS:-5}"
+MERGEABLE_POLL_DELAY="${MERGEABLE_POLL_DELAY:-3}"
 
 MAX_API_RETRIES=3
 API_RETRY_DELAY=5
@@ -46,6 +52,30 @@ gh_api() {
     [ "$attempt" -le "$MAX_API_RETRIES" ] && sleep "$API_RETRY_DELAY"
   done
   return 1
+}
+
+# Resolve a PR's mergeable_state. GitHub computes it asynchronously and resets
+# it to null/"unknown" whenever the base branch moves, which on busy repos
+# happens constantly. Poll with linear backoff and return the first definitive
+# value. A residual "unknown" is returned as-is so the caller can defer instead
+# of guessing (acting on a guess can force a needless rebase or skip a cheaper
+# rerun). Returns non-zero only when the PR GET itself fails.
+mergeable_state_for_pr() {
+  local num="$1" attempt=1 ms pr
+  while [ "$attempt" -le "$MERGEABLE_MAX_POLLS" ]; do
+    pr=$(gh_api "repos/${REPOSITORY}/pulls/${num}") || return 1
+    ms=$(echo "$pr" | jq -r '.mergeable_state // "unknown"')
+    if [ "$ms" != "unknown" ]; then
+      printf '%s' "$ms"
+      return 0
+    fi
+    if [ "$attempt" -lt "$MERGEABLE_MAX_POLLS" ]; then
+      sleep "$(( MERGEABLE_POLL_DELAY * attempt ))"
+    fi
+    attempt=$((attempt + 1))
+  done
+  printf 'unknown'
+  return 0
 }
 
 # Required status check contexts for a base branch, discovered from repository
@@ -123,24 +153,21 @@ candidates=$(printf '%s\n' "$pulls_ndjson" | jq -s \
 candidate_count=$(echo "$candidates" | jq 'length')
 echo "In-scope Renovate PRs: ${candidate_count}"
 
-entries=()
+# Pre-warm the required-checks cache once per distinct base branch, in THIS
+# shell. The per-PR call below uses command substitution ($(...)), which runs
+# in a subshell; a subshell inherits a copy of REQUIRED_CACHE but cannot write
+# back to it, so warming the cache here is what makes the in-loop calls cache
+# hits instead of re-discovering rulesets (many gh api calls) for every PR.
+while IFS= read -r warm_base; do
+  [ -z "$warm_base" ] && continue
+  required_checks_for_base "$warm_base" >/dev/null
+done < <(echo "$candidates" | jq -r '.[].base' | sort -u)
 
-while read -r cand; do
-  [ -z "$cand" ] && continue
-  num=$(echo "$cand" | jq -r '.number')
-  base=$(echo "$cand" | jq -r '.base')
-  head_sha=$(echo "$cand" | jq -r '.head_sha')
-
-  # mergeable_state is computed asynchronously; re-poll once if still unknown.
-  pr=$(gh_api "repos/${REPOSITORY}/pulls/${num}") || { echo "::warning::skip PR #${num}: GET failed"; continue; }
-  ms=$(echo "$pr" | jq -r '.mergeable_state // "unknown"')
-  if [ "$ms" = "unknown" ]; then
-    sleep 3
-    pr=$(gh_api "repos/${REPOSITORY}/pulls/${num}") || true
-    ms=$(echo "$pr" | jq -r '.mergeable_state // "unknown"')
-  fi
-
-  # Staleness inputs (stateless; both reset by a rebase).
+# Compute staleness for one PR: sets behind_by, age_hours, stale (globals).
+# Cost: 1 compare + 1 commit GET. Called only for states whose decision can
+# depend on staleness (blocked/unstable/clean/has_hooks).
+compute_staleness() {
+  local base="$1" head_sha="$2" base_enc head_date head_epoch
   # URL-encode '/' in the base ref so base branches like `stable/8.7` don't break the path.
   base_enc="${base//\//%2F}"
   behind_by=$(gh_api "repos/${REPOSITORY}/compare/${base_enc}...${head_sha}" --jq '.behind_by' 2>/dev/null || echo 0)
@@ -152,15 +179,19 @@ while read -r cand; do
     head_epoch=$NOW_EPOCH
   fi
   age_hours=$(( (NOW_EPOCH - head_epoch) / 3600 ))
-
-  stale=false
   if [ "$behind_by" -ge "$BEHIND_THRESHOLD" ] || [ "$age_hours" -ge "$STALE_HOURS" ]; then
     stale=true
   fi
+}
 
-  # Rerun eligibility, scoped to REQUIRED checks only:
-  #   failing required check-run -> its check suite -> the workflow run that produced it.
-  # This avoids rerunning non-required (non-blocking) workflows.
+# Compute rerun eligibility for one PR, scoped to REQUIRED checks only:
+#   failing required check-run -> its check suite -> the workflow run that produced it.
+# Sets required_count, eligible_ids, eligible_count (globals). This avoids
+# rerunning non-required (non-blocking) workflows.
+# Cost: 1 check-runs + 1 actions/runs GET (both paginated — the most expensive
+# pair). Called only for blocked/unstable, the only states with a rerun path.
+compute_rerun_eligibility() {
+  local base="$1" head_sha="$2" required_checks required_json checkruns_ndjson failing_suites runs_ndjson
   required_checks=$(required_checks_for_base "$base")
   required_json=$(printf '%s\n' "$required_checks" | jq -R . | jq -s 'map(select(length > 0))')
   required_count=$(echo "$required_json" | jq 'length')
@@ -177,6 +208,36 @@ while read -r cand; do
   eligible_ids=$(printf '%s\n' "$runs_ndjson" | jq -s --argjson n "$RERUN_BUDGET" --argjson suites "$failing_suites" \
     '[.[] | select(((.suite as $s | $suites | index($s)) != null) and .run_attempt <= $n) | .id] | unique' 2>/dev/null || echo "[]")
   eligible_count=$(echo "$eligible_ids" | jq 'length' 2>/dev/null || echo 0)
+}
+
+entries=()
+
+while read -r cand; do
+  [ -z "$cand" ] && continue
+  num=$(echo "$cand" | jq -r '.number')
+  base=$(echo "$cand" | jq -r '.base')
+  head_sha=$(echo "$cand" | jq -r '.head_sha')
+
+  # mergeable_state is computed asynchronously and reset by base pushes; poll
+  # with backoff. A residual "unknown" is handled conservatively in the case
+  # statement below (deferred, never acted on).
+  ms=$(mergeable_state_for_pr "$num") || { echo "::warning::skip PR #${num}: GET failed"; continue; }
+
+  # Per-PR diagnostic/plan fields. Defaulted here, then filled lazily by the
+  # case below — we only fetch what each state's decision actually needs:
+  #   - rerun eligibility (check-runs + actions/runs, the costliest pair) only
+  #     matters for blocked/unstable.
+  #   - staleness (compare + commit date) only matters for states that can
+  #     rebase-on-stale (blocked/unstable/clean/has_hooks).
+  # dirty/behind/unknown have a fixed action and fetch nothing further.
+  # apply.sh consumes only number/action/run_ids, so the defaulted diagnostic
+  # fields (behind_by/age_hours) on fixed-action states are cosmetic, not load-bearing.
+  behind_by=0
+  age_hours=0
+  required_count=0
+  eligible_ids="[]"
+  eligible_count=0
+  stale=false
 
   action="none"
   reason=""
@@ -186,6 +247,10 @@ while read -r cand; do
     behind)
       action="rebase"; reason="behind base (require-up-to-date blocks merge)" ;;
     blocked|unstable)
+      # Needs rerun eligibility; staleness is the rebase fallback and also
+      # populates behind_by/age diagnostics for these (the actionable) PRs.
+      compute_rerun_eligibility "$base" "$head_sha"
+      compute_staleness "$base" "$head_sha"
       if [ "$eligible_count" -gt 0 ]; then
         action="rerun"; reason="failing required checks; rerun ${eligible_count} run(s) (budget left)"
       elif [ "$stale" = "true" ]; then
@@ -193,12 +258,19 @@ while read -r cand; do
       else
         action="none"; reason="checks failing, no required rerun candidate, not stale"
       fi ;;
-    *)
+    clean|has_hooks)
+      compute_staleness "$base" "$head_sha"
       if [ "$stale" = "true" ]; then
         action="rebase"; reason="stale (behind_by>=${BEHIND_THRESHOLD} or age>=${STALE_HOURS}h)"
       else
         action="none"; reason="fresh & green"
       fi ;;
+    *)
+      # unknown / indeterminate: GitHub had not finished (re)computing
+      # mergeability, typically because the base moved during the run. Acting
+      # here would be a guess that can force a needless rebase or skip a cheaper
+      # rerun, so defer to the next run instead.
+      action="none"; reason="indeterminate mergeable_state ('${ms}'); deferring to next run" ;;
   esac
 
   echo "PR #${num} [${ms}] behind_by=${behind_by} age=${age_hours}h required=${required_count} -> ${action} (${reason})"

--- a/renovate-pr-maintainer/classify.sh
+++ b/renovate-pr-maintainer/classify.sh
@@ -1,84 +1,76 @@
 #!/usr/bin/env bash
 # Classify in-scope Renovate PRs into maintenance actions.
 #
-# This script is READ-ONLY: it never mutates any PR. It inspects each in-scope
-# Renovate PR and decides one of: skip / rerun / rebase / none, then writes a
-# JSON plan to $PLAN_FILE which apply.sh consumes.
+# READ-ONLY: never mutates a PR. Inspects each in-scope Renovate PR, decides one
+# of skip / rerun / rebase / none, and writes a JSON plan to $PLAN_FILE that
+# apply.sh consumes.
 #
-# Decision model:
-#   - already carries the rebase label               -> pending (rebase requested but not
-#                                                       yet consumed by Renovate; do
-#                                                       nothing, just report), checked
-#                                                       first — cheapest, no fetch needed
-#   - branch edited by a non-Renovate author        -> skip (Renovate's "Edited/Blocked"
-#                                                       state; rebasing would discard the
-#                                                       human's commits), checked first
-#                                                       for every actionable state below
-#   - dirty (merge conflict)                  -> skip   (Renovate rebases conflicts itself)
-#   - behind (blocked by "require up to date") -> rebase if REQUIRE_UP_TO_DATE=true,
-#                                                 else decided by staleness (like clean)
-#   - blocked/unstable (required checks red)   -> rebase if stale (rerunning stale code
-#                                                 burns CI for a SHA that can't merge),
-#                                                 else rerun if a failed run has budget,
-#                                                 else none
-#   - clean/has_hooks                          -> rebase if stale, else none
-#   - unknown (mergeability not yet computed)  -> none   (defer; never act on a guess)
+# Decision model (first match wins; a human-edited head always downgrades an
+# actionable state to skip, since Renovate won't auto-rebase it):
+#   rebase label present  -> pending (rebase already queued; report only, no fetch)
+#   dirty (conflict)      -> skip    (Renovate rebases conflicts itself)
+#   behind                -> rebase if require-up-to-date, else treat like blocked
+#   blocked / unstable    -> rebase if stale, else rerun a failing required run, else none
+#   clean / has_hooks     -> rebase if stale, else none
+#   unknown               -> none    (mergeability pending; never act on a guess)
 #
-# Staleness is OR of two stateless signals, both reset by a rebase:
-#   behind_by >= BEHIND_THRESHOLD   OR   age_since_head >= STALE_HOURS
+# Stale = behind_by >= BEHIND_THRESHOLD OR head age >= STALE_HOURS (both reset by a rebase).
 set -euo pipefail
 
 : "${REPOSITORY:?REPOSITORY is required (owner/name)}"
 : "${PLAN_FILE:?PLAN_FILE is required}"
+# Login identifying Renovate's PRs: selects which PRs are in scope and is the
+# trusted head author/committer (see GITHUB_SIGNING_COMMITTER, EXTRA_TRUSTED_LOGINS).
 RENOVATE_AUTHOR="${RENOVATE_AUTHOR:-renovate[bot]}"
+# Comma-separated labels that take a PR out of scope (e.g. Renovate already keeps
+# `keep-updated` PRs continuously rebased, so this action leaves them alone).
 EXCLUDE_LABELS="${EXCLUDE_LABELS:-keep-updated,stop-updating}"
+# Staleness signals (OR'd, both reset by a rebase): rebase once the head is at
+# least this many commits behind base, or at least this many hours old.
 BEHIND_THRESHOLD="${BEHIND_THRESHOLD:-60}"
 STALE_HOURS="${STALE_HOURS:-24}"
+# Max workflow-run attempts per head SHA before reruns stop. 0 (default) disables
+# reruns; the count derives from run_attempt, so a fresh SHA resets it.
 RERUN_BUDGET="${RERUN_BUDGET:-0}"
-# Comma- or newline-separated extra check-run names to treat as required for the
-# rerun decision, unioned with the contexts discovered from rulesets. Lets an
-# operator opt a non-required check (e.g. a flaky job, or one enforced only via
-# classic branch protection, which this action does not read) into reruns.
+# Extra check-run names (comma/newline-separated) treated as required for the
+# rerun decision, unioned with the ruleset-discovered contexts (this action reads
+# only rulesets, not classic branch protection).
 EXTRA_RERUN_CHECKS="${EXTRA_RERUN_CHECKS:-}"
+# Optional exact base-branch filter; empty (default) means all base branches.
 BASE_BRANCH="${BASE_BRANCH:-}"
-# When false (default), the `behind` mergeable_state ("Require branches to be up
-# to date before merging") is ignored from the decision logic: a behind PR is
-# decided purely by staleness, like a clean PR. Set true to treat behind as a
-# hard merge blocker and rebase it immediately.
+# When true, treat the `behind` mergeable_state ("Require branches up to date")
+# as a hard merge blocker and rebase immediately. When false (default), ignore it
+# and decide a behind PR by staleness, like a clean one.
 REQUIRE_UP_TO_DATE="${REQUIRE_UP_TO_DATE:-false}"
-# Renovate's rebase label. A PR already carrying it has a rebase queued (Renovate
-# strips the label once it rebases), so the maintainer leaves it alone and just
-# reports it. Must match apply.sh's REBASE_LABEL.
+# Renovate's one-off rebase label. A PR already carrying it has a rebase queued,
+# so it is reported, not acted on. Must match apply.sh's REBASE_LABEL.
 REBASE_LABEL="${REBASE_LABEL:-rebase}"
-# GitHub stamps this login as the committer on Renovate's API-created (signed)
-# commits, so it is treated as Renovate-owned, not a human edit. Any other
-# non-Renovate author/committer on the head commit marks the branch as edited.
+# Committer GitHub stamps on Renovate's API-created (signed) commits; counts as
+# Renovate-owned, not a human edit. Any other non-Renovate author/committer does.
 GITHUB_SIGNING_COMMITTER="${GITHUB_SIGNING_COMMITTER:-web-flow}"
-# Comma- or newline-separated extra logins (author or committer) that are ALSO
-# treated as Renovate-owned, in addition to RENOVATE_AUTHOR and
-# GITHUB_SIGNING_COMMITTER. Lets trusted automation that pushes follow-up commits
-# to Renovate branches (e.g. github-actions[bot] running upgrade scripts) avoid
-# being misread as a human edit. Whitespace around entries is trimmed.
+# Extra logins (comma/newline-separated) also treated as Renovate-owned, beyond
+# RENOVATE_AUTHOR and GITHUB_SIGNING_COMMITTER, so trusted automation pushing
+# follow-up commits (e.g. github-actions[bot]) isn't misread as a human edit.
 EXTRA_TRUSTED_LOGINS="${EXTRA_TRUSTED_LOGINS:-}"
-# Polling for GitHub's asynchronously-computed mergeable_state. Every push to
-# the base branch resets it to "unknown", so a single retry is often not enough
-# on busy repos; poll a few times with backoff before giving up.
+# Polling for GitHub's async mergeable_state: every base-branch push resets it to
+# "unknown", so poll a few times with linear backoff before giving up.
 MERGEABLE_MAX_POLLS="${MERGEABLE_MAX_POLLS:-5}"
 MERGEABLE_POLL_DELAY="${MERGEABLE_POLL_DELAY:-3}"
-# Per-PR classification is independent across PRs, so we fan out with a bounded
-# worker pool. Workers are bash forks that inherit the pre-warmed REQUIRED_CACHE
-# (read-only), so concurrency adds no extra ruleset discovery. Tunable; set to 1
-# to force fully serial execution.
+# Bounded worker pool for the independent per-PR classification. Workers are bash
+# forks inheriting the pre-warmed REQUIRED_CACHE (read-only), so concurrency adds
+# no ruleset discovery. Set to 1 for fully serial execution.
 CLASSIFY_CONCURRENCY="${CLASSIFY_CONCURRENCY:-8}"
-# Guard against bad overrides: a non-integer or < 1 value would make the numeric
-# throttle test below fail under `set -e` or spin forever. Coerce to an int >= 1.
+# Coerce a bad override (non-integer or < 1) to 1: the throttle test below is
+# numeric and would fail under `set -e` or spin forever otherwise.
 if ! [[ "$CLASSIFY_CONCURRENCY" =~ ^[0-9]+$ ]] || [ "$CLASSIFY_CONCURRENCY" -lt 1 ]; then
   echo "::warning::invalid CLASSIFY_CONCURRENCY='${CLASSIFY_CONCURRENCY}'; falling back to 1" >&2
   CLASSIFY_CONCURRENCY=1
 fi
 
+# Bounded retries for transient gh api failures (see gh_api below).
 MAX_API_RETRIES=3
 API_RETRY_DELAY=5
+# Single reference time so every PR's age is measured against the same "now".
 NOW_EPOCH=$(date -u +%s)
 
 # gh api with bounded retries on transient failures. Prints body on success.
@@ -100,12 +92,9 @@ gh_api() {
   return 1
 }
 
-# Resolve a PR's mergeable_state. GitHub computes it asynchronously and resets
-# it to null/"unknown" whenever the base branch moves, which on busy repos
-# happens constantly. Poll with linear backoff and return the first definitive
-# value. A residual "unknown" is returned as-is so the caller can defer instead
-# of guessing (acting on a guess can force a needless rebase or skip a cheaper
-# rerun). Returns non-zero only when the PR GET itself fails.
+# Resolve a PR's mergeable_state, polling with linear backoff past the transient
+# "unknown" GitHub returns while (re)computing it after a base push. A residual
+# "unknown" is returned as-is so the caller defers. Non-zero only if the GET fails.
 mergeable_state_for_pr() {
   local num="$1" attempt=1 ms pr
   while [ "$attempt" -le "$MERGEABLE_MAX_POLLS" ]; do
@@ -124,10 +113,9 @@ mergeable_state_for_pr() {
   return 0
 }
 
-# Required status check contexts for a base branch, discovered from repository
-# rulesets targeting that branch. Newline-separated, cached per base branch.
-# NOTE: only rulesets are inspected (not classic branch protection), mirroring
-# the wait-for-required-checks action.
+# Required status-check contexts for a base branch, discovered from repository
+# rulesets targeting it (not classic branch protection, mirroring the
+# wait-for-required-checks action). Newline-separated, cached per base branch.
 DEFAULT_BRANCH=$(gh_api "repos/${REPOSITORY}" --jq '.default_branch' 2>/dev/null || echo "")
 declare -A REQUIRED_CACHE
 required_checks_for_base() {
@@ -145,8 +133,7 @@ required_checks_for_base() {
     [ -z "$ruleset" ] && continue
 
     # Does this ruleset target the base branch? Handles GitHub's special refs
-    # `~ALL` (every branch) and `~DEFAULT_BRANCH`, plus glob includes like
-    # `refs/heads/stable/**`. Glob match avoids regex injection.
+    # `~ALL` and `~DEFAULT_BRANCH` plus glob includes; case-glob avoids regex injection.
     local matches=false include
     while IFS= read -r include; do
       [ -z "$include" ] && continue
@@ -201,44 +188,34 @@ candidates=$(printf '%s\n' "$pulls_ndjson" | jq -s \
 candidate_count=$(echo "$candidates" | jq 'length')
 echo "In-scope Renovate PRs: ${candidate_count}"
 
-# Pre-warm the required-checks cache once per distinct base branch, in THIS
-# shell. The per-PR call below uses command substitution ($(...)), which runs
-# in a subshell; a subshell inherits a copy of REQUIRED_CACHE but cannot write
-# back to it, so warming the cache here is what makes the in-loop calls cache
-# hits instead of re-discovering rulesets (many gh api calls) for every PR.
+# Pre-warm the required-checks cache once per base branch in THIS shell: the
+# workers below run in subshells that inherit REQUIRED_CACHE but can't write back,
+# so warming here turns their lookups into cache hits instead of re-discovery.
 while IFS= read -r warm_base; do
   [ -z "$warm_base" ] && continue
   required_checks_for_base "$warm_base" >/dev/null
 done < <(echo "$candidates" | jq -r '.[].base' | sort -u)
 
-# True when $1 is one of the EXTRA_TRUSTED_LOGINS extra logins. The list is
-# split on commas AND newlines and each entry is whitespace-trimmed, so a YAML
-# block scalar (one login per line) works as well as a comma-separated string.
-# Widens the set of identities considered Renovate-owned beyond RENOVATE_AUTHOR
-# and GITHUB_SIGNING_COMMITTER. An empty login or empty list is never a match
-# (the caller handles the empty-login case).
+# True when $1 is listed in EXTRA_TRUSTED_LOGINS (split on commas and newlines,
+# each entry trimmed, so a YAML block scalar or a CSV string both work). An empty
+# login or empty list never matches.
 login_is_extra_allowed() {
   local login="$1" extra
   { [ -z "$login" ] || [ -z "$EXTRA_TRUSTED_LOGINS" ]; } && return 1
-  # `|| [ -n "$extra" ]` processes the final entry even when the pipeline emits
-  # no trailing newline (true for a single login or the last item of any list).
+  # `|| [ -n "$extra" ]` also reads the final entry when it has no trailing newline.
   while IFS= read -r extra || [ -n "$extra" ]; do
     [ -n "$extra" ] && [ "$login" = "$extra" ] && return 0
   done < <(printf '%s' "$EXTRA_TRUSTED_LOGINS" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
   return 1
 }
 
-# Fetch the head commit once and derive age + edit ownership: sets age_hours and
-# head_modified (globals), memoized per PR via head_meta_done. Renovate refuses
-# to auto-rebase a branch it did not author ("Edited/Blocked"); we mirror that by
-# flagging head_modified when the head commit's author or committer is anyone
-# other than Renovate (GITHUB_SIGNING_COMMITTER is Renovate's signed-commit
-# committer and does not count, and EXTRA_TRUSTED_LOGINS adds further
-# trusted logins). Login mapping is best-effort: an unmapped author (null login)
-# is treated as Renovate-owned to avoid skipping legitimate PRs.
-# If the commit GET itself fails (after retries), we fail closed and mark the
-# head modified: an unverifiable branch must never be rebased ("never rebases
-# human-edited branches"); the PR is just deferred to the next run.
+# Fetch the head commit once to derive age + edit ownership: sets age_hours and
+# head_modified (globals), memoized per PR via head_meta_done. Mirrors Renovate's
+# refusal to auto-rebase a branch it didn't author by flagging head_modified when
+# the head author/committer is anyone but Renovate (GITHUB_SIGNING_COMMITTER and
+# EXTRA_TRUSTED_LOGINS still count as Renovate; an unmapped null login is treated
+# as Renovate-owned to avoid skipping legitimate PRs). If the commit GET fails we
+# fail closed (head_modified=true): an unverifiable branch is never rebased.
 # Cost: 1 commit GET (shared with compute_staleness).
 fetch_head_meta() {
   local head_sha="$1" head_json author committer head_date head_epoch
@@ -266,13 +243,12 @@ fetch_head_meta() {
   age_hours=$(( (NOW_EPOCH - head_epoch) / 3600 ))
 }
 
-# Compute staleness for one PR: sets behind_by, age_hours, stale, head_modified
-# (globals). Cost: 1 compare + 1 commit GET (the latter via fetch_head_meta).
-# Called only for states whose decision can depend on staleness
-# (blocked/unstable/clean/has_hooks).
+# Staleness for one PR: sets behind_by, age_hours, stale, head_modified (globals).
+# Called only for states whose decision depends on staleness. Cost: 1 compare +
+# 1 commit GET (the latter via fetch_head_meta).
 compute_staleness() {
   local base="$1" head_sha="$2" base_enc
-  # URL-encode '/' in the base ref so base branches like `stable/8.7` don't break the path.
+  # URL-encode '/' so base branches like `stable/8.7` don't break the compare path.
   base_enc="${base//\//%2F}"
   behind_by=$(gh_api "repos/${REPOSITORY}/compare/${base_enc}...${head_sha}" --jq '.behind_by' 2>/dev/null || echo 0)
   [ -z "$behind_by" ] && behind_by=0
@@ -282,44 +258,39 @@ compute_staleness() {
   fi
 }
 
-# Compute rerun eligibility for one PR, scoped to REQUIRED checks only:
-#   failing required check-run -> its check suite -> the workflow run that produced it.
-# The required set is the ruleset-discovered contexts unioned with EXTRA_RERUN_CHECKS.
-# Sets required_count, eligible_ids, eligible_count, checks_in_progress (globals).
-# This avoids rerunning non-required (non-blocking) workflows.
-# Cost: 1 check-runs + 1 actions/runs GET (both paginated — the most expensive
-# pair). Called for blocked/unstable and for behind when require-up-to-date is
-# disabled (the states with a rerun path); short-circuits when reruns are off.
+# Rerun eligibility for one PR, scoped to REQUIRED checks only (never reruns
+# non-blocking workflows): failing required check-run -> its suite -> the workflow
+# run that produced it. Required set = ruleset contexts ∪ EXTRA_RERUN_CHECKS. Sets
+# required_count, eligible_ids, eligible_count, checks_in_progress (globals).
+# Cost: 1 check-runs + 1 actions/runs GET (paginated, the costliest pair);
+# short-circuits when reruns are off.
 compute_rerun_eligibility() {
   local base="$1" head_sha="$2" required_checks required_json checkruns_ndjson failing_suites runs_ndjson
-  # Reruns disabled (budget < 1): no run can ever be eligible (run_attempt is
-  # always >= 1), so short-circuit before the two costly paginated GETs.
+  # Reruns disabled (budget < 1): nothing can be eligible, so short-circuit
+  # before the two costly paginated GETs.
   if [ "$RERUN_BUDGET" -lt 1 ]; then
     required_count=0; eligible_ids="[]"; eligible_count=0; checks_in_progress=false; failing_required_count=0
     return 0
   fi
   required_checks=$(required_checks_for_base "$base")
-  # Union the ruleset-discovered contexts with any operator-supplied extra rerun
-  # checks (comma- or newline-separated, whitespace-trimmed, de-duplicated). With
-  # no extras this is identical to the ruleset set (already sort -u'd).
+  # Union ruleset contexts with EXTRA_RERUN_CHECKS (split, trimmed, de-duped);
+  # with no extras this is just the ruleset set.
   required_json=$(
     { printf '%s\n' "$required_checks"
       printf '%s' "$EXTRA_RERUN_CHECKS" | tr ',' '\n'
     } | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | jq -R . | jq -s 'map(select(length > 0)) | unique')
   required_count=$(echo "$required_json" | jq 'length')
 
-  # Check suites on the head SHA that contain a failing REQUIRED check-run. We
-  # also carry each run's status so we can tell "failing" from "still running":
-  # GitHub reports `unstable` for both a failing AND a merely-pending non-required
-  # check, so a fresh PR with no rerun candidate may simply be mid-CI.
+  # Suites on the head SHA with a failing REQUIRED check-run. Status is carried
+  # too so the caller can tell "failing" from "still running": `unstable` covers
+  # both a failing and a merely-pending non-required check.
   checkruns_ndjson=$(gh_api "repos/${REPOSITORY}/commits/${head_sha}/check-runs?per_page=100" --paginate \
     --jq '.check_runs[] | {name, status, conclusion, suite: .check_suite.id}' 2>/dev/null || echo "")
   checks_in_progress=$(printf '%s\n' "$checkruns_ndjson" | jq -s 'any(.[]; .status != "completed")' 2>/dev/null || echo false)
   failing_suites=$(printf '%s\n' "$checkruns_ndjson" | jq -s --argjson req "$required_json" \
     '[.[] | select(.conclusion == "failure" and ((.name as $n | $req | index($n)) != null)) | .suite] | unique' 2>/dev/null || echo "[]")
-  # Number of failing REQUIRED suites, regardless of rerun budget. Lets the
-  # caller distinguish "a required check is failing but its run is over budget"
-  # from "nothing required is failing" — they look identical via eligible_count.
+  # Failing REQUIRED suites regardless of budget, so the caller can tell "failing
+  # but over budget" from "nothing required failing" (both give eligible_count 0).
   failing_required_count=$(echo "$failing_suites" | jq 'length' 2>/dev/null || echo 0)
 
   # Workflow runs whose suite has a failing required check, still within rerun budget.
@@ -330,10 +301,9 @@ compute_rerun_eligibility() {
   eligible_count=$(echo "$eligible_ids" | jq 'length' 2>/dev/null || echo 0)
 }
 
-# Reason for a fresh PR that ends up with no rerun ($1 = context prefix). Keeps
-# the wording honest: a no-candidate `unstable`/`behind` PR is often just mid-CI
-# (pending non-required checks), not actually failing. Reads RERUN_BUDGET,
-# checks_in_progress and failing_required_count (globals).
+# Human-readable reason a fresh PR gets no rerun ($1 = context prefix): a
+# no-candidate PR is often just mid-CI, not failing. Reads RERUN_BUDGET,
+# checks_in_progress, failing_required_count (globals).
 no_rerun_reason() {
   if [ "$RERUN_BUDGET" -lt 1 ]; then
     printf '%sreruns disabled (rerun-budget=0)' "$1"
@@ -348,10 +318,9 @@ no_rerun_reason() {
 
 entries=()
 
-# Classify a single candidate PR and write its plan entry (one JSON object) to
-# <out_file>. Progress is logged to stderr. Designed to run as a background
-# worker: it only reads the pre-warmed REQUIRED_CACHE, never writes it, so it is
-# safe to fork. A PR that fails its initial GET writes nothing (skipped).
+# Classify one candidate PR and write its plan entry (one JSON object) to
+# <out_file>; logs progress to stderr. Safe to fork as a worker: only reads the
+# pre-warmed REQUIRED_CACHE, never writes it. A PR that fails its GET writes nothing.
 classify_one_pr() {
   local cand="$1" out_file="$2"
   local num base head_sha ms
@@ -359,12 +328,9 @@ classify_one_pr() {
   base=$(echo "$cand" | jq -r '.base')
   head_sha=$(echo "$cand" | jq -r '.head_sha')
 
-  # Already-queued rebase: the PR still carries the Renovate rebase label, so a
-  # rebase was requested but Renovate has not consumed it yet (it strips the
-  # label once done). Re-adding the label is a no-op and any CI we trigger now is
-  # wasted because the SHA is about to change, so do nothing and report it. The
-  # label list is already in the candidate, so this short-circuits before the
-  # mergeable_state poll and every per-PR fetch — the cheapest exit.
+  # Rebase already queued: the PR still carries the label (Renovate strips it once
+  # done), so acting now is wasted — the SHA is about to change. Decided from the
+  # candidate's labels alone, before any per-PR fetch: the cheapest exit.
   if [ -n "$REBASE_LABEL" ] && echo "$cand" | jq -e --arg l "$REBASE_LABEL" '(.labels // []) | index($l)' >/dev/null; then
     echo "PR #${num} [rebase-labeled] -> pending (rebase already requested; awaiting Renovate)" >&2
     jq -nc --argjson num "$num" \
@@ -373,25 +339,15 @@ classify_one_pr() {
     return 0
   fi
 
-  # mergeable_state is computed asynchronously and reset by base pushes; poll
-  # with backoff. A residual "unknown" is handled conservatively in the case
-  # statement below (deferred, never acted on).
+  # mergeable_state is async and reset by base pushes; poll with backoff. A
+  # residual "unknown" is deferred (never acted on) in the case below.
   ms=$(mergeable_state_for_pr "$num") || { echo "::warning::skip PR #${num}: GET failed" >&2; return 0; }
 
-  # Per-PR diagnostic/plan fields. Defaulted here, then filled lazily by the
-  # case below — we only fetch what each state's decision actually needs:
-  #   - staleness (compare + commit date) gates every rebase-on-stale state
-  #     (blocked/unstable/clean/has_hooks) and is checked first for those.
-  #   - rerun eligibility (check-runs + actions/runs, the costliest pair) only
-  #     matters for a fresh PR with a rerun path (blocked/unstable, or behind
-  #     when require-up-to-date is disabled), so it is skipped once such a PR is
-  #     found stale, and short-circuits entirely when reruns are off.
-  #   - head ownership (head_modified) gates every action that would push a new
-  #     SHA; it rides along on the commit GET that staleness already does, and
-  #     is fetched standalone for `behind` (otherwise a no-fetch state).
-  # dirty/unknown have a fixed action and fetch nothing further.
-  # apply.sh consumes only number/action/run_ids, so the defaulted diagnostic
-  # fields (behind_by/age_hours) on fixed-action states are cosmetic, not load-bearing.
+  # Per-PR fields, defaulted here and filled lazily by the case below — each state
+  # fetches only what its decision needs: staleness (compare + commit GET) gates
+  # the rebase-on-stale states, rerun eligibility (the costly check-runs + runs
+  # pair) only a fresh PR with a rerun path, head ownership rides along on the
+  # staleness commit GET. dirty/unknown fetch nothing further.
   local behind_by=0 age_hours=0 required_count=0 eligible_ids="[]" eligible_count=0 stale=false
   local head_modified=false head_meta_done=false checks_in_progress=false failing_required_count=0
   local action="none" reason=""
@@ -400,9 +356,8 @@ classify_one_pr() {
       action="skip"; reason="merge conflict; Renovate owns the rebase" ;;
     behind)
       if [ "$REQUIRE_UP_TO_DATE" = "true" ]; then
-        # "Require branches up to date" blocks the merge until a rebase happens,
-        # so a rebase is unavoidable regardless of staleness. It pushes a fresh
-        # SHA, so honor an edited branch first.
+        # "Require branches up to date" blocks merge until a rebase, so rebase is
+        # unavoidable regardless of staleness — but honor an edited branch first.
         fetch_head_meta "$head_sha"
         if [ "$head_modified" = "true" ]; then
           action="skip"; reason="branch edited by non-Renovate author; leave for human (rebase would discard manual commits)"
@@ -410,12 +365,10 @@ classify_one_pr() {
           action="rebase"; reason="behind base (require-up-to-date blocks merge)"
         fi
       else
-        # require-up-to-date disabled: `behind` is not itself a blocker, but
-        # GitHub's `behind` state masks any failing-check state (behind outranks
-        # blocked/unstable in mergeable_state). So decide exactly like
-        # blocked/unstable: staleness first, then rerun failing required checks
-        # on a fresh SHA. Without this, a behind PR's failing checks would never
-        # be rerun — and on busy repos nearly every PR is behind.
+        # require-up-to-date disabled: `behind` outranks (masks) blocked/unstable
+        # in mergeable_state, so decide it identically — staleness first, then
+        # rerun failing required checks on a fresh SHA. Otherwise a behind PR's
+        # failing checks would never rerun, and on busy repos nearly all are behind.
         compute_staleness "$base" "$head_sha"
         if [ "$head_modified" = "true" ]; then
           action="skip"; reason="branch edited by non-Renovate author; leave for human (Renovate won't auto-rebase it)"
@@ -431,10 +384,9 @@ classify_one_pr() {
         fi
       fi ;;
     blocked|unstable)
-      # Staleness wins over rerun: a stale PR must rebase to merge anyway, so
-      # rerunning its (stale) SHA burns a full CI matrix for nothing. Only when
-      # fresh do we pay for rerun eligibility and prefer the cheap failed-job
-      # rerun over a full rebase. compute_staleness also sets head_modified.
+      # Staleness wins over rerun: a stale PR rebases to merge anyway, so
+      # rerunning its stale SHA burns CI for nothing. Only when fresh do we pay
+      # for rerun eligibility. compute_staleness also sets head_modified.
       compute_staleness "$base" "$head_sha"
       if [ "$head_modified" = "true" ]; then
         action="skip"; reason="branch edited by non-Renovate author; leave for human (Renovate won't auto-rebase it)"
@@ -458,10 +410,8 @@ classify_one_pr() {
         action="none"; reason="fresh & green"
       fi ;;
     *)
-      # unknown / indeterminate: GitHub had not finished (re)computing
-      # mergeability, typically because the base moved during the run. Acting
-      # here would be a guess that can force a needless rebase or skip a cheaper
-      # rerun, so defer to the next run instead.
+      # unknown: GitHub hadn't finished (re)computing mergeability (base likely
+      # moved mid-run). Acting would be a guess, so defer to the next run.
       action="none"; reason="indeterminate mergeable_state ('${ms}'); deferring to next run" ;;
   esac
 
@@ -479,9 +429,8 @@ classify_one_pr() {
     > "$out_file"
 }
 
-# Fan out classification across a bounded pool of background workers. Each PR
-# writes its entry to a separate, index-named file so we can reassemble the plan
-# in stable (input) order regardless of completion order.
+# Fan out classification across a bounded worker pool. Each PR writes to a
+# separate index-named file so the plan reassembles in stable input order.
 work_dir=$(mktemp -d)
 trap 'rm -rf "$work_dir"' EXIT
 

--- a/renovate-pr-maintainer/classify.sh
+++ b/renovate-pr-maintainer/classify.sh
@@ -6,6 +6,10 @@
 # JSON plan to $PLAN_FILE which apply.sh consumes.
 #
 # Decision model (see camunda/team-infrastructure#1053):
+#   - branch edited by a non-Renovate author        -> skip (Renovate's "Edited/Blocked"
+#                                                       state; rebasing would discard the
+#                                                       human's commits), checked first
+#                                                       for every actionable state below
 #   - dirty (merge conflict)                  -> skip   (Renovate rebases conflicts itself)
 #   - behind (blocked by "require up to date") -> rebase (apply the rebase label)
 #   - blocked/unstable (required checks red)   -> rebase if stale (rerunning stale code
@@ -27,6 +31,10 @@ BEHIND_THRESHOLD="${BEHIND_THRESHOLD:-60}"
 STALE_HOURS="${STALE_HOURS:-24}"
 RERUN_BUDGET="${RERUN_BUDGET:-1}"
 BASE_BRANCH="${BASE_BRANCH:-}"
+# GitHub stamps this login as the committer on Renovate's API-created (signed)
+# commits, so it is treated as Renovate-owned, not a human edit. Any other
+# non-Renovate author/committer on the head commit marks the branch as edited.
+GITHUB_SIGNING_COMMITTER="${GITHUB_SIGNING_COMMITTER:-web-flow}"
 # Polling for GitHub's asynchronously-computed mergeable_state. Every push to
 # the base branch resets it to "unknown", so a single retry is often not enough
 # on busy repos; poll a few times with backoff before giving up.
@@ -176,22 +184,49 @@ while IFS= read -r warm_base; do
   required_checks_for_base "$warm_base" >/dev/null
 done < <(echo "$candidates" | jq -r '.[].base' | sort -u)
 
-# Compute staleness for one PR: sets behind_by, age_hours, stale (globals).
-# Cost: 1 compare + 1 commit GET. Called only for states whose decision can
-# depend on staleness (blocked/unstable/clean/has_hooks).
-compute_staleness() {
-  local base="$1" head_sha="$2" base_enc head_date head_epoch
-  # URL-encode '/' in the base ref so base branches like `stable/8.7` don't break the path.
-  base_enc="${base//\//%2F}"
-  behind_by=$(gh_api "repos/${REPOSITORY}/compare/${base_enc}...${head_sha}" --jq '.behind_by' 2>/dev/null || echo 0)
-  [ -z "$behind_by" ] && behind_by=0
-  head_date=$(gh_api "repos/${REPOSITORY}/commits/${head_sha}" --jq '.commit.committer.date' 2>/dev/null || echo "")
+# Fetch the head commit once and derive age + edit ownership: sets age_hours and
+# head_modified (globals), memoized per PR via head_meta_done. Renovate refuses
+# to auto-rebase a branch it did not author ("Edited/Blocked"); we mirror that by
+# flagging head_modified when the head commit's author or committer is anyone
+# other than Renovate (GITHUB_SIGNING_COMMITTER is Renovate's signed-commit
+# committer and does not count). Login mapping is best-effort: an unmapped author
+# (null login) is treated as Renovate-owned to avoid skipping legitimate PRs.
+# Cost: 1 commit GET (shared with compute_staleness).
+fetch_head_meta() {
+  local head_sha="$1" head_json author committer head_date head_epoch
+  [ "$head_meta_done" = "true" ] && return 0
+  head_meta_done=true
+  head_json=$(gh_api "repos/${REPOSITORY}/commits/${head_sha}" 2>/dev/null || echo "")
+  if [ -z "$head_json" ]; then
+    age_hours=0
+    return 0
+  fi
+  author=$(echo "$head_json" | jq -r '.author.login // ""')
+  committer=$(echo "$head_json" | jq -r '.committer.login // ""')
+  if { [ -n "$author" ] && [ "$author" != "$RENOVATE_AUTHOR" ]; } ||
+     { [ -n "$committer" ] && [ "$committer" != "$RENOVATE_AUTHOR" ] && [ "$committer" != "$GITHUB_SIGNING_COMMITTER" ]; }; then
+    head_modified=true
+  fi
+  head_date=$(echo "$head_json" | jq -r '.commit.committer.date // ""')
   if [ -n "$head_date" ]; then
     head_epoch=$(date -u -d "$head_date" +%s 2>/dev/null || echo "$NOW_EPOCH")
   else
     head_epoch=$NOW_EPOCH
   fi
   age_hours=$(( (NOW_EPOCH - head_epoch) / 3600 ))
+}
+
+# Compute staleness for one PR: sets behind_by, age_hours, stale, head_modified
+# (globals). Cost: 1 compare + 1 commit GET (the latter via fetch_head_meta).
+# Called only for states whose decision can depend on staleness
+# (blocked/unstable/clean/has_hooks).
+compute_staleness() {
+  local base="$1" head_sha="$2" base_enc
+  # URL-encode '/' in the base ref so base branches like `stable/8.7` don't break the path.
+  base_enc="${base//\//%2F}"
+  behind_by=$(gh_api "repos/${REPOSITORY}/compare/${base_enc}...${head_sha}" --jq '.behind_by' 2>/dev/null || echo 0)
+  [ -z "$behind_by" ] && behind_by=0
+  fetch_head_meta "$head_sha"
   if [ "$behind_by" -ge "$BEHIND_THRESHOLD" ] || [ "$age_hours" -ge "$STALE_HOURS" ]; then
     stale=true
   fi
@@ -248,23 +283,35 @@ classify_one_pr() {
   #   - rerun eligibility (check-runs + actions/runs, the costliest pair) only
   #     matters for blocked/unstable that are NOT stale, so it is skipped
   #     entirely once a blocked/unstable PR is found stale.
-  # dirty/behind/unknown have a fixed action and fetch nothing further.
+  #   - head ownership (head_modified) gates every action that would push a new
+  #     SHA; it rides along on the commit GET that staleness already does, and
+  #     is fetched standalone for `behind` (otherwise a no-fetch state).
+  # dirty/unknown have a fixed action and fetch nothing further.
   # apply.sh consumes only number/action/run_ids, so the defaulted diagnostic
   # fields (behind_by/age_hours) on fixed-action states are cosmetic, not load-bearing.
   local behind_by=0 age_hours=0 required_count=0 eligible_ids="[]" eligible_count=0 stale=false
+  local head_modified=false head_meta_done=false
   local action="none" reason=""
   case "$ms" in
     dirty)
       action="skip"; reason="merge conflict; Renovate owns the rebase" ;;
     behind)
-      action="rebase"; reason="behind base (require-up-to-date blocks merge)" ;;
+      # A rebase here would push a fresh SHA, so honor an edited branch first.
+      fetch_head_meta "$head_sha"
+      if [ "$head_modified" = "true" ]; then
+        action="skip"; reason="branch edited by non-Renovate author; leave for human (rebase would discard manual commits)"
+      else
+        action="rebase"; reason="behind base (require-up-to-date blocks merge)"
+      fi ;;
     blocked|unstable)
       # Staleness wins over rerun: a stale PR must rebase to merge anyway, so
       # rerunning its (stale) SHA burns a full CI matrix for nothing. Only when
       # fresh do we pay for rerun eligibility and prefer the cheap failed-job
-      # rerun over a full rebase.
+      # rerun over a full rebase. compute_staleness also sets head_modified.
       compute_staleness "$base" "$head_sha"
-      if [ "$stale" = "true" ]; then
+      if [ "$head_modified" = "true" ]; then
+        action="skip"; reason="branch edited by non-Renovate author; leave for human (Renovate won't auto-rebase it)"
+      elif [ "$stale" = "true" ]; then
         action="rebase"; reason="checks failing + stale -> rebase (fresh SHA; skip rerun on stale code)"
       else
         compute_rerun_eligibility "$base" "$head_sha"
@@ -276,7 +323,9 @@ classify_one_pr() {
       fi ;;
     clean|has_hooks)
       compute_staleness "$base" "$head_sha"
-      if [ "$stale" = "true" ]; then
+      if [ "$head_modified" = "true" ]; then
+        action="skip"; reason="branch edited by non-Renovate author; leave for human (Renovate won't auto-rebase it)"
+      elif [ "$stale" = "true" ]; then
         action="rebase"; reason="stale (behind_by>=${BEHIND_THRESHOLD} or age>=${STALE_HOURS}h)"
       else
         action="none"; reason="fresh & green"

--- a/renovate-pr-maintainer/classify.sh
+++ b/renovate-pr-maintainer/classify.sh
@@ -6,6 +6,10 @@
 # JSON plan to $PLAN_FILE which apply.sh consumes.
 #
 # Decision model (see camunda/team-infrastructure#1053):
+#   - already carries the rebase label               -> pending (rebase requested but not
+#                                                       yet consumed by Renovate; do
+#                                                       nothing, just report), checked
+#                                                       first — cheapest, no fetch needed
 #   - branch edited by a non-Renovate author        -> skip (Renovate's "Edited/Blocked"
 #                                                       state; rebasing would discard the
 #                                                       human's commits), checked first
@@ -31,6 +35,10 @@ BEHIND_THRESHOLD="${BEHIND_THRESHOLD:-60}"
 STALE_HOURS="${STALE_HOURS:-24}"
 RERUN_BUDGET="${RERUN_BUDGET:-1}"
 BASE_BRANCH="${BASE_BRANCH:-}"
+# Renovate's rebase label. A PR already carrying it has a rebase queued (Renovate
+# strips the label once it rebases), so the maintainer leaves it alone and just
+# reports it. Must match apply.sh's REBASE_LABEL.
+REBASE_LABEL="${REBASE_LABEL:-rebase}"
 # GitHub stamps this login as the committer on Renovate's API-created (signed)
 # commits, so it is treated as Renovate-owned, not a human edit. Any other
 # non-Renovate author/committer on the head commit marks the branch as edited.
@@ -270,6 +278,20 @@ classify_one_pr() {
   num=$(echo "$cand" | jq -r '.number')
   base=$(echo "$cand" | jq -r '.base')
   head_sha=$(echo "$cand" | jq -r '.head_sha')
+
+  # Already-queued rebase: the PR still carries the Renovate rebase label, so a
+  # rebase was requested but Renovate has not consumed it yet (it strips the
+  # label once done). Re-adding the label is a no-op and any CI we trigger now is
+  # wasted because the SHA is about to change, so do nothing and report it. The
+  # label list is already in the candidate, so this short-circuits before the
+  # mergeable_state poll and every per-PR fetch — the cheapest exit.
+  if [ -n "$REBASE_LABEL" ] && echo "$cand" | jq -e --arg l "$REBASE_LABEL" '(.labels // []) | index($l)' >/dev/null; then
+    echo "PR #${num} [rebase-labeled] -> pending (rebase already requested; awaiting Renovate)" >&2
+    jq -nc --argjson num "$num" \
+      '{number: $num, state: "rebase-labeled", action: "pending", reason: "rebase label already set; awaiting Renovate", run_ids: [], behind_by: 0, age_hours: 0}' \
+      > "$out_file"
+    return 0
+  fi
 
   # mergeable_state is computed asynchronously and reset by base pushes; poll
   # with backoff. A residual "unknown" is handled conservatively in the case

--- a/renovate-pr-maintainer/classify.sh
+++ b/renovate-pr-maintainer/classify.sh
@@ -8,8 +8,10 @@
 # Decision model (see camunda/team-infrastructure#1053):
 #   - dirty (merge conflict)                  -> skip   (Renovate rebases conflicts itself)
 #   - behind (blocked by "require up to date") -> rebase (apply the rebase label)
-#   - blocked/unstable (required checks red)   -> rerun  if a failed run still has budget,
-#                                                 else rebase if stale, else none
+#   - blocked/unstable (required checks red)   -> rebase if stale (rerunning stale code
+#                                                 burns CI for a SHA that can't merge),
+#                                                 else rerun if a failed run has budget,
+#                                                 else none
 #   - clean/has_hooks                          -> rebase if stale, else none
 #   - unknown (mergeability not yet computed)  -> none   (defer; never act on a guess)
 #
@@ -241,10 +243,11 @@ classify_one_pr() {
 
   # Per-PR diagnostic/plan fields. Defaulted here, then filled lazily by the
   # case below — we only fetch what each state's decision actually needs:
+  #   - staleness (compare + commit date) gates every rebase-on-stale state
+  #     (blocked/unstable/clean/has_hooks) and is checked first for those.
   #   - rerun eligibility (check-runs + actions/runs, the costliest pair) only
-  #     matters for blocked/unstable.
-  #   - staleness (compare + commit date) only matters for states that can
-  #     rebase-on-stale (blocked/unstable/clean/has_hooks).
+  #     matters for blocked/unstable that are NOT stale, so it is skipped
+  #     entirely once a blocked/unstable PR is found stale.
   # dirty/behind/unknown have a fixed action and fetch nothing further.
   # apply.sh consumes only number/action/run_ids, so the defaulted diagnostic
   # fields (behind_by/age_hours) on fixed-action states are cosmetic, not load-bearing.
@@ -256,16 +259,20 @@ classify_one_pr() {
     behind)
       action="rebase"; reason="behind base (require-up-to-date blocks merge)" ;;
     blocked|unstable)
-      # Needs rerun eligibility; staleness is the rebase fallback and also
-      # populates behind_by/age diagnostics for these (the actionable) PRs.
-      compute_rerun_eligibility "$base" "$head_sha"
+      # Staleness wins over rerun: a stale PR must rebase to merge anyway, so
+      # rerunning its (stale) SHA burns a full CI matrix for nothing. Only when
+      # fresh do we pay for rerun eligibility and prefer the cheap failed-job
+      # rerun over a full rebase.
       compute_staleness "$base" "$head_sha"
-      if [ "$eligible_count" -gt 0 ]; then
-        action="rerun"; reason="failing required checks; rerun ${eligible_count} run(s) (budget left)"
-      elif [ "$stale" = "true" ]; then
-        action="rebase"; reason="checks failing, no required rerun left, stale -> fresh SHA"
+      if [ "$stale" = "true" ]; then
+        action="rebase"; reason="checks failing + stale -> rebase (fresh SHA; skip rerun on stale code)"
       else
-        action="none"; reason="checks failing, no required rerun candidate, not stale"
+        compute_rerun_eligibility "$base" "$head_sha"
+        if [ "$eligible_count" -gt 0 ]; then
+          action="rerun"; reason="failing required checks on fresh SHA; rerun ${eligible_count} run(s) (budget left)"
+        else
+          action="none"; reason="checks failing, fresh, no required rerun candidate"
+        fi
       fi ;;
     clean|has_hooks)
       compute_staleness "$base" "$head_sha"

--- a/renovate-pr-maintainer/classify.sh
+++ b/renovate-pr-maintainer/classify.sh
@@ -15,7 +15,8 @@
 #                                                       human's commits), checked first
 #                                                       for every actionable state below
 #   - dirty (merge conflict)                  -> skip   (Renovate rebases conflicts itself)
-#   - behind (blocked by "require up to date") -> rebase (apply the rebase label)
+#   - behind (blocked by "require up to date") -> rebase if REQUIRE_UP_TO_DATE=true,
+#                                                 else decided by staleness (like clean)
 #   - blocked/unstable (required checks red)   -> rebase if stale (rerunning stale code
 #                                                 burns CI for a SHA that can't merge),
 #                                                 else rerun if a failed run has budget,
@@ -33,8 +34,18 @@ RENOVATE_AUTHOR="${RENOVATE_AUTHOR:-renovate[bot]}"
 EXCLUDE_LABELS="${EXCLUDE_LABELS:-keep-updated,stop-updating}"
 BEHIND_THRESHOLD="${BEHIND_THRESHOLD:-60}"
 STALE_HOURS="${STALE_HOURS:-24}"
-RERUN_BUDGET="${RERUN_BUDGET:-1}"
+RERUN_BUDGET="${RERUN_BUDGET:-0}"
+# Comma- or newline-separated extra check-run names to treat as required for the
+# rerun decision, unioned with the contexts discovered from rulesets. Lets an
+# operator opt a non-required check (e.g. a flaky job, or one enforced only via
+# classic branch protection, which this action does not read) into reruns.
+EXTRA_RERUN_CHECKS="${EXTRA_RERUN_CHECKS:-}"
 BASE_BRANCH="${BASE_BRANCH:-}"
+# When false (default), the `behind` mergeable_state ("Require branches to be up
+# to date before merging") is ignored from the decision logic: a behind PR is
+# decided purely by staleness, like a clean PR. Set true to treat behind as a
+# hard merge blocker and rebase it immediately.
+REQUIRE_UP_TO_DATE="${REQUIRE_UP_TO_DATE:-false}"
 # Renovate's rebase label. A PR already carrying it has a rebase queued (Renovate
 # strips the label once it rebases), so the maintainer leaves it alone and just
 # reports it. Must match apply.sh's REBASE_LABEL.
@@ -43,6 +54,12 @@ REBASE_LABEL="${REBASE_LABEL:-rebase}"
 # commits, so it is treated as Renovate-owned, not a human edit. Any other
 # non-Renovate author/committer on the head commit marks the branch as edited.
 GITHUB_SIGNING_COMMITTER="${GITHUB_SIGNING_COMMITTER:-web-flow}"
+# Comma- or newline-separated extra logins (author or committer) that are ALSO
+# treated as Renovate-owned, in addition to RENOVATE_AUTHOR and
+# GITHUB_SIGNING_COMMITTER. Lets trusted automation that pushes follow-up commits
+# to Renovate branches (e.g. github-actions[bot] running upgrade scripts) avoid
+# being misread as a human edit. Whitespace around entries is trimmed.
+EXTRA_TRUSTED_LOGINS="${EXTRA_TRUSTED_LOGINS:-}"
 # Polling for GitHub's asynchronously-computed mergeable_state. Every push to
 # the base branch resets it to "unknown", so a single retry is often not enough
 # on busy repos; poll a few times with backoff before giving up.
@@ -160,8 +177,10 @@ required_checks_for_base() {
 }
 
 echo "Scanning open PRs in ${REPOSITORY} authored by '${RENOVATE_AUTHOR}'"
-echo "Thresholds: behind_by>=${BEHIND_THRESHOLD}, age>=${STALE_HOURS}h, rerun-budget=${RERUN_BUDGET}"
+echo "Thresholds: behind_by>=${BEHIND_THRESHOLD}, age>=${STALE_HOURS}h, rerun-budget=${RERUN_BUDGET}, require-up-to-date=${REQUIRE_UP_TO_DATE}"
 [ -n "$BASE_BRANCH" ] && echo "Base-branch filter: ${BASE_BRANCH}"
+[ -n "$EXTRA_TRUSTED_LOGINS" ] && echo "Extra trusted logins (author/committer): ${EXTRA_TRUSTED_LOGINS}"
+[ -n "$EXTRA_RERUN_CHECKS" ] && echo "Extra rerun checks: ${EXTRA_RERUN_CHECKS}"
 
 # List open PRs (the list endpoint omits mergeable_state, so we only collect
 # cheap metadata here and fetch mergeable_state per-PR below).
@@ -192,13 +211,31 @@ while IFS= read -r warm_base; do
   required_checks_for_base "$warm_base" >/dev/null
 done < <(echo "$candidates" | jq -r '.[].base' | sort -u)
 
+# True when $1 is one of the EXTRA_TRUSTED_LOGINS extra logins. The list is
+# split on commas AND newlines and each entry is whitespace-trimmed, so a YAML
+# block scalar (one login per line) works as well as a comma-separated string.
+# Widens the set of identities considered Renovate-owned beyond RENOVATE_AUTHOR
+# and GITHUB_SIGNING_COMMITTER. An empty login or empty list is never a match
+# (the caller handles the empty-login case).
+login_is_extra_allowed() {
+  local login="$1" extra
+  { [ -z "$login" ] || [ -z "$EXTRA_TRUSTED_LOGINS" ]; } && return 1
+  # `|| [ -n "$extra" ]` processes the final entry even when the pipeline emits
+  # no trailing newline (true for a single login or the last item of any list).
+  while IFS= read -r extra || [ -n "$extra" ]; do
+    [ -n "$extra" ] && [ "$login" = "$extra" ] && return 0
+  done < <(printf '%s' "$EXTRA_TRUSTED_LOGINS" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+  return 1
+}
+
 # Fetch the head commit once and derive age + edit ownership: sets age_hours and
 # head_modified (globals), memoized per PR via head_meta_done. Renovate refuses
 # to auto-rebase a branch it did not author ("Edited/Blocked"); we mirror that by
 # flagging head_modified when the head commit's author or committer is anyone
 # other than Renovate (GITHUB_SIGNING_COMMITTER is Renovate's signed-commit
-# committer and does not count). Login mapping is best-effort: an unmapped author
-# (null login) is treated as Renovate-owned to avoid skipping legitimate PRs.
+# committer and does not count, and EXTRA_TRUSTED_LOGINS adds further
+# trusted logins). Login mapping is best-effort: an unmapped author (null login)
+# is treated as Renovate-owned to avoid skipping legitimate PRs.
 # Cost: 1 commit GET (shared with compute_staleness).
 fetch_head_meta() {
   local head_sha="$1" head_json author committer head_date head_epoch
@@ -211,8 +248,8 @@ fetch_head_meta() {
   fi
   author=$(echo "$head_json" | jq -r '.author.login // ""')
   committer=$(echo "$head_json" | jq -r '.committer.login // ""')
-  if { [ -n "$author" ] && [ "$author" != "$RENOVATE_AUTHOR" ]; } ||
-     { [ -n "$committer" ] && [ "$committer" != "$RENOVATE_AUTHOR" ] && [ "$committer" != "$GITHUB_SIGNING_COMMITTER" ]; }; then
+  if { [ -n "$author" ] && [ "$author" != "$RENOVATE_AUTHOR" ] && ! login_is_extra_allowed "$author"; } ||
+     { [ -n "$committer" ] && [ "$committer" != "$RENOVATE_AUTHOR" ] && [ "$committer" != "$GITHUB_SIGNING_COMMITTER" ] && ! login_is_extra_allowed "$committer"; }; then
     head_modified=true
   fi
   head_date=$(echo "$head_json" | jq -r '.commit.committer.date // ""')
@@ -242,21 +279,43 @@ compute_staleness() {
 
 # Compute rerun eligibility for one PR, scoped to REQUIRED checks only:
 #   failing required check-run -> its check suite -> the workflow run that produced it.
-# Sets required_count, eligible_ids, eligible_count (globals). This avoids
-# rerunning non-required (non-blocking) workflows.
+# The required set is the ruleset-discovered contexts unioned with EXTRA_RERUN_CHECKS.
+# Sets required_count, eligible_ids, eligible_count, checks_in_progress (globals).
+# This avoids rerunning non-required (non-blocking) workflows.
 # Cost: 1 check-runs + 1 actions/runs GET (both paginated — the most expensive
-# pair). Called only for blocked/unstable, the only states with a rerun path.
+# pair). Called for blocked/unstable and for behind when require-up-to-date is
+# disabled (the states with a rerun path); short-circuits when reruns are off.
 compute_rerun_eligibility() {
   local base="$1" head_sha="$2" required_checks required_json checkruns_ndjson failing_suites runs_ndjson
+  # Reruns disabled (budget < 1): no run can ever be eligible (run_attempt is
+  # always >= 1), so short-circuit before the two costly paginated GETs.
+  if [ "$RERUN_BUDGET" -lt 1 ]; then
+    required_count=0; eligible_ids="[]"; eligible_count=0; checks_in_progress=false; failing_required_count=0
+    return 0
+  fi
   required_checks=$(required_checks_for_base "$base")
-  required_json=$(printf '%s\n' "$required_checks" | jq -R . | jq -s 'map(select(length > 0))')
+  # Union the ruleset-discovered contexts with any operator-supplied extra rerun
+  # checks (comma- or newline-separated, whitespace-trimmed, de-duplicated). With
+  # no extras this is identical to the ruleset set (already sort -u'd).
+  required_json=$(
+    { printf '%s\n' "$required_checks"
+      printf '%s' "$EXTRA_RERUN_CHECKS" | tr ',' '\n'
+    } | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | jq -R . | jq -s 'map(select(length > 0)) | unique')
   required_count=$(echo "$required_json" | jq 'length')
 
-  # Check suites on the head SHA that contain a failing REQUIRED check-run.
+  # Check suites on the head SHA that contain a failing REQUIRED check-run. We
+  # also carry each run's status so we can tell "failing" from "still running":
+  # GitHub reports `unstable` for both a failing AND a merely-pending non-required
+  # check, so a fresh PR with no rerun candidate may simply be mid-CI.
   checkruns_ndjson=$(gh_api "repos/${REPOSITORY}/commits/${head_sha}/check-runs?per_page=100" --paginate \
-    --jq '.check_runs[] | {name, conclusion, suite: .check_suite.id}' 2>/dev/null || echo "")
+    --jq '.check_runs[] | {name, status, conclusion, suite: .check_suite.id}' 2>/dev/null || echo "")
+  checks_in_progress=$(printf '%s\n' "$checkruns_ndjson" | jq -s 'any(.[]; .status != "completed")' 2>/dev/null || echo false)
   failing_suites=$(printf '%s\n' "$checkruns_ndjson" | jq -s --argjson req "$required_json" \
     '[.[] | select(.conclusion == "failure" and ((.name as $n | $req | index($n)) != null)) | .suite] | unique' 2>/dev/null || echo "[]")
+  # Number of failing REQUIRED suites, regardless of rerun budget. Lets the
+  # caller distinguish "a required check is failing but its run is over budget"
+  # from "nothing required is failing" — they look identical via eligible_count.
+  failing_required_count=$(echo "$failing_suites" | jq 'length' 2>/dev/null || echo 0)
 
   # Workflow runs whose suite has a failing required check, still within rerun budget.
   runs_ndjson=$(gh_api "repos/${REPOSITORY}/actions/runs?head_sha=${head_sha}&per_page=100" --paginate \
@@ -264,6 +323,22 @@ compute_rerun_eligibility() {
   eligible_ids=$(printf '%s\n' "$runs_ndjson" | jq -s --argjson n "$RERUN_BUDGET" --argjson suites "$failing_suites" \
     '[.[] | select(((.suite as $s | $suites | index($s)) != null) and .run_attempt <= $n) | .id] | unique' 2>/dev/null || echo "[]")
   eligible_count=$(echo "$eligible_ids" | jq 'length' 2>/dev/null || echo 0)
+}
+
+# Reason for a fresh PR that ends up with no rerun ($1 = context prefix). Keeps
+# the wording honest: a no-candidate `unstable`/`behind` PR is often just mid-CI
+# (pending non-required checks), not actually failing. Reads RERUN_BUDGET,
+# checks_in_progress and failing_required_count (globals).
+no_rerun_reason() {
+  if [ "$RERUN_BUDGET" -lt 1 ]; then
+    printf '%sreruns disabled (rerun-budget=0)' "$1"
+  elif [ "$failing_required_count" -gt 0 ]; then
+    printf '%sfailing required check but rerun budget exhausted (attempt > %s)' "$1" "$RERUN_BUDGET"
+  elif [ "$checks_in_progress" = "true" ]; then
+    printf '%schecks still in progress, nothing to rerun yet' "$1"
+  else
+    printf '%sno failing required check to rerun' "$1"
+  fi
 }
 
 entries=()
@@ -303,8 +378,9 @@ classify_one_pr() {
   #   - staleness (compare + commit date) gates every rebase-on-stale state
   #     (blocked/unstable/clean/has_hooks) and is checked first for those.
   #   - rerun eligibility (check-runs + actions/runs, the costliest pair) only
-  #     matters for blocked/unstable that are NOT stale, so it is skipped
-  #     entirely once a blocked/unstable PR is found stale.
+  #     matters for a fresh PR with a rerun path (blocked/unstable, or behind
+  #     when require-up-to-date is disabled), so it is skipped once such a PR is
+  #     found stale, and short-circuits entirely when reruns are off.
   #   - head ownership (head_modified) gates every action that would push a new
   #     SHA; it rides along on the commit GET that staleness already does, and
   #     is fetched standalone for `behind` (otherwise a no-fetch state).
@@ -312,18 +388,42 @@ classify_one_pr() {
   # apply.sh consumes only number/action/run_ids, so the defaulted diagnostic
   # fields (behind_by/age_hours) on fixed-action states are cosmetic, not load-bearing.
   local behind_by=0 age_hours=0 required_count=0 eligible_ids="[]" eligible_count=0 stale=false
-  local head_modified=false head_meta_done=false
+  local head_modified=false head_meta_done=false checks_in_progress=false failing_required_count=0
   local action="none" reason=""
   case "$ms" in
     dirty)
       action="skip"; reason="merge conflict; Renovate owns the rebase" ;;
     behind)
-      # A rebase here would push a fresh SHA, so honor an edited branch first.
-      fetch_head_meta "$head_sha"
-      if [ "$head_modified" = "true" ]; then
-        action="skip"; reason="branch edited by non-Renovate author; leave for human (rebase would discard manual commits)"
+      if [ "$REQUIRE_UP_TO_DATE" = "true" ]; then
+        # "Require branches up to date" blocks the merge until a rebase happens,
+        # so a rebase is unavoidable regardless of staleness. It pushes a fresh
+        # SHA, so honor an edited branch first.
+        fetch_head_meta "$head_sha"
+        if [ "$head_modified" = "true" ]; then
+          action="skip"; reason="branch edited by non-Renovate author; leave for human (rebase would discard manual commits)"
+        else
+          action="rebase"; reason="behind base (require-up-to-date blocks merge)"
+        fi
       else
-        action="rebase"; reason="behind base (require-up-to-date blocks merge)"
+        # require-up-to-date disabled: `behind` is not itself a blocker, but
+        # GitHub's `behind` state masks any failing-check state (behind outranks
+        # blocked/unstable in mergeable_state). So decide exactly like
+        # blocked/unstable: staleness first, then rerun failing required checks
+        # on a fresh SHA. Without this, a behind PR's failing checks would never
+        # be rerun — and on busy repos nearly every PR is behind.
+        compute_staleness "$base" "$head_sha"
+        if [ "$head_modified" = "true" ]; then
+          action="skip"; reason="branch edited by non-Renovate author; leave for human (Renovate won't auto-rebase it)"
+        elif [ "$stale" = "true" ]; then
+          action="rebase"; reason="stale (behind_by>=${BEHIND_THRESHOLD} or age>=${STALE_HOURS}h)"
+        else
+          compute_rerun_eligibility "$base" "$head_sha"
+          if [ "$eligible_count" -gt 0 ]; then
+            action="rerun"; reason="behind (ignored) + failing required checks on fresh SHA; rerun ${eligible_count} run(s) (budget left)"
+          else
+            action="none"; reason="$(no_rerun_reason "behind (ignored), fresh; ")"
+          fi
+        fi
       fi ;;
     blocked|unstable)
       # Staleness wins over rerun: a stale PR must rebase to merge anyway, so
@@ -334,13 +434,13 @@ classify_one_pr() {
       if [ "$head_modified" = "true" ]; then
         action="skip"; reason="branch edited by non-Renovate author; leave for human (Renovate won't auto-rebase it)"
       elif [ "$stale" = "true" ]; then
-        action="rebase"; reason="checks failing + stale -> rebase (fresh SHA; skip rerun on stale code)"
+        action="rebase"; reason="stale -> rebase (fresh SHA; rerun skipped on stale code)"
       else
         compute_rerun_eligibility "$base" "$head_sha"
         if [ "$eligible_count" -gt 0 ]; then
           action="rerun"; reason="failing required checks on fresh SHA; rerun ${eligible_count} run(s) (budget left)"
         else
-          action="none"; reason="checks failing, fresh, no required rerun candidate"
+          action="none"; reason="$(no_rerun_reason "fresh; ")"
         fi
       fi ;;
     clean|has_hooks)

--- a/renovate-pr-maintainer/classify.sh
+++ b/renovate-pr-maintainer/classify.sh
@@ -5,7 +5,7 @@
 # Renovate PR and decides one of: skip / rerun / rebase / none, then writes a
 # JSON plan to $PLAN_FILE which apply.sh consumes.
 #
-# Decision model (see camunda/team-infrastructure#1053):
+# Decision model:
 #   - already carries the rebase label               -> pending (rebase requested but not
 #                                                       yet consumed by Renovate; do
 #                                                       nothing, just report), checked
@@ -236,6 +236,9 @@ login_is_extra_allowed() {
 # committer and does not count, and EXTRA_TRUSTED_LOGINS adds further
 # trusted logins). Login mapping is best-effort: an unmapped author (null login)
 # is treated as Renovate-owned to avoid skipping legitimate PRs.
+# If the commit GET itself fails (after retries), we fail closed and mark the
+# head modified: an unverifiable branch must never be rebased ("never rebases
+# human-edited branches"); the PR is just deferred to the next run.
 # Cost: 1 commit GET (shared with compute_staleness).
 fetch_head_meta() {
   local head_sha="$1" head_json author committer head_date head_epoch
@@ -243,6 +246,8 @@ fetch_head_meta() {
   head_meta_done=true
   head_json=$(gh_api "repos/${REPOSITORY}/commits/${head_sha}" 2>/dev/null || echo "")
   if [ -z "$head_json" ]; then
+    # Fail closed: ownership unverifiable, so block any rebase of this branch.
+    head_modified=true
     age_hours=0
     return 0
   fi


### PR DESCRIPTION
# Description

Hardens and speeds up `renovate-pr-maintainer`, the scheduled action that keeps Renovate PRs fresh and unstuck on repos using `rebaseWhen: "conflicted"` (camunda/team-infrastructure#1053).

- **Better runtime efficiency**: caching, lazy fetches, and concurrent classification
- **Cautious writes**: never rebases human-edited branches
- **More accurate plan output**: reports in-progress and over-budget checks distinctly instead of "failing"
- **Opt-in controls**: `require-up-to-date`, `extra-trusted-logins`, `extra-rerun-checks`, and `rerun-budget` (reruns now opt-in)

A subset of the multiple tests performed:
- https://github.com/camunda/infra-core/actions/runs/27608630105
- https://github.com/camunda/infra-core/actions/runs/27608739837
- https://github.com/camunda/infra-core/actions/runs/27618832323

Related:
- camunda/team-infrastructure#1053
