### PR TITLE
ci: make renovate-pr-maintainer releasable by release-please

### DIFF
--- a/.github/config/.release-please-manifest.json
+++ b/.github/config/.release-please-manifest.json
@@ -15,6 +15,7 @@
   "kubernetes-image-replace": "0.0.0",
   "preview-env": "1.0.7",
   "previous-version": "1.0.0",
+  "renovate-pr-maintainer": "0.0.0",
   "rerun-failed-run": "1.1.0",
   "rerun-failed-run/check-annotations-and-logs": "1.0.0",
   "sanitize-branch-name": "1.0.0",

--- a/.github/config/release-please-config.json
+++ b/.github/config/release-please-config.json
@@ -85,6 +85,9 @@
     "previous-version": {
       "package-name": "previous-version"
     },
+    "renovate-pr-maintainer": {
+      "package-name": "renovate-pr-maintainer"
+    },
     "rerun-failed-run": {
       "package-name": "rerun-failed-run"
     },


### PR DESCRIPTION
# Description

Onboards the `renovate-pr-maintainer` composite action to release-please so it gets versioned tags and an auto-generated changelog like the other actions in this repo.

- Register the package in [.github/config/release-please-config.json](.github/config/release-please-config.json) so a `renovate-pr-maintainer-<version>` tag is produced.
- Bootstrap it at `0.0.0` in [.github/config/.release-please-manifest.json](.github/config/.release-please-manifest.json), following the existing precedent for never-released actions (e.g. `kubernetes-image-replace`).

Related:
- camunda/team-infrastructure#1053