### PR TITLE
chore: adds workflow_ref value for new column to build_status_v2 table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 __pycache__/
 *.pyc
+.claude

--- a/submit-aborted-gha-status/README.md
+++ b/submit-aborted-gha-status/README.md
@@ -25,6 +25,7 @@ All data submitted by this action is stored as one record in the Big Query table
 | report_time      | TIMESTAMP  | REQUIRED   | Time of record submission |
 | ci_url           | STRING     | REQUIRED   | Github repository URL from `"$GITHUB_SERVER_URL/$GITHUB_REPOSITORY"` |
 | workflow_name    | STRING     | NULLABLE   | GHA workflow name from `"$GITHUB_WORKFLOW"` |
+| workflow_ref     | STRING     | NULLABLE   | GHA workflow file path extracted from `"$GITHUB_WORKFLOW_REF"`, e.g. `.github/workflows/ci.yml` |
 | job_name         | STRING     | REQUIRED   | GHA workflow job ID of the aborted job |
 | build_id         | STRING     | REQUIRED   | GHA workflow run ID from `"$GITHUB_RUN_ID/$GITHUB_RUN_ATTEMPT"` |
 | build_trigger    | STRING     | NULLABLE   | Github event name from `"$GITHUB_EVENT_NAME"` |

--- a/submit-aborted-gha-status/action.yml
+++ b/submit-aborted-gha-status/action.yml
@@ -47,6 +47,9 @@ runs:
       DATASET="${DATASET_TABLE%%.*}"
       TABLE="${DATASET_TABLE#*.}"
 
+      WORKFLOW_REF_PATH="${GITHUB_WORKFLOW_REF%@*}"
+      WORKFLOW_REF_PATH="${WORKFLOW_REF_PATH#"$GITHUB_REPOSITORY/"}"
+
       gh api -X GET "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/attempts/$GITHUB_RUN_ATTEMPT/jobs?per_page=100" --jq '.jobs[] | select(.conclusion=="failure") .id' | while read job_id; do
         echo "Checking failed job $job_id for abort due to runner problem..."
 
@@ -66,6 +69,7 @@ runs:
         "report_time": "$(date '+%Y-%m-%d %H:%M:%S')",
         "ci_url": "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY",
         "workflow_name": "$GITHUB_WORKFLOW",
+        "workflow_ref": "$WORKFLOW_REF_PATH",
         "job_name": "$job_name",
         "build_id": "$GITHUB_RUN_ID/$GITHUB_RUN_ATTEMPT",
         "build_trigger": "$GITHUB_EVENT_NAME",

--- a/submit-build-status/README.md
+++ b/submit-build-status/README.md
@@ -30,6 +30,7 @@ All data submitted by this action is stored as one record in the Big Query table
 | report_time      | TIMESTAMP  | REQUIRED   | Time of record submission |
 | ci_url           | STRING     | REQUIRED   | Github repository URL from `"$GITHUB_SERVER_URL/$GITHUB_REPOSITORY"` |
 | workflow_name    | STRING     | NULLABLE   | GHA workflow name from `"$GITHUB_WORKFLOW"` |
+| workflow_ref     | STRING     | NULLABLE   | GHA workflow file path extracted from `"$GITHUB_WORKFLOW_REF"`, e.g. `.github/workflows/ci.yml` |
 | job_name         | STRING     | REQUIRED   | GHA workflow job ID from `"$GITHUB_JOB"` |
 | build_id         | STRING     | REQUIRED   | GHA workflow run ID from `"$GITHUB_RUN_ID/$GITHUB_RUN_ATTEMPT"` |
 | build_trigger    | STRING     | NULLABLE   | Github event name from `"$GITHUB_EVENT_NAME"` |

--- a/submit-build-status/action.yml
+++ b/submit-build-status/action.yml
@@ -102,6 +102,9 @@ runs:
         RUNNER_TYPE_FIELD=$(printf ', "runner_type": "%s"' "$RUNS_ON")
       fi
 
+      WORKFLOW_REF_PATH="${GITHUB_WORKFLOW_REF%@*}"
+      WORKFLOW_REF_PATH="${WORKFLOW_REF_PATH#"$GITHUB_REPOSITORY/"}"
+
       # ── Parse BigQuery table name (format: project_id:dataset.table) ──
       TABLE_NAME="${{ inputs.big_query_table_name }}"
       PROJECT_ID="${TABLE_NAME%%:*}"
@@ -115,6 +118,7 @@ runs:
         "report_time": "$(date '+%Y-%m-%d %H:%M:%S')",
         "ci_url": "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY",
         "workflow_name": "$GITHUB_WORKFLOW",
+        "workflow_ref": "$WORKFLOW_REF_PATH",
         "job_name": "${{ (inputs.job_name_override == '') && '$GITHUB_JOB' || inputs.job_name_override }}",
         "build_id": "$GITHUB_RUN_ID/$GITHUB_RUN_ATTEMPT",
         "build_trigger": "$GITHUB_EVENT_NAME",


### PR DESCRIPTION
Include a new column in the build_status_v2 table to track the workflow_path.
This is meant to easily combine the outputs from the GitHub Enterprise detailed cost report (which distinguishes cost down to the workflow_path level) with the information coming from the build_status_v2 table.

Tests already performed in `camunda/camunda` - e.g.:  https://github.com/camunda/camunda/actions?query=branch%3Ainfra-1080-workflow-ref-info
Example data collected in `ci-30-162810.dev_ci_analytics.build_status_v2`

| report_time | ci_url | workflow_name | job_name | workflow_ref |
|---|---|---|---|---|
| 2026-06-18 15:07:16.000000 UTC | https://github.com/camunda/camunda | CI | e2e-cloud-test | .github/workflows/ci.yml |
| 2026-06-18 15:11:14.000000 UTC | https://github.com/camunda/camunda | CI | optimize-it-elasticsearch/ccsm-test | .github/workflows/ci.yml |
| 2026-06-18 15:10:55.000000 UTC | https://github.com/camunda/camunda | CI | optimize-it-opensearch/ccsm-test | .github/workflows/ci.yml |
| 2026-06-18 15:09:42.000000 UTC | https://github.com/camunda/camunda | CI | optimize-e2e-smoke | .github/workflows/ci.yml |
| 2026-06-19 10:29:47.000000 UTC | https://github.com/camunda/camunda | Trigger c8-cross-component-e2e-tests | trigger-e2e-tests | .github/workflows/trigger-c8run-e2e-tests.yml |
| 2026-06-18 12:58:47.000000 UTC | https://github.com/camunda/camunda | Check for PR conflicts | check-single-pr-conflict | .github/workflows/check-pr-conflicts.yml |
| 2026-06-18 12:58:46.000000 UTC | https://github.com/camunda/camunda | Check Outdated PRs | get-prs | .github/workflows/check-outdated-prs.yml |
| 2026-06-18 12:59:15.000000 UTC | https://github.com/camunda/camunda | CI | junit-vintage-check | .github/workflows/ci.yml |
| 2026-06-18 12:59:18.000000 UTC | https://github.com/camunda/camunda | CI | codeowners-check | .github/workflows/ci.yml |
| 2026-06-18 12:59:19.000000 UTC | https://github.com/camunda/camunda | CI | hadolint/optimize.Dockerfile | .github/workflows/ci.yml |
