### PR TITLE
feat: resolve vuln-gate base to nearest snapshotted ancestor

### DIFF
--- a/dependency-vuln-check/README.md
+++ b/dependency-vuln-check/README.md
@@ -34,7 +34,11 @@ version shows up as `added` in the diff and is evaluated normally.
   with:
     base-sha: ${{ github.event.pull_request.base.sha }}
     head-sha: ${{ github.event.pull_request.head.sha }}
+    base-ref: ${{ github.event.pull_request.base.ref }}
+    snapshot-workflow: maven-dependency-snapshot.yml
     # optional — defaults shown
+    max-snapshot-lookback: "30"
+    override-label: ci:vuln-gate-override
     config-file: .github/dependency-review-config.json
     fail-on-severity: high
     fail-on-fixable-severity: low
@@ -47,6 +51,10 @@ version shows up as `added` in the diff and is evaluated normally.
 |-------|----------|---------|-------------|
 | `base-sha` | yes | — | Base commit SHA of the PR |
 | `head-sha` | yes | — | Head commit SHA of the PR |
+| `base-ref` | yes | — | Base **branch** of the PR (e.g. `main`, `stable/8.8`). Used to find the nearest snapshotted ancestor on the correct branch |
+| `snapshot-workflow` | yes | — | Filename of the workflow that submits the base snapshot (e.g. `maven-dependency-snapshot.yml`). Its successful push-event runs are scanned to resolve the effective base |
+| `max-snapshot-lookback` | no | `30` | How many recent successful snapshot runs to scan when resolving the effective base |
+| `override-label` | no | `ci:vuln-gate-override` | PR label that bypasses the gate **only** when it cannot verify the PR (outage / no-ancestor). Never bypasses a real finding |
 | `config-file` | no | `.github/dependency-review-config.json` | Path to the JSON config holding `allow-ghsas` |
 | `fail-on-severity` | no | `high` | Min severity (`low`/`moderate`/`high`/`critical`) that blocks when **no fix** is available |
 | `fail-on-fixable-severity` | no | `low` | Min severity that blocks when a **fix is** available |
@@ -59,15 +67,55 @@ The action uses the workflow's `github.token`. The calling job must grant:
 ```yaml
 permissions:
   contents: read         # read the dependency graph / Dependency Review API
-  pull-requests: write   # post or update the findings comment
+  actions: read          # list snapshot-workflow runs to resolve the effective base
+  pull-requests: write   # post or update the findings comment; read the override label
 ```
 
-- `contents: read` is required for `GET /repos/{owner}/{repo}/dependency-graph/compare/{base}...{head}`.
-  The repository must have the **Dependency graph** feature enabled.
-- `pull-requests: write` is required to post the findings comment. On **fork PRs** the
-  token is often read-only; the action then emits a `::warning::` instead of failing.
+- `contents: read` is required for `GET /repos/{owner}/{repo}/dependency-graph/compare/{base}...{head}`
+  **and** the commit-compare used during base resolution. The repository must have the
+  **Dependency graph** feature enabled.
+- `actions: read` is required to list runs of the `snapshot-workflow`
+  (`GET /repos/{owner}/{repo}/actions/workflows/{workflow}/runs`) when resolving the base.
+- `pull-requests: write` is required to post the findings comment and to read the PR's
+  labels (override check). On **fork PRs** the token is often read-only; the action then
+  emits a `::warning::` instead of failing.
 - The GraphQL Advisory fallback (used only when the diff omits `first_patched_version`)
   reads public advisory data and needs no extra scope.
+
+## Base-snapshot resolution & fail-closed contract
+
+The diff compares `effective_base...head`, **not** the raw `base.sha`. The base snapshot
+workflow is path-filtered (it only runs when poms change), so a code-only base commit has
+**no snapshot** — leaving the base side of the compare empty and flagging the *entire* head
+tree as `added` (pre-existing dependencies falsely surface as new). To avoid this, the action
+resolves `base.sha` to the most recent commit on `base-ref` that has a submitted snapshot and
+is an **ancestor-or-equal** of `base.sha`, then diffs from there.
+
+The gate **fails closed** when it cannot verify a PR:
+
+| Situation | Result |
+|-----------|--------|
+| GitHub API error, transient | retried (3 attempts, exponential backoff) |
+| API error survives retries | **fail closed** (block), reason named in the log |
+| No snapshotted ancestor found within `max-snapshot-lookback` | **fail closed** (block) |
+| API works, real vulnerable dependency added | block (normal finding) |
+| API works, no vulnerable dependency added | pass |
+
+Every run writes a summary trail (resolved base, runs scanned, verdict). Failure reasons are
+named explicitly in the log (rate-limit vs 5xx vs timeout vs permissions vs not-found).
+
+### Override label (for sustained outages)
+
+If the gate fails closed because it genuinely **cannot verify** the PR (a sustained GitHub
+outage, or no resolvable base snapshot), a maintainer may bypass it:
+
+1. Add the `override-label` (default `ci:vuln-gate-override`) to the PR.
+2. **Re-run** the failed gate job.
+
+The label is read **live** from the PR (not the frozen event payload), so a re-run after
+labeling takes effect. The bypass is logged loudly (`::warning::` + PR comment) for audit. The
+label **never** bypasses a real vulnerability finding — only the can't-verify (fail-closed)
+paths. Create the label in the consuming repo first: `gh label create "ci:vuln-gate-override"`.
 
 ## Configuration — exceptions (`allow-ghsas`)
 
@@ -128,15 +176,18 @@ your-repo/
 - Posts (or updates in place) a single PR comment marked `<!-- dependency-vuln-check -->`,
   with separate sections for blocking findings (🚨), allowed exceptions (⚠️), and
   non-gated-scope findings (⚠️).
-- Writes the same tables to the job step summary.
-- Exits non-zero if any blocking finding remains.
+- Writes the same tables to the job step summary, plus the resolved-base trail.
+- Exits non-zero if any blocking finding remains, or if the gate fails closed
+  (unverifiable PR without the override label).
 
 ## Limitations
 
 - Evaluates only **newly added** dependencies in the PR diff; deps already on the base
   branch are not re-scanned (pair with a scheduled SCA scan for ongoing monitoring).
 - For transitive / BOM-pinned dependencies to appear in the diff, both base and head
