### PR TITLE
feat(renovate-pr-maintainer): link PRs and report per-run outcome in summary

### DIFF
--- a/renovate-pr-maintainer/README.md
+++ b/renovate-pr-maintainer/README.md
@@ -1,6 +1,68 @@
 # Renovate PR maintainer
 
-Keeps open [Renovate](https://docs.renovatebot.com/) PRs fresh and unstuck on repositories using `rebaseWhen: "conflicted"` by taking the **minimum** action per PR — rebase stale PRs (via the Renovate `rebase` label) or re-run failed required jobs (within a budget). Background: [camunda/team-infrastructure#1053](https://github.com/camunda/team-infrastructure/issues/1053).
+Keeps open [Renovate](https://docs.renovatebot.com/) PRs fresh and unstuck on repositories using `rebaseWhen: "conflicted"` by taking the **minimum** action per PR — rebase stale PRs (via the Renovate `rebase` label) or re-run failed required jobs (within a budget). On `rebaseWhen: "conflicted"`, PRs silently drift behind base until their checks rot, yet eager rebasing triggers a CI-burning rebase storm — this nudges only the PRs that are actually stale or stuck. Background: [camunda/team-infrastructure#1053](https://github.com/camunda/team-infrastructure/issues/1053).
+
+## Usage
+
+Run it on a schedule so it periodically nudges open Renovate PRs. With the defaults it only **rebases stale PRs** (reruns are off until you set a `rerun-budget`):
+
+```yaml
+name: Renovate PR maintainer
+
+on:
+  schedule:
+    - cron: "0 */4 * * *" # every 4 hours
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  checks: read
+  actions: write
+  pull-requests: write
+
+jobs:
+  maintain:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: camunda/infra-global-github-actions/renovate-pr-maintainer@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Common tweaks
+
+Try it safely first — classify and log only, change nothing:
+
+```yaml
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          dry-run: true
+```
+
+Also re-run failed required checks (up to 2 attempts per commit):
+
+```yaml
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          rerun-budget: 2
+```
+
+## What it does
+
+A few common situations and the action it takes (with the defaults: rebase once a PR is ≥ 60 commits behind base **or** its head is > 24h old):
+
+| Renovate PR situation | What the maintainer does |
+|:----------------------|:-------------------------|
+| 70 commits behind base, or head 30h old | Adds the `rebase` label → Renovate rebases it (fresh SHA) |
+| Green and fresh (few commits behind, recent head) | Nothing — leaves it alone |
+| Has a merge conflict | Nothing — Renovate rebases conflicts itself |
+| Failing required check, fresh head¹ | Re-runs the failed jobs in place (no new SHA) |
+| Already carries the `rebase` label | Nothing — a rebase is already queued |
+| Branch has human-pushed commits | Nothing — leaves it for the human |
+
+¹ Only when `rerun-budget` ≥ 1 (reruns are off by default).
+
+See the [decision model](#decision-model) below for the exact rules.
 
 ## Decision model
 
@@ -12,9 +74,9 @@ stateDiagram-v2
 
     [*] --> classify: in-scope Renovate PR
 
-    classify --> report: carries rebase label
+    classify --> pending: carries rebase label
     classify --> skip: dirty (merge conflict)
-    classify --> none: unknown (mergeability pending)
+    classify --> none: unknown (mergeability undecided)
     classify --> owned: behind / blocked / unstable / clean
 
     owned --> skip: head edited by a human
@@ -40,7 +102,10 @@ stateDiagram-v2
 
 - **rebase** — add the Renovate `rebase` label; Renovate does the real rebase (regenerates lockfiles, pushes a fresh SHA). This action never pushes commits.
 - **rerun** — re-run the failed required workflow run(s) in place, no new SHA; budget derives from `run_attempt`.
-- **skip · report · none** — no mutation (left for Renovate, a human, or the next run).
+- **no action** — the PR is left untouched this run; three states share that outcome but differ by reason and what comes next:
+  - **`skip`** — merge conflict (Renovate rebases it itself) or a human-edited head (a rebase would discard manual commits); stays skipped until that changes.
+  - **`pending`** — already carries the `rebase` label, so a rebase is queued; clears once Renovate acts on it.
+  - **`none`** — fresh & green, or mergeability not yet known; re-evaluated next run.
 
 ## Inputs
 

--- a/renovate-pr-maintainer/action.yml
+++ b/renovate-pr-maintainer/action.yml
@@ -111,4 +111,9 @@ runs:
         DRY_RUN: ${{ inputs.dry-run }}
         REBASE_LABEL: "rebase"
         PLAN_FILE: ${{ runner.temp }}/renovate-pr-maintainer-plan.json
+        # Surfaced in the step-summary footnote (recap of thresholds/logic).
+        BEHIND_THRESHOLD: ${{ inputs.behind-threshold }}
+        STALE_HOURS: ${{ inputs.stale-hours }}
+        RERUN_BUDGET: ${{ inputs.rerun-budget }}
+        REQUIRE_UP_TO_DATE: ${{ inputs.require-up-to-date }}
       run: bash "$GITHUB_ACTION_PATH/apply.sh"

--- a/renovate-pr-maintainer/apply.sh
+++ b/renovate-pr-maintainer/apply.sh
@@ -21,6 +21,12 @@ DRY_RUN="${DRY_RUN:-true}"
 REBASE_LABEL="${REBASE_LABEL:-rebase}"
 MAX_API_RETRIES="${MAX_API_RETRIES:-3}"
 API_RETRY_DELAY="${API_RETRY_DELAY:-5}"
+# Thresholds/knobs surfaced in the step-summary footnote only (classify.sh owns
+# the actual decisions); defaults mirror classify.sh and action.yml.
+BEHIND_THRESHOLD="${BEHIND_THRESHOLD:-60}"
+STALE_HOURS="${STALE_HOURS:-24}"
+RERUN_BUDGET="${RERUN_BUDGET:-0}"
+REQUIRE_UP_TO_DATE="${REQUIRE_UP_TO_DATE:-false}"
 
 # gh api write (POST) with bounded retries, mirroring classify.sh's gh_api.
 # Retrying is safe: re-adding the rebase label is a no-op, and a rerun whose POST
@@ -53,37 +59,54 @@ if [ "$DRY_RUN" = "true" ]; then
 fi
 echo "Batch size: ${BATCH_SIZE}"
 
+declare -A OUTCOME
+outcomes_seen=false  # set -u-safe guard: avoids expanding an empty OUTCOME on bash < 4.4
 applied=0
+deferred=0
 while read -r item; do
   [ -z "$item" ] && continue
   action=$(echo "$item" | jq -r '.action')
   num=$(echo "$item" | jq -r '.number')
 
+  # Non-actionable states never count against the batch and need no write; they
+  # render as "—" (no action) in the summary.
   case "$action" in
     none|skip|pending) continue ;;
   esac
 
+  # Blast-radius cap: once BATCH_SIZE actionable PRs have been processed, defer
+  # the rest to the next run. We keep iterating (no break) solely to record their
+  # deferred outcome for the summary — no API calls are made for these.
   if [ "$applied" -ge "$BATCH_SIZE" ]; then
-    echo "Batch cap (${BATCH_SIZE}) reached; deferring remaining actions to the next run."
-    break
+    echo "Batch cap (${BATCH_SIZE}) reached; deferring PR #${num} (${action}) to the next run."
+    OUTCOME[$num]="deferred"
+    outcomes_seen=true
+    deferred=$((deferred + 1))
+    continue
   fi
 
+  # Every item reaching here is actionable and records an OUTCOME below.
+  outcomes_seen=true
   case "$action" in
     rebase)
       if [ "$DRY_RUN" = "true" ]; then
         echo "[dry-run] PR #${num}: would add '${REBASE_LABEL}' label"
+        OUTCOME[$num]="dry-run"
       else
         if err=$(gh_api_write -X POST "repos/${REPOSITORY}/issues/${num}/labels" \
           -f "labels[]=${REBASE_LABEL}"); then
           echo "PR #${num}: added '${REBASE_LABEL}' label"
+          OUTCOME[$num]="applied"
         else
           echo "::warning::PR #${num}: failed to add '${REBASE_LABEL}' label: ${err}"
+          OUTCOME[$num]="failed"
         fi
       fi
       applied=$((applied + 1))
       ;;
     rerun)
       mapfile -t rids < <(echo "$item" | jq -r '.run_ids[]')
+      rerun_failed=false
       for rid in "${rids[@]}"; do
         [ -z "$rid" ] && continue
         if [ "$DRY_RUN" = "true" ]; then
@@ -93,15 +116,70 @@ while read -r item; do
             echo "PR #${num}: reran failed jobs of run ${rid}"
           else
             echo "::warning::PR #${num}: failed to rerun run ${rid}: ${err}"
+            rerun_failed=true
           fi
         fi
       done
+      if [ "$DRY_RUN" = "true" ]; then
+        OUTCOME[$num]="dry-run"
+      elif [ "$rerun_failed" = "true" ]; then
+        OUTCOME[$num]="failed"
+      else
+        OUTCOME[$num]="applied"
+      fi
       applied=$((applied + 1))
       ;;
     *)
+      # Defensive: classify.sh only emits none/skip/pending/rebase/rerun, so this
+      # is unreachable in practice. Report it as `failed` (we could not act on it)
+      # to keep the summary's applied? values within the documented set; the
+      # warning above carries the detail.
       echo "::warning::PR #${num}: unknown action '${action}', skipping"
+      OUTCOME[$num]="failed"
       ;;
   esac
 done < <(jq -c '.[]' "$PLAN_FILE")
 
-echo "Actionable PRs processed this run: ${applied}"
+echo "Actionable PRs processed this run: ${applied} (deferred by batch cap: ${deferred})"
+
+# Human-readable step summary: the classify plan plus what THIS run actually did.
+# Rendered here (not in classify.sh) because each PR's applied/deferred outcome is
+# only known after the batch-capped loop above.
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  # Build links from the runner's GitHub context (with sensible fallbacks) so they
+  # are correct on GitHub Enterprise Server and the README link points at the
+  # action version actually running, not always main. These are default runner
+  # env vars; the fallbacks cover local-path usage where they may be unset.
+  server_url="${GITHUB_SERVER_URL:-https://github.com}"
+  action_repo="${GITHUB_ACTION_REPOSITORY:-camunda/infra-global-github-actions}"
+  action_ref="${GITHUB_ACTION_REF:-main}"
+  readme_url="${server_url}/${action_repo}/blob/${action_ref}/renovate-pr-maintainer/README.md#decision-model"
+
+  # Fold the per-PR OUTCOME map into a JSON object so jq can join it onto the plan.
+  outcomes_json='{}'
+  if [ "$outcomes_seen" = "true" ]; then
+    outcomes_json=$(
+      for k in "${!OUTCOME[@]}"; do
+        jq -nc --arg k "$k" --arg v "${OUTCOME[$k]}" '{($k): $v}'
+      done | jq -sc 'add'
+    )
+  fi
+
+  {
+    echo "### Renovate PR maintainer — plan"
+    echo ""
+    echo "| PR | state | behind_by | head age (h) | action | applied?\\* | reason |"
+    echo "|---:|:------|----------:|-------------:|:-------|:----------|:-------|"
+    jq -r --arg server "$server_url" --arg repo "$REPOSITORY" --argjson outcomes "$outcomes_json" '
+      .[]
+      | ($outcomes[(.number | tostring)] // "—") as $applied
+      | "| [#\(.number)](\($server)/\($repo)/pull/\(.number)) | \(.state) | \(.behind_by) | \(.age_hours) | \(.action) | \($applied) | \(.reason) |"
+    ' "$PLAN_FILE"
+    echo ""
+    # Backticks here are literal Markdown code spans, so the single-quoted format
+    # is intentional (values are injected via the %s positional args).
+    # shellcheck disable=SC2016
+    printf '\\* **applied?** = this run'"'"'s outcome: `applied`, `dry-run`, `failed`, `deferred` (over the `batch-size`=%s cap, retried next run), or `—` (no action needed).\n\n**state** = GitHub'"'"'s `mergeable_state`: `clean`/`has_hooks` green · `blocked` a **required** check failing/pending · `unstable` only **non-required** failing · `dirty` merge conflict · `behind` head behind base · `unknown` not yet computed · `rebase-labeled` rebase already queued.\n\n**Decision:** **rebase** when stale — ≥ %s commits behind base or head ≥ %sh old — or immediately if behind base and `require-up-to-date`=true (currently %s); otherwise **re-run** failing required checks within `rerun-budget`=%s. Full [decision model](%s).\n' \
+      "$BATCH_SIZE" "$BEHIND_THRESHOLD" "$STALE_HOURS" "$REQUIRE_UP_TO_DATE" "$RERUN_BUDGET" "$readme_url"
+  } >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/renovate-pr-maintainer/classify.sh
+++ b/renovate-pr-maintainer/classify.sh
@@ -458,15 +458,6 @@ else
   echo '[]' > "$PLAN_FILE"
 fi
 
-# Optional human-readable summary.
-if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
-  {
-    echo "### Renovate PR maintainer — plan"
-    echo ""
-    echo "| PR | state | behind_by | age (h) | action | reason |"
-    echo "|---:|:------|----------:|--------:|:-------|:-------|"
-    jq -r '.[] | "| #\(.number) | \(.state) | \(.behind_by) | \(.age_hours) | \(.action) | \(.reason) |"' "$PLAN_FILE"
-  } >> "$GITHUB_STEP_SUMMARY"
-fi
-
+# The human-readable step summary is rendered by apply.sh (the final step), which
+# also knows each PR's applied/deferred outcome under the batch cap.
 echo "Plan written to ${PLAN_FILE}"


### PR DESCRIPTION
# Description

Makes the Renovate PR maintainer job summary actionable: an operator reading it can now tell, at a glance, which PRs were actually acted on versus merely planned, and jump straight to each PR.

- PR numbers are now clickable links (built from the runner's GitHub context, so GitHub Enterprise Server works too).
- New `applied?` column reports the real per-run outcome (`applied` / `dry-run` / `deferred` / `failed` / `—`), so it's clear which actionable PRs ran and which the `batch-size` blast-radius cap held back.
- A footnote recaps the rebase/rerun thresholds and links the README decision model at the running action version.
- The summary now renders from the apply step (the only step that knows each PR's outcome) instead of the read-only classify step.
- Documented the action with a Usage section and a "What it does" behavior table.

Related:
- camunda/team-infrastructure#1053