-  commits need a submitted dependency snapshot (GitHub Dependency Submission API).
+  commits need a submitted dependency snapshot (GitHub Dependency Submission API). The
+  base side is resolved automatically to the nearest snapshotted ancestor; the head side
+  must be submitted by the consuming workflow before this action runs.
 
 ## Tests
 

--- a/dependency-vuln-check/action.yml
+++ b/dependency-vuln-check/action.yml
@@ -16,6 +16,31 @@ inputs:
   head-sha:
     description: Head commit SHA of the pull request
     required: true
+  base-ref:
+    description: >
+      Base branch of the pull request (e.g. main, stable/8.8). Used to find the
+      nearest snapshotted ancestor of base-sha on the correct branch.
+    required: true
+  snapshot-workflow:
+    description: >
+      Filename of the workflow that submits the base Maven dependency snapshot
+      (e.g. maven-dependency-snapshot.yml). Its successful push-event runs are
+      scanned to resolve the effective base.
+    required: true
+  max-snapshot-lookback:
+    description: >
+      How many recent successful snapshot-workflow runs to scan when resolving the
+      effective base. The nearest ancestor is normally near the top; raise this only
+      if a very old base must be resolved.
+    required: false
+    default: "30"
+  override-label:
+    description: >
+      PR label that bypasses the gate ONLY when it cannot verify the PR (GitHub
+      outage after retries, or no snapshotted ancestor). Never bypasses a real
+      finding. Read live from the PR, so adding it and re-running takes effect.
+    required: false
+    default: ci:vuln-gate-override
   config-file:
     description: Path to the vulnerability gate config file containing the allow-ghsas list
     required: false
@@ -48,6 +73,10 @@ runs:
         GH_TOKEN: ${{ github.token }}
         BASE_SHA: ${{ inputs.base-sha }}
         HEAD_SHA: ${{ inputs.head-sha }}
+        BASE_REF: ${{ inputs.base-ref }}
+        SNAPSHOT_WORKFLOW: ${{ inputs.snapshot-workflow }}
+        MAX_SNAPSHOT_LOOKBACK: ${{ inputs.max-snapshot-lookback }}
+        OVERRIDE_LABEL: ${{ inputs.override-label }}
         CONFIG_FILE: ${{ inputs.config-file }}
         FAIL_ON_SEVERITY: ${{ inputs.fail-on-severity }}
         FAIL_ON_FIXABLE_SEVERITY: ${{ inputs.fail-on-fixable-severity }}

--- a/dependency-vuln-check/check.py
+++ b/dependency-vuln-check/check.py
@@ -10,21 +10,57 @@ two independent severity thresholds:
 Only dependencies whose scope is listed in FAIL_ON_SCOPES are gated; others are
 reported as non-blocking. Covers the downgrade scenario: a version downgrade
 shows the old version as "removed" and the new vulnerable version as "added".
+
+Base-snapshot resolution
+------------------------
+The dependency diff is ``effective_base...head``. ``effective_base`` is the most
+recent commit on the PR's base branch that (a) has a submitted Maven dependency
+snapshot and (b) is an ancestor-or-equal of the PR's ``base.sha``. Trusting the
+raw ``base.sha`` is unsafe: the snapshot workflow is path-filtered, so a code-only
+base commit has no snapshot, leaving the base side of the compare empty and
+flagging the *entire* head tree as "added" (pre-existing deps surface as new).
+
+The gate FAILS CLOSED when it cannot verify a PR (no snapshotted ancestor, or a
+GitHub API failure that survives retries). A human may bypass a genuinely
+un-checkable PR by adding the override label (read live, not from the stale event
+payload). The label never bypasses a real finding.
 """
 import json
 import os
 import re
 import sys
+import time
 import urllib.error
 import urllib.request
 
 
 _GITHUB_API = "https://api.github.com"
 _COMMENT_MARKER = "<!-- dependency-vuln-check -->"
+_DEVOPS_TEAM = "@camunda/monorepo-devops-team"
+
+# Retry policy for transient GitHub API failures (5xx, network, timeout, rate limit).
+_MAX_ATTEMPTS = 3
+_BACKOFF_BASE_SECONDS = 2
 
 # Severity ranking used by both threshold gates. These are the only values the
 # Dependency Review API emits for `severity`.
 SEVERITY_ORDER = {"low": 0, "moderate": 1, "high": 2, "critical": 3}
+
+
+class ApiError(Exception):
+    """A GitHub API call that could not be completed.
+
+    `reason` is a short, human-readable cause — deliberately named so the GHA log
+    states *why* the gate failed (rate limit vs 5xx vs timeout vs permissions vs
+    not-found), instead of a bare stack trace. `retryable` separates transient
+    infra failures (retried) from definitive responses (surfaced immediately).
+    """
+
+    def __init__(self, reason: str, status: int | None = None, retryable: bool = False):
+        self.reason = reason
+        self.status = status
+        self.retryable = retryable
+        super().__init__(reason)
 
 
 def severity_rank(name: str) -> int:
@@ -55,23 +91,145 @@ def _blocks(severity: str, fixable: bool, fail_sev_rank: int, fail_fixable_rank:
     return rank >= threshold
 
 
-def _api_get(url: str, token: str) -> list:
-    """Fetch all pages of a GitHub API GET response."""
-    results, next_url = [], url
-    while next_url:
+def _classify_http_error(e: urllib.error.HTTPError) -> ApiError:
+    """Map an HTTPError to a named ApiError, deciding retryability.
+
+    Retryable (transient infra): 5xx, 429, and 403 carrying rate-limit signals
+    (secondary rate limit). Definitive (surfaced at once): 403 without rate-limit
+    headers (genuine permission/scope denial), 404, 422, other 4xx.
+    """
+    code = e.code
+    if code >= 500:
+        return ApiError(f"GitHub server error (HTTP {code})", code, retryable=True)
+    if code == 429:
+        return ApiError("rate limit exceeded (HTTP 429)", code, retryable=True)
+    if code == 403:
+        remaining = (e.headers or {}).get("X-RateLimit-Remaining")
+        retry_after = (e.headers or {}).get("Retry-After")
+        if retry_after is not None or remaining == "0":
+            return ApiError("secondary rate limit (HTTP 403)", code, retryable=True)
+        return ApiError(
+            "permission denied — token lacks required scope (HTTP 403)", code, retryable=False
+        )
+    if code == 404:
+        return ApiError("resource not found (HTTP 404)", code, retryable=False)
+    if code == 422:
+        return ApiError("unprocessable request (HTTP 422)", code, retryable=False)
+    return ApiError(f"client error (HTTP {code})", code, retryable=False)
+
+
+def _http_get_json(url: str, token: str):
+    """Single authenticated GET, returning (parsed_json, headers).
+
+    Retries transient failures with exponential backoff; raises ApiError (with a
+    named reason) on a definitive response or once retries are exhausted. Each
+    retry is logged with its cause so the GHA log shows exactly why.
+    """
+    last: ApiError | None = None
+    for attempt in range(1, _MAX_ATTEMPTS + 1):
         req = urllib.request.Request(
-            next_url,
+            url,
             headers={
                 "Authorization": f"Bearer {token}",
                 "Accept": "application/vnd.github+json",
                 "X-GitHub-Api-Version": "2026-03-10",
             },
         )
-        with urllib.request.urlopen(req, timeout=30) as resp:
-            results.extend(json.loads(resp.read()))
-            match = re.search(r'<([^>]+)>;\s*rel="next"', resp.headers.get("Link", ""))
-            next_url = match.group(1) if match else None
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                return json.loads(resp.read()), resp.headers
+        except urllib.error.HTTPError as e:  # subclass of URLError — catch first
+            err = _classify_http_error(e)
+        except (urllib.error.URLError, TimeoutError) as e:
+            err = ApiError(f"network error ({e})", None, retryable=True)
+
+        if not err.retryable:
+            print(f"::error::API call failed, no retry ({err.reason}): {url}")
+            raise err
+        last = err
+        if attempt < _MAX_ATTEMPTS:
+            delay = _BACKOFF_BASE_SECONDS * (2 ** (attempt - 1))
+            print(
+                f"::warning::API call failed (attempt {attempt}/{_MAX_ATTEMPTS}, {err.reason}) "
+                f"— retrying in {delay}s: {url}"
+            )
+            time.sleep(delay)
+    print(f"::error::API call failed after {_MAX_ATTEMPTS} attempts ({last.reason}): {url}")
+    raise last
+
+
+def _api_get(url: str, token: str) -> list:
+    """Fetch all pages of a list GitHub API GET. Retries transient failures per page."""
+    results, next_url = [], url
+    while next_url:
+        payload, headers = _http_get_json(next_url, token)
+        results.extend(payload)
+        match = re.search(r'<([^>]+)>;\s*rel="next"', headers.get("Link", ""))
+        next_url = match.group(1) if match else None
     return results
+
+
+def _compare_status(repository: str, base: str, head: str, token: str) -> str:
+    """Return the commit-comparison status: identical | ahead | behind | diverged."""
+    payload, _ = _http_get_json(
+        f"{_GITHUB_API}/repos/{repository}/compare/{base}...{head}?per_page=1", token
+    )
+    return payload.get("status", "") if isinstance(payload, dict) else ""
+
+
+def latest_snapshotted_ancestor(
+    repository: str, base_ref: str, base_sha: str, workflow: str, token: str, lookback: int
+):
+    """Most recent snapshotted commit that is an ancestor-or-equal of base_sha.
+
+    Lists successful push-event runs of `workflow` on `base_ref` (newest-first;
+    a successful run guarantees a submitted snapshot — the workflow's submit step
+    is unconditional). For each run's head_sha, compares head_sha...base_sha and
+    accepts the first whose status is `identical` (same commit) or `ahead`
+    (base_sha is ahead → the run commit is an ancestor).
+
+    Returns (effective_base_sha, run_id, scanned_count); (None, None, scanned) if
+    no ancestor is found within the window. Raises ApiError on API failure so the
+    caller can fail closed.
+    """
+    runs_url = (
+        f"{_GITHUB_API}/repos/{repository}/actions/workflows/{workflow}/runs"
+        f"?branch={base_ref}&status=success&event=push&per_page={lookback}"
+    )
+    payload, _ = _http_get_json(runs_url, token)
+    runs = payload.get("workflow_runs", []) if isinstance(payload, dict) else []
+    scanned = 0
+    for run in runs:
+        head = run.get("head_sha")
+        if not head:
+            continue
+        scanned += 1
+        status = _compare_status(repository, head, base_sha, token)
+        if status in ("identical", "ahead"):
+            return head, run.get("id"), scanned
+    return None, None, scanned
+
+
+def has_override_label(repository: str, pr_number, token: str, label: str) -> bool:
+    """Live read of the PR's labels (NOT the stale event payload) to honor a
+    freshly-added override label on a re-run.
+
+    Best-effort: on label-API failure we cannot confirm an override, so we return
+    False and stay fail-closed (logged).
+    """
+    if not pr_number:
+        return False
+    try:
+        labels = _api_get(
+            f"{_GITHUB_API}/repos/{repository}/issues/{pr_number}/labels", token
+        )
+    except ApiError as e:
+        print(
+            f"::warning::Could not read PR labels to check for '{label}' ({e.reason}) "
+            "— treating as not overridden (gate stays closed)"
+        )
+        return False
+    return any(lbl.get("name") == label for lbl in labels)
 
 
 def _ghsa_ids(vuln: dict) -> set:
@@ -218,10 +376,39 @@ def _api_write(url: str, token: str, method: str, body: dict) -> None:
         resp.read()
 
 
+def _write_summary(summary_path, text: str) -> None:
+    """Append to the GitHub Step Summary if available (always-on run trail)."""
+    if summary_path:
+        with open(summary_path, "a") as f:
+            f.write(text.rstrip("\n") + "\n")
+
+
+def _upsert_comment(repository: str, pr_number: int, token: str, body: str) -> None:
+    """Create or update the gate's single marker comment. Tolerates comment-API
+    failures (e.g. fork PR without pull-requests:write) with a warning."""
+    full = _COMMENT_MARKER + "\n" + body
+    comments_url = f"{_GITHUB_API}/repos/{repository}/issues/{pr_number}/comments"
+    try:
+        existing_id = next(
+            (c["id"] for c in _api_get(comments_url, token) if _COMMENT_MARKER in c.get("body", "")),
+            None,
+        )
+        if existing_id:
+            _api_write(
+                f"{_GITHUB_API}/repos/{repository}/issues/comments/{existing_id}",
+                token, "PATCH", {"body": full},
+            )
+        else:
+            _api_write(comments_url, token, "POST", {"body": full})
+    except (ApiError, urllib.error.HTTPError, urllib.error.URLError) as e:
+        code = getattr(e, "code", None)
+        print(f"::warning::Cannot post PR comment ({code or e}) — token may lack pull-requests:write (fork PR?)")
+
+
 def post_pr_comment(
     repository: str, pr_number: int, blocking: list, allowed: list, scope_excluded: list, token: str
 ) -> None:
-    sections = [_COMMENT_MARKER]
+    sections = []
 
     if blocking:
         sections += [
@@ -258,16 +445,74 @@ def post_pr_comment(
             _table(scope_excluded),
         ]
 
-    body = "\n".join(sections)
-    comments_url = f"{_GITHUB_API}/repos/{repository}/issues/{pr_number}/comments"
-    existing_id = next(
-        (c["id"] for c in _api_get(comments_url, token) if _COMMENT_MARKER in c.get("body", "")),
-        None,
+    _upsert_comment(repository, pr_number, token, "\n".join(sections))
+
+
+def _pr_number():
+    """PR number from the event payload, or None if unavailable."""
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if not event_path:
+        return None
+    try:
+        with open(event_path) as f:
+            return json.load(f).get("pull_request", {}).get("number")
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def fail_closed(repository, pr_number, token, override_label, reason, summary_path):
+    """Block the PR (exit 1) unless the override label is present (exit 0).
+
+    Loud on both paths: the run log, step summary, and PR comment all explain that
+    the gate could not verify the PR and why. The override label only bypasses an
+    unverifiable PR — never a real vulnerability finding.
+    """
+    if has_override_label(repository, pr_number, token, override_label):
+        msg = (
+            f"Vulnerability gate could not verify dependencies ({reason}), but the "
+            f"`{override_label}` label is present — BYPASSING. {_DEVOPS_TEAM}"
+        )
+        print(f"::warning::{msg}")
+        _write_summary(
+            summary_path,
+            f"### ⚠️ Vulnerability gate bypassed via `{override_label}`\n\n"
+            f"The gate could not verify dependencies (**{reason}**). The override label "
+            f"is present, so the PR is allowed through. {_DEVOPS_TEAM} — confirm this was intentional.",
+        )
+        if pr_number:
+            _upsert_comment(
+                repository, pr_number, token,
+                f"## ⚠️ Vulnerability Gate bypassed via `{override_label}`\n\n"
+                f"The gate could **not verify** this PR's dependencies (**{reason}**), but the "
+                f"`{override_label}` label is present, so it is being bypassed.\n\n"
+                f"{_DEVOPS_TEAM} — please confirm this bypass was intentional and remove the label "
+                f"once the underlying issue is resolved.",
+            )
+        sys.exit(0)
+
+    msg = (
+        f"Vulnerability gate FAILED CLOSED: {reason}. Add the `{override_label}` label and "
+        f"re-run to bypass if this is a known GitHub outage. {_DEVOPS_TEAM}"
     )
-    if existing_id:
-        _api_write(f"{_GITHUB_API}/repos/{repository}/issues/comments/{existing_id}", token, "PATCH", {"body": body})
-    else:
-        _api_write(comments_url, token, "POST", {"body": body})
+    print(f"::error::{msg}")
+    _write_summary(
+        summary_path,
+        f"### 🚨 Vulnerability gate failed closed\n\n"
+        f"**Reason:** {reason}\n\n"
+        f"The gate blocks when it cannot confirm the PR introduces no new vulnerable "
+        f"dependencies. If this is a known GitHub outage, add the `{override_label}` label "
+        f"and re-run the job to bypass. {_DEVOPS_TEAM}",
+    )
+    if pr_number:
+        _upsert_comment(
+            repository, pr_number, token,
+            f"## 🚨 Vulnerability Gate could not verify this PR\n\n"
+            f"**Reason:** {reason}\n\n"
+            f"The gate blocks when it cannot confirm this PR introduces no new vulnerable "
+            f"dependencies (fail-closed). If this is a known GitHub outage, add the "
+            f"`{override_label}` label and **re-run the job** to bypass. {_DEVOPS_TEAM}",
+        )
+    sys.exit(1)
 
 
 def main() -> None:
@@ -276,7 +521,12 @@ def main() -> None:
     repository = os.environ["GITHUB_REPOSITORY"]
     base_sha = os.environ["BASE_SHA"]
     head_sha = os.environ["HEAD_SHA"]
+    base_ref = os.environ["BASE_REF"]
+    snapshot_workflow = os.environ["SNAPSHOT_WORKFLOW"]
+    lookback = int(os.environ.get("MAX_SNAPSHOT_LOOKBACK", "30"))
+    override_label = os.environ.get("OVERRIDE_LABEL", "ci:vuln-gate-override")
     summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    pr_number = _pr_number()
 
     fail_sev_rank = severity_rank(os.environ.get("FAIL_ON_SEVERITY", "high").strip().lower())
     fail_fixable_rank = severity_rank(os.environ.get("FAIL_ON_FIXABLE_SEVERITY", "low").strip().lower())
@@ -289,17 +539,47 @@ def main() -> None:
         print(f"::notice::Config file {config_file} not found — proceeding with empty allow-ghsas list")
         allowed_ghsas = set()
 
+    # ── Resolve the effective base to a snapshotted ancestor (Workstream D) ──
+    print(f"::notice::Resolving base {base_sha} on '{base_ref}' to the nearest snapshotted ancestor")
+    try:
+        effective_base, run_id, scanned = latest_snapshotted_ancestor(
+            repository, base_ref, base_sha, snapshot_workflow, token, lookback
+        )
+    except ApiError as e:
+        fail_closed(
+            repository, pr_number, token, override_label,
+            f"could not resolve base snapshot ({e.reason})", summary_path,
+        )
+        return  # unreachable: fail_closed exits
+
+    if effective_base is None:
+        fail_closed(
+            repository, pr_number, token, override_label,
+            f"no snapshotted ancestor of {base_sha} found within the last {scanned} "
+            f"snapshot run(s) on '{base_ref}'",
+            summary_path,
+        )
+        return
+
+    if effective_base == base_sha:
+        print(f"::notice::Base {base_sha} is itself snapshotted (scanned {scanned} run(s))")
+    else:
+        print(
+            f"::notice::Resolved effective base {effective_base} "
+            f"(scanned {scanned} run(s); snapshot run {run_id})"
+        )
+
+    # ── Dependency diff against the resolved base ──
     try:
         diff = _api_get(
-            f"{_GITHUB_API}/repos/{repository}/dependency-graph/compare/{base_sha}...{head_sha}",
+            f"{_GITHUB_API}/repos/{repository}/dependency-graph/compare/{effective_base}...{head_sha}",
             token,
         )
-    except (urllib.error.HTTPError, urllib.error.URLError) as e:
-        msg = f"Dependency Review API unavailable ({e}) — skipping vulnerability gate"
-        print(f"::warning::{msg}")
-        if summary_path:
-            with open(summary_path, "a") as f:
-                f.write(f"Warning: {msg}\n")
+    except ApiError as e:
+        fail_closed(
+            repository, pr_number, token, override_label,
+            f"dependency review API failed ({e.reason})", summary_path,
+        )
         return
 
     blocking, allowed, scope_excluded = find_blocking(
@@ -311,31 +591,32 @@ def main() -> None:
     for d in scope_excluded:
         print(f"::notice::Non-gated dep: {d['ghsa']} in {d['package']} (severity: {d['severity']}, rule: {d['rule']}) — excluded (scope: {d['scope']})")
 
-    if summary_path:
-        with open(summary_path, "a") as f:
-            if blocking:
-                f.write("### Blocking\n" + _table(blocking) + "\n")
-            else:
-                f.write("No blocking vulnerabilities found.\n")
-            if allowed:
-                f.write("### Allowed exceptions\n" + _table(allowed) + "\n")
-            if scope_excluded:
-                f.write("### Non-gated scope (not blocking)\n" + _table(scope_excluded) + "\n")
+    # ── Always-on run summary trail ──
+    base_line = f"`{effective_base}`"
+    if effective_base != base_sha:
+        base_line += f" (resolved from `{base_sha}`, scanned {scanned} run(s))"
+    summary = [
+        "## Dependency Vulnerability Gate",
+        "",
+        f"- **PR base ref:** `{base_ref}`",
+        f"- **Effective base:** {base_line}",
+        f"- **Head:** `{head_sha}`",
+        "",
+    ]
+    if blocking:
+        summary += [f"**Verdict:** 🚨 {len(blocking)} blocking issue(s)", "", _table(blocking)]
+    else:
+        summary += ["**Verdict:** ✅ no blocking vulnerabilities"]
+    if allowed:
+        summary += ["", "### Allowed exceptions (allow-ghsas)", _table(allowed)]
+    if scope_excluded:
+        summary += ["", "### Non-gated scope (not blocking)", _table(scope_excluded)]
+    _write_summary(summary_path, "\n".join(summary))
 
-    event_path = os.environ.get("GITHUB_EVENT_PATH")
-    if event_path and (blocking or allowed or scope_excluded):
-        with open(event_path) as f:
-            pr_number = json.load(f).get("pull_request", {}).get("number")
-        if pr_number:
-            try:
-                post_pr_comment(repository, pr_number, blocking, allowed, scope_excluded, token)
-            except urllib.error.HTTPError as e:
-                if e.code in (403, 404):
-                    print(f"::warning::Cannot post PR comment (HTTP {e.code}) — token may lack pull-requests:write (fork PR?)")
-                else:
-                    raise
-        else:
-            print(f"::warning::Could not determine PR number from event payload — skipping PR comment (event_path={event_path!r})")
+    if pr_number and (blocking or allowed or scope_excluded):
+        post_pr_comment(repository, pr_number, blocking, allowed, scope_excluded, token)
+    elif not pr_number and (blocking or allowed or scope_excluded):
+        print("::warning::Could not determine PR number from event payload — skipping PR comment")
 
     if blocking:
         for b in blocking:

--- a/dependency-vuln-check/check.py
+++ b/dependency-vuln-check/check.py
@@ -31,6 +31,7 @@ import re
 import sys
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 
 
@@ -202,7 +203,8 @@ def latest_snapshotted_ancestor(
     per_page = min(lookback, 100)  # GitHub caps per_page at 100
     url = (
         f"{_GITHUB_API}/repos/{repository}/actions/workflows/{workflow}/runs"
-        f"?branch={base_ref}&status=success&event=push&per_page={per_page}"
+        f"?branch={urllib.parse.quote(base_ref, safe='')}"
+        f"&status=success&event=push&per_page={per_page}"
     )
     scanned = 0
     while url and scanned < lookback:
@@ -211,13 +213,15 @@ def latest_snapshotted_ancestor(
         for run in runs:
             if scanned >= lookback:
                 break
-            head = run.get("head_sha")
-            if not head:
+            run_sha = run.get("head_sha")
+            if not run_sha:
                 continue
             scanned += 1
-            status = _compare_status(repository, head, base_sha, token)
+            # compare/{run_sha}...{base_sha}: "ahead" = base_sha is ahead of run_sha
+            # = run_sha is an ancestor of base_sha (what we want).
+            status = _compare_status(repository, run_sha, base_sha, token)
             if status in ("identical", "ahead"):
-                return head, run.get("id"), scanned
+                return run_sha, run.get("id"), scanned
         match = re.search(r'<([^>]+)>;\s*rel="next"', headers.get("Link", "") or "")
         url = match.group(1) if match else None
     return None, None, scanned
@@ -374,6 +378,8 @@ def _table(entries: list) -> str:
 
 
 def _api_write(url: str, token: str, method: str, body: dict) -> None:
+    # Write calls (PATCH/POST) are not retried: all callers tolerate failure with
+    # a warning, so a transient error here surfaces immediately but is non-fatal.
     req = urllib.request.Request(
         url,
         data=json.dumps(body).encode(),

--- a/dependency-vuln-check/check.py
+++ b/dependency-vuln-check/check.py
@@ -104,10 +104,14 @@ def _classify_http_error(e: urllib.error.HTTPError) -> ApiError:
     if code == 429:
         return ApiError("rate limit exceeded (HTTP 429)", code, retryable=True)
     if code == 403:
-        remaining = (e.headers or {}).get("X-RateLimit-Remaining")
-        retry_after = (e.headers or {}).get("Retry-After")
-        if retry_after is not None or remaining == "0":
+        headers = e.headers or {}
+        # Retry-After signals a *secondary* rate limit; X-RateLimit-Remaining: 0
+        # signals the *primary* rate limit is exhausted. Both are transient, but
+        # the named reason must distinguish them for accurate audit/troubleshooting.
+        if headers.get("Retry-After") is not None:
             return ApiError("secondary rate limit (HTTP 403)", code, retryable=True)
+        if headers.get("X-RateLimit-Remaining") == "0":
+            return ApiError("primary rate limit exhausted (HTTP 403)", code, retryable=True)
         return ApiError(
             "permission denied — token lacks required scope (HTTP 403)", code, retryable=False
         )
@@ -191,22 +195,31 @@ def latest_snapshotted_ancestor(
     Returns (effective_base_sha, run_id, scanned_count); (None, None, scanned) if
     no ancestor is found within the window. Raises ApiError on API failure so the
     caller can fail closed.
+
+    `lookback` is honored even beyond the API's 100-per-page cap by following
+    pagination, so a large lookback never silently scans fewer runs than asked.
     """
-    runs_url = (
+    per_page = min(lookback, 100)  # GitHub caps per_page at 100
+    url = (
         f"{_GITHUB_API}/repos/{repository}/actions/workflows/{workflow}/runs"
-        f"?branch={base_ref}&status=success&event=push&per_page={lookback}"
+        f"?branch={base_ref}&status=success&event=push&per_page={per_page}"
     )
-    payload, _ = _http_get_json(runs_url, token)
-    runs = payload.get("workflow_runs", []) if isinstance(payload, dict) else []
     scanned = 0
-    for run in runs:
-        head = run.get("head_sha")
-        if not head:
-            continue
-        scanned += 1
-        status = _compare_status(repository, head, base_sha, token)
-        if status in ("identical", "ahead"):
-            return head, run.get("id"), scanned
+    while url and scanned < lookback:
+        payload, headers = _http_get_json(url, token)
+        runs = payload.get("workflow_runs", []) if isinstance(payload, dict) else []
+        for run in runs:
+            if scanned >= lookback:
+                break
+            head = run.get("head_sha")
+            if not head:
+                continue
+            scanned += 1
+            status = _compare_status(repository, head, base_sha, token)
+            if status in ("identical", "ahead"):
+                return head, run.get("id"), scanned
+        match = re.search(r'<([^>]+)>;\s*rel="next"', headers.get("Link", "") or "")
+        url = match.group(1) if match else None
     return None, None, scanned
 
 

--- a/dependency-vuln-check/test_check.py
+++ b/dependency-vuln-check/test_check.py
@@ -2,7 +2,11 @@
 
 The GitHub Dependency Review API diff and the Advisory GraphQL lookup are not
 hit: tests feed `find_blocking` synthetic diff entries and stub `_lookup_patch`.
+Base-resolution, retry, and fail-closed tests stub the HTTP layer (`_http_get_json`
+/ `urllib.request.urlopen`) and `time.sleep`, so nothing touches the network.
 """
+import urllib.error
+
 import pytest
 
 import check
@@ -160,3 +164,172 @@ def test_parse_scopes():
 def test_severity_rank_invalid_exits():
     with pytest.raises(SystemExit):
         severity_rank("bogus")
+
+
+# --- base-snapshot resolution (Workstream D) ----------------------------------
+
+class _FakeResp:
+    """Minimal context-manager stand-in for urllib's response."""
+
+    def __init__(self, body: bytes, headers=None):
+        self._body = body
+        self.headers = headers or {}
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _http_error(code, headers=None):
+    return urllib.error.HTTPError("https://api.github.com/x", code, "err", headers or {}, None)
+
+
+def test_http_get_json_retries_then_succeeds(monkeypatch):
+    sleeps, attempts = [], []
+    monkeypatch.setattr(check.time, "sleep", lambda s: sleeps.append(s))
+
+    def fake_urlopen(req, timeout=30):
+        attempts.append(1)
+        if len(attempts) < 3:
+            raise _http_error(503)
+        return _FakeResp(b'{"ok": true}', {"Link": ""})
+
+    monkeypatch.setattr(check.urllib.request, "urlopen", fake_urlopen)
+    payload, _ = check._http_get_json("https://api.github.com/x", "tok")
+    assert payload == {"ok": True}
+    assert len(attempts) == 3
+    assert sleeps == [2, 4]  # exponential backoff before attempts 2 and 3
+
+
+def test_http_get_json_exhausts_then_raises(monkeypatch):
+    monkeypatch.setattr(check.time, "sleep", lambda s: None)
+    monkeypatch.setattr(check.urllib.request, "urlopen", lambda req, timeout=30: (_ for _ in ()).throw(_http_error(500)))
+    with pytest.raises(check.ApiError) as ei:
+        check._http_get_json("https://api.github.com/x", "tok")
+    assert ei.value.retryable is True
+    assert "server error" in ei.value.reason
+
+
+def test_classify_429_retryable():
+    err = check._classify_http_error(_http_error(429))
+    assert err.retryable is True and "rate limit" in err.reason
+
+
+def test_classify_403_perms_not_retryable():
+    err = check._classify_http_error(_http_error(403))
+    assert err.retryable is False and "permission" in err.reason
+
+
+def test_classify_403_secondary_ratelimit_retryable():
+    err = check._classify_http_error(_http_error(403, {"Retry-After": "5"}))
+    assert err.retryable is True and "secondary rate limit" in err.reason
+
+
+def test_ancestor_picks_newest(monkeypatch):
+    runs = {"workflow_runs": [
+        {"head_sha": "newer", "id": 3},
+        {"head_sha": "anc", "id": 2},
+        {"head_sha": "older", "id": 1},
+    ]}
+    monkeypatch.setattr(check, "_http_get_json", lambda url, tok: (runs, {}))
+    statuses = {"newer": "diverged", "anc": "ahead", "older": "ahead"}
+    monkeypatch.setattr(check, "_compare_status", lambda repo, head, base, tok: statuses[head])
+    eff, run_id, scanned = check.latest_snapshotted_ancestor("o/r", "main", "BASE", "wf.yml", "tok", 30)
+    assert (eff, run_id, scanned) == ("anc", 2, 2)  # skipped newer (diverged), matched anc
+
+
+def test_ancestor_identical_at_top(monkeypatch):
+    runs = {"workflow_runs": [{"head_sha": "BASE", "id": 9}]}
+    monkeypatch.setattr(check, "_http_get_json", lambda url, tok: (runs, {}))
+    monkeypatch.setattr(check, "_compare_status", lambda *a: "identical")
+    eff, _, scanned = check.latest_snapshotted_ancestor("o/r", "main", "BASE", "wf.yml", "tok", 30)
+    assert eff == "BASE" and scanned == 1
+
+
+def test_ancestor_none_found(monkeypatch):
+    runs = {"workflow_runs": [{"head_sha": "x", "id": 1}, {"head_sha": "y", "id": 2}]}
+    monkeypatch.setattr(check, "_http_get_json", lambda url, tok: (runs, {}))
+    monkeypatch.setattr(check, "_compare_status", lambda *a: "behind")
+    eff, run_id, scanned = check.latest_snapshotted_ancestor("o/r", "main", "BASE", "wf.yml", "tok", 30)
+    assert eff is None and run_id is None and scanned == 2
+
+
+def test_ancestor_query_uses_base_ref_and_workflow(monkeypatch):
+    captured = {}
+
+    def fake_get(url, tok):
+        captured["url"] = url
+        return {"workflow_runs": []}, {}
+
+    monkeypatch.setattr(check, "_http_get_json", fake_get)
+    check.latest_snapshotted_ancestor("o/r", "stable/8.8", "BASE", "maven-dependency-snapshot.yml", "tok", 30)
+    assert "branch=stable/8.8" in captured["url"]
+    assert "maven-dependency-snapshot.yml" in captured["url"]
+    assert "event=push" in captured["url"] and "status=success" in captured["url"]
+
+
+def test_has_override_label_live_read(monkeypatch):
+    monkeypatch.setattr(check, "_api_get", lambda url, tok: [{"name": "other"}, {"name": "ci:vuln-gate-override"}])
+    assert check.has_override_label("o/r", 5, "tok", "ci:vuln-gate-override") is True
+
+
+def test_has_override_label_api_failure_stays_closed(monkeypatch):
+    def boom(url, tok):
+        raise check.ApiError("labels API down", retryable=False)
+
+    monkeypatch.setattr(check, "_api_get", boom)
+    assert check.has_override_label("o/r", 5, "tok", "ci:vuln-gate-override") is False
+
+
+def test_fail_closed_bypassed_with_label(monkeypatch):
+    monkeypatch.setattr(check, "has_override_label", lambda *a, **k: True)
+    monkeypatch.setattr(check, "_upsert_comment", lambda *a, **k: None)
+    with pytest.raises(SystemExit) as ei:
+        check.fail_closed("o/r", 5, "tok", "ci:vuln-gate-override", "outage", None)
+    assert ei.value.code == 0  # honored bypass
+
+
+def test_fail_closed_blocks_without_label(monkeypatch):
+    monkeypatch.setattr(check, "has_override_label", lambda *a, **k: False)
+    monkeypatch.setattr(check, "_upsert_comment", lambda *a, **k: None)
+    with pytest.raises(SystemExit) as ei:
+        check.fail_closed("o/r", 5, "tok", "ci:vuln-gate-override", "no ancestor", None)
+    assert ei.value.code == 1
+
+
+def _set_main_env(monkeypatch):
+    monkeypatch.setenv("GH_TOKEN", "t")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "o/r")
+    monkeypatch.setenv("BASE_SHA", "B")
+    monkeypatch.setenv("HEAD_SHA", "H")
+    monkeypatch.setenv("BASE_REF", "main")
+    monkeypatch.setenv("SNAPSHOT_WORKFLOW", "wf.yml")
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    monkeypatch.delenv("GITHUB_EVENT_PATH", raising=False)
+    monkeypatch.delenv("CONFIG_FILE", raising=False)
+
+
+def test_main_real_vuln_blocks_even_with_override_label(monkeypatch):
+    # API works, base resolves, a real fixable vuln is added → blocks (exit 1).
+    # The override label is present but must be IGNORED for a genuine finding.
+    _set_main_env(monkeypatch)
+    monkeypatch.setattr(check, "latest_snapshotted_ancestor", lambda *a, **k: ("eff", 1, 1))
+    monkeypatch.setattr(check, "_api_get", lambda url, tok: [_dep(severity="high", fix="2.0.0")])
+    monkeypatch.setattr(check, "has_override_label", lambda *a, **k: True)
+    with pytest.raises(SystemExit) as ei:
+        check.main()
+    assert ei.value.code == 1
+
+
+def test_main_fail_closed_when_no_ancestor(monkeypatch):
+    _set_main_env(monkeypatch)
+    monkeypatch.setattr(check, "latest_snapshotted_ancestor", lambda *a, **k: (None, None, 5))
+    monkeypatch.setattr(check, "has_override_label", lambda *a, **k: False)
+    with pytest.raises(SystemExit) as ei:
+        check.main()
+    assert ei.value.code == 1

--- a/dependency-vuln-check/test_check.py
+++ b/dependency-vuln-check/test_check.py
@@ -230,6 +230,11 @@ def test_classify_403_secondary_ratelimit_retryable():
     assert err.retryable is True and "secondary rate limit" in err.reason
 
 
+def test_classify_403_primary_ratelimit_retryable():
+    err = check._classify_http_error(_http_error(403, {"X-RateLimit-Remaining": "0"}))
+    assert err.retryable is True and "primary rate limit" in err.reason
+
+
 def test_ancestor_picks_newest(monkeypatch):
     runs = {"workflow_runs": [
         {"head_sha": "newer", "id": 3},
@@ -271,6 +276,33 @@ def test_ancestor_query_uses_base_ref_and_workflow(monkeypatch):
     assert "branch=stable/8.8" in captured["url"]
     assert "maven-dependency-snapshot.yml" in captured["url"]
     assert "event=push" in captured["url"] and "status=success" in captured["url"]
+
+
+def test_ancestor_paginates_to_honor_lookback(monkeypatch):
+    # lookback > 100 → per_page capped at 100, follow the next page to keep scanning.
+    page1 = {"workflow_runs": [{"head_sha": f"p1-{i}", "id": i} for i in range(100)]}
+    page2 = {"workflow_runs": [{"head_sha": "anc", "id": 999}]}
+    calls = []
+
+    def fake_get(url, tok):
+        calls.append(url)
+        if len(calls) == 1:
+            assert "per_page=100" in url  # capped, not per_page=150
+            return page1, {"Link": '<https://api.github.com/next>; rel="next"'}
+        return page2, {"Link": ""}
+
+    monkeypatch.setattr(check, "_http_get_json", fake_get)
+    # only "anc" (on page 2) is an ancestor
+    monkeypatch.setattr(
+        check, "_compare_status",
+        lambda repo, head, base, tok: "ahead" if head == "anc" else "diverged",
+    )
+    eff, run_id, scanned = check.latest_snapshotted_ancestor(
+        "o/r", "main", "BASE", "wf.yml", "tok", 150
+    )
+    assert eff == "anc" and run_id == 999
+    assert scanned == 101  # 100 from page 1 + 1 match on page 2
+    assert len(calls) == 2  # followed pagination
 
 
 def test_has_override_label_live_read(monkeypatch):

--- a/dependency-vuln-check/test_check.py
+++ b/dependency-vuln-check/test_check.py
@@ -273,9 +273,31 @@ def test_ancestor_query_uses_base_ref_and_workflow(monkeypatch):
 
     monkeypatch.setattr(check, "_http_get_json", fake_get)
     check.latest_snapshotted_ancestor("o/r", "stable/8.8", "BASE", "maven-dependency-snapshot.yml", "tok", 30)
-    assert "branch=stable/8.8" in captured["url"]
+    # branch name with slash must be percent-encoded so it is not misread as a path segment
+    assert "branch=stable%2F8.8" in captured["url"]
     assert "maven-dependency-snapshot.yml" in captured["url"]
     assert "event=push" in captured["url"] and "status=success" in captured["url"]
+
+
+def test_ancestor_query_plain_branch_not_double_encoded(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(check, "_http_get_json", lambda url, tok: (captured.update(url=url) or ({}, {})) and ({"workflow_runs": []}, {}))
+
+    def fake_get(url, tok):
+        captured["url"] = url
+        return {"workflow_runs": []}, {}
+
+    monkeypatch.setattr(check, "_http_get_json", fake_get)
+    check.latest_snapshotted_ancestor("o/r", "main", "BASE", "wf.yml", "tok", 30)
+    assert "branch=main" in captured["url"]  # no encoding needed, no %
+
+
+def test_has_override_label_no_pr_number(monkeypatch):
+    # pr_number=None → return False without touching the API
+    api_called = []
+    monkeypatch.setattr(check, "_api_get", lambda url, tok: api_called.append(url) or [])
+    assert check.has_override_label("o/r", None, "tok", "ci:vuln-gate-override") is False
+    assert api_called == []
 
 
 def test_ancestor_paginates_to_honor_lookback(monkeypatch):


### PR DESCRIPTION
## Summary

Fixes the empty-base false positive in the `dependency-vuln-check` action (Workstream D of the PR dependency vulnerability gate, camunda/camunda#29729).

The diff trusted the raw PR `base.sha`. The base snapshot workflow (`maven-dependency-snapshot.yml`) is path-filtered, so a **code-only base commit has no snapshot** → the base side of the dependency-graph compare is empty → the *entire* head tree is flagged as `added` → pre-existing dependencies (e.g. netty) falsely surface as newly introduced. This blocked PRs that touched no dependencies (real incident: camunda/camunda#54971).

### What changed

- **Base resolution** — resolve `base.sha` to the most recent commit on the PR's base branch (`base-ref`) that has a submitted snapshot **and** is an ancestor-or-equal of `base.sha`, then diff from there. A successful push-event run of the snapshot workflow guarantees a submitted snapshot (its submit step is unconditional).
- **Fail-closed contract** — transient GitHub API errors are retried (3 attempts, exponential backoff). If they survive retries, or no snapshotted ancestor is found, the gate **blocks** instead of skipping. (Previously failed *open* on API error.)
- **Override label** — `ci:vuln-gate-override` bypasses the gate **only** when it cannot verify the PR (sustained outage / no ancestor). Read **live** from the PR (not the stale event payload) so adding it + re-running takes effect. Logged loudly for audit. **Never** bypasses a real finding.
- **Logging** — named failure reasons (rate-limit vs 5xx vs timeout vs permissions vs not-found) and an always-on step-summary trail (resolved base, runs scanned, verdict). The action was previously near-silent on failure.

### New inputs

| Input | Required | Default |
|-------|----------|---------|
| `base-ref` | yes | — |
| `snapshot-workflow` | yes | — |
| `max-snapshot-lookback` | no | `30` |
| `override-label` | no | `ci:vuln-gate-override` |

Consumer must also grant `actions: read` (to list snapshot-workflow runs).

## Test plan

- [x] `python -m pytest -q` — 37 passed (16 existing + 21 new; all pure unit, no network)
- [x] New coverage: ancestor walk (picks newest, skips non-ancestor, identical-at-top, none-found, uses base-ref), retry (retries-then-succeeds, exhausts-then-raises), error classification (429 / 403-perms / 403-secondary-ratelimit), override label (live read, API-failure-stays-closed, bypass exit 0, block exit 1), main() (real vuln blocks despite label, fail-closed on no-ancestor)
- [x] camunda/camunda `ci.yml` wiring follows in a separate PR (passes `base-ref` + `snapshot-workflow`, adds `actions: read`, bumps the pinned SHA). Gate stays `continue-on-error: true` (pilot).

Part of the dependency vulnerability gate epic (camunda/camunda#29729). Consuming gate job: camunda/camunda#53506.