### PR TITLE
feat(renovate-pr-maintainer): surface processed PRs as a structured output

### DIFF
--- a/renovate-pr-maintainer/README.md
+++ b/renovate-pr-maintainer/README.md
@@ -75,15 +75,17 @@ A few common situations and the action it takes (with the defaults: rebase once 
 | 70 commits behind base, or behind base with a 30h-old head | Adds the `rebase` label → Renovate rebases it (fresh SHA) |
 | Up to date with base, even with an old head | Nothing — not behind, so no rebase (its checks are re-run if they fail) |
 | Green and fresh (few commits behind, recent head) | Nothing — leaves it alone |
-| Has a merge conflict | Nothing — Renovate rebases conflicts itself |
+| Has a merge conflict | Nothing — Renovate rebases conflicts itself³ |
 | Failing required check, fresh head¹ | Re-runs the failed jobs in place (no new SHA) |
-| Already carries the `rebase` label | Nothing — a rebase is already queued |
+| Already carries the `rebase` label | Nothing — a rebase is already queued³ |
 | Branch has human-pushed commits | Nothing — leaves it for the human |
 | Behind base & auto-merging² | Rebases it immediately so Renovate can merge it next scan |
 
 ¹ Only when `rerun-budget` ≥ 1 (reruns are off by default).
 
 ² With `require-up-to-date-strategy: automerge`, every behind auto-merging PR is rebased; with `automerge-optimized`, only one least-behind **mergeable** auto-merging PR per base branch is (blocked ones excluded).
+
+³ Still left for Renovate to handle; its head age is recorded in the [`processed-prs`](#outputs) output so a **caller** can flag a PR stuck `dirty`/awaiting a rebase for too long — a sign Renovate is not processing the repo.
 
 See the [decision model](#decision-model) below for the exact rules.
 
@@ -160,3 +162,9 @@ Every PR in the step-summary plan also shows its **blockers** — why GitHub won
 | `require-up-to-date-strategy` | `none` | How to handle the `behind` state ("require branches up to date"). `none`: ignored, decided by staleness. `automerge`: every behind auto-merging PR is rebased immediately (non-automerge PRs still staleness-driven). `automerge-optimized`: per base branch, only one least-behind **mergeable** auto-merging PR is rebased (blocked ones excluded so they can't stall the train), and only when no auto-merging PR is already merge-ready or being rebased. `all`: every behind PR is rebased immediately. |
 | `automerge-labels` | `automerge` | Comma- or newline-separated labels marking a Renovate PR as auto-merging (used by `require-up-to-date-strategy: automerge` and `automerge-optimized`). GitHub native auto-merge is detected too; set empty to rely on that only. |
 | `dry-run` | `false` | When true, classify and log only; never modify any PR. |
+
+## Outputs
+
+| Output | Description |
+|:-------|:------------|
+| `processed-prs` | JSON array describing every in-scope Renovate PR the run processed, each `{number, base, state, action, behind_by, age_hours, blockers, automerge}` (the same per-PR facts as the step summary); `[]` when none. `behind_by` is `null` only when not measured (an indeterminate `unknown` mergeable_state, deferred to the next run). |

--- a/renovate-pr-maintainer/action.yml
+++ b/renovate-pr-maintainer/action.yml
@@ -105,10 +105,21 @@ inputs:
     required: false
     default: "false"
 
+outputs:
+  processed-prs:
+    description: >
+      JSON array describing every in-scope Renovate PR the run processed, each
+      `{number, base, state, action, behind_by, age_hours, blockers, automerge}`
+      (the same per-PR facts as the step summary). `behind_by` is `null` only when
+      not measured (an indeterminate `unknown` mergeable_state, deferred to the next
+      run). Empty array (`[]`) when there are none.
+    value: ${{ steps.classify.outputs.processed-prs }}
+
 runs:
   using: composite
   steps:
     - name: Classify in-scope Renovate PRs (read-only)
+      id: classify
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github-token }}

--- a/renovate-pr-maintainer/apply.sh
+++ b/renovate-pr-maintainer/apply.sh
@@ -179,19 +179,20 @@ if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
         [ -z "$base" ] && continue
         echo "#### Base \`${base}\`"
         echo ""
-        # "behind since (h)" = head-commit age, shown only while the PR is behind
-        # (state behind, or behind_by>0) since that is the staleness clock that
-        # drives a rebase; a PR level with base has no behind clock, so it shows —.
-        echo "| PR | state | blockers | automerge | behind_by | behind since (h) | action | note |"
-        echo "|---:|:------|:---------|:---------:|----------:|-----------------:|:-------|:-----|"
+        # "head age (h)" = hours since the head was pushed, shown for behind PRs
+        # (staleness clock) and dirty/rebase-labeled PRs (stuck clock); "—" when
+        # not measured (a level, up-to-date PR, whose head age isn't fetched).
+        echo "| PR | state | blockers | automerge | behind_by | head age (h) | action | note |"
+        echo "|---:|:------|:---------|:---------:|----------:|-------------:|:-------|:-----|"
         jq -r --arg server "$server_url" --arg repo "$REPOSITORY" --arg base "$base" --argjson outcomes "$outcomes_json" '
           [.[] | select(.base == $base)] | .[]
           | ($outcomes[(.number | tostring)] // "—") as $applied
           | (if $applied == "—" then .action else "\(.action) (\($applied))" end) as $act
           | (if .automerge then "yes" else "no" end) as $am
           | ((.blockers // "") | if . == "" then "—" else . end) as $bl
-          | (if (.state == "behind" or .behind_by > 0) then (.age_hours | tostring) else "—" end) as $since
-          | "| [#\(.number)](\($server)/\($repo)/pull/\(.number)) | \(.state) | \($bl) | \($am) | \(.behind_by) | \($since) | \($act) | \(.reason) |"
+          | (if (.state == "behind" or (.behind_by != null and .behind_by > 0) or .state == "dirty" or .state == "rebase-labeled") then (.age_hours | tostring) else "—" end) as $since
+          | (if .behind_by == null then "—" else (.behind_by | tostring) end) as $bb
+          | "| [#\(.number)](\($server)/\($repo)/pull/\(.number)) | \(.state) | \($bl) | \($am) | \($bb) | \($since) | \($act) | \(.reason) |"
         ' "$PLAN_FILE"
         echo ""
       done <<< "$bases"
@@ -202,7 +203,7 @@ if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
     # line Markdown needs. Backticks are literal code spans, so the single-quoted
     # format is intentional; values are injected via the %s positional args.
     # shellcheck disable=SC2016
-    printf '\n**Columns**\n\n- **state** — GitHub `mergeable_state`; the ones worth context: `blocked` (a required gate unmet — a failing/pending required check *or* a missing required review), `unstable` (only a *non-required* check is failing/pending, so GitHub still allows merge), `behind` (head behind base), `dirty` (merge conflict).\n- **blockers** — why the PR is not merge-ready now: failing/pending required check, awaiting required review, merge conflict, behind base; `—` = nothing blocking.\n- **behind since (h)** — hours since the head was pushed, shown only while behind base (the clock a stale rebase resets).\n- **action** — what the maintainer did, outcome in parens: `applied`, `dry-run`, `failed`, or `deferred` (past the `batch-size`=%s cap, retried next run); `none`/`skip`/`pending` change nothing.\n\n**How it works** — **rebases** stale behind PRs (≥ %s commits behind or ≥ %sh old) and **re-runs** failing required checks (`rerun-budget`=%s). Full [decision model](%s).\n' \
+    printf '\n**Columns**\n\n- **state** — GitHub `mergeable_state`; the ones worth context: `blocked` (a required gate unmet — a failing/pending required check *or* a missing required review), `unstable` (only a *non-required* check is failing/pending, so GitHub still allows merge), `behind` (head behind base), `dirty` (merge conflict).\n- **blockers** — why the PR is not merge-ready now: failing/pending required check, awaiting required review, merge conflict, behind base; `—` = nothing blocking.\n- **automerge** — `yes` when the PR is set to auto-merge once green (drives `require-up-to-date-strategy`).\n- **behind_by** — commits the head is behind base; `—` when not measured (indeterminate `unknown` state).\n- **head age (h)** — hours since the head was pushed: while behind base it is the staleness clock a rebase resets; for `dirty`/`rebase-labeled` PRs it is the stuck clock (how long the PR has sat conflicted or awaiting Renovate); `—` when not measured.\n- **action** — what the maintainer did, outcome in parens: `applied`, `dry-run`, `failed`, or `deferred` (past the `batch-size`=%s cap, retried next run); `none`/`skip`/`pending` change nothing.\n\n**How it works** — **rebases** stale behind PRs (≥ %s commits behind or ≥ %sh old) and **re-runs** failing required checks (`rerun-budget`=%s). Full [decision model](%s).\n' \
       "$BATCH_SIZE" "$BEHIND_THRESHOLD" "$STALE_HOURS" "$RERUN_BUDGET" "$readme_url"
   } >> "$GITHUB_STEP_SUMMARY"
 fi

--- a/renovate-pr-maintainer/classify.sh
+++ b/renovate-pr-maintainer/classify.sh
@@ -300,6 +300,7 @@ compute_staleness() {
   base_enc="${base//\//%2F}"
   behind_by=$(gh_api "repos/${REPOSITORY}/compare/${base_enc}...${head_sha}" --jq '.behind_by' 2>/dev/null || echo 0)
   [ -z "$behind_by" ] && behind_by=0
+  behind_measured=true
   fetch_head_meta "$head_sha"
   # A rebase only helps a PR that is actually behind its base; one level with base
   # (behind_by=0) would just get an identical tree re-run through CI. So staleness
@@ -469,17 +470,25 @@ classify_one_pr() {
   # below. Computed even when unused so every plan entry carries a stable
   # `automerge` field.
   local is_automerge=false
+  # Head age + ownership (fetch_head_meta) and behind_by/staleness (compute_staleness),
+  # declared up here (not only in the case block below) so the rebase-labeled early
+  # return can also report a real head age AND behind_by, which stuck detection needs.
+  local age_hours=0 head_modified=false head_meta_done=false
+  local behind_by=0 behind_measured=false stale=false
   labels_has_automerge "$cand" && is_automerge=true
 
   # Rebase already queued: the PR still carries the label (Renovate strips it once
   # done), so acting now is wasted — the SHA is about to change. Decided from the
-  # candidate's labels alone, before any per-PR fetch: the cheapest exit. We never
-  # fetch this PR's mergeability, so blockers are reported as not-evaluated rather
-  # than empty (empty renders as "—" = "nothing blocking", which we can't claim here).
+  # candidate's labels alone. We still measure staleness (head-commit age + behind_by,
+  # one commit + one compare GET) so a caller can tell a freshly-labeled PR from one
+  # Renovate has left awaiting a rebase for too long / far behind (stuck). We do NOT
+  # poll the mergeable_state, so blockers are reported as not-evaluated rather than
+  # empty (empty renders as "—" = "nothing blocking", which we can't claim here).
   if [ -n "$REBASE_LABEL" ] && echo "$cand" | jq -e --arg l "$REBASE_LABEL" '(.labels // []) | index($l)' >/dev/null; then
-    echo "PR #${num} [rebase-labeled] -> pending (rebase already requested; awaiting Renovate)" >&2
-    jq -nc --argjson num "$num" --arg base "$base" --argjson am "$is_automerge" \
-      '{number: $num, base: $base, state: "rebase-labeled", action: "pending", reason: "rebase label already set; awaiting Renovate", run_ids: [], behind_by: 0, age_hours: 0, automerge: $am, blockers: "not evaluated (rebase queued)"}' \
+    compute_staleness "$base" "$head_sha"
+    echo "PR #${num} [rebase-labeled] -> pending (rebase already requested; awaiting Renovate; head ${age_hours}h old, behind_by=${behind_by})" >&2
+    jq -nc --argjson num "$num" --arg base "$base" --argjson am "$is_automerge" --argjson age "$age_hours" --argjson behind "$behind_by" \
+      '{number: $num, base: $base, state: "rebase-labeled", action: "pending", reason: "rebase label already set; awaiting Renovate", run_ids: [], behind_by: $behind, age_hours: $age, automerge: $am, blockers: "not evaluated (rebase queued)"}' \
       > "$out_file"
     return 0
   fi
@@ -497,13 +506,23 @@ classify_one_pr() {
   # fetches only what its decision needs: staleness (compare + commit GET) gates
   # the rebase-on-stale states, rerun eligibility (the costly check-runs + runs
   # pair) only a fresh PR with a rerun path, head ownership rides along on the
-  # staleness commit GET. dirty/unknown fetch nothing further.
-  local behind_by=0 age_hours=0 required_count=0 eligible_ids="[]" eligible_count=0 stale=false
-  local head_modified=false head_meta_done=false checks_in_progress=false failing_required_count=0
+  # staleness commit GET. dirty also runs staleness (compare + commit GET) for its
+  # stuck context (head age + behind_by) but never acts; unknown fetches nothing
+  # further. (age_hours/head_modified/head_meta_done/behind_by/stale are declared
+  # above so the rebase-labeled early return can use them too.)
+  # behind_by is only measured by compute_staleness (a compare API call). The one
+  # state that still skips it (unknown) must NOT report 0 — that reads as "level
+  # with base" when it is really "not measured" — so it emits null instead.
+  local required_count=0 eligible_ids="[]" eligible_count=0
+  local checks_in_progress=false failing_required_count=0
   local check_status_done=false failing_suites="[]" review_decision="" blockers=""
   local action="none" reason=""
   case "$ms" in
     dirty)
+      # Renovate owns the conflict rebase; we only READ staleness (head age +
+      # behind_by) so a caller can flag a PR that has stayed conflicted too long /
+      # far behind (Renovate not processing it). We never act on it ourselves.
+      compute_staleness "$base" "$head_sha"
       action="skip"; reason="merge conflict; Renovate owns the rebase" ;;
     behind)
       # Rebase a behind PR immediately when require-up-to-date-strategy demands it: `all`
@@ -608,7 +627,12 @@ classify_one_pr() {
 
   compute_blockers
 
-  echo "PR #${num} [${ms}] behind_by=${behind_by} age=${age_hours}h required=${required_count} blockers=[${blockers}] -> ${action} (${reason})" >&2
+  # Report behind_by only when actually measured; otherwise null ("n/a" in the log)
+  # so a skipped compare never masquerades as 0 (= level with base).
+  local behind_json behind_disp
+  if [ "$behind_measured" = "true" ]; then behind_json="$behind_by"; behind_disp="$behind_by"; else behind_json=null; behind_disp="n/a"; fi
+
+  echo "PR #${num} [${ms}] behind_by=${behind_disp} age=${age_hours}h required=${required_count} blockers=[${blockers}] -> ${action} (${reason})" >&2
 
   jq -nc \
     --argjson num "$num" \
@@ -618,7 +642,7 @@ classify_one_pr() {
     --arg reason "$reason" \
     --arg blockers "$blockers" \
     --argjson rids "$eligible_ids" \
-    --argjson behind "$behind_by" \
+    --argjson behind "$behind_json" \
     --argjson age "$age_hours" \
     --argjson am "$is_automerge" \
     '{number: $num, base: $base, state: $state, action: $action, reason: $reason, blockers: $blockers, run_ids: $rids, behind_by: $behind, age_hours: $age, automerge: $am}' \
@@ -700,6 +724,22 @@ if [ "$REQUIRE_UP_TO_DATE_STRATEGY" = "automerge-optimized" ]; then
   else
     echo "Automerge merge-train (optimized): no prime needed (each base already has a merge-progressing automerge PR, or none are mergeable-behind)"
   fi
+fi
+
+# Expose the per-PR plan as a structured output so a caller can act on it (e.g.
+# flag PRs stuck dirty/awaiting a rebase) without this action prescribing that
+# policy. Mirrors the step-summary facts, minus internal fields (run_ids/reason).
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  processed_json=$(jq -c '
+    [ .[] | {number, base, state, action, behind_by, age_hours, blockers, automerge} ]
+  ' "$PLAN_FILE")
+  processed_count=$(echo "$processed_json" | jq 'length')
+  {
+    echo "processed-prs<<EOF"
+    echo "$processed_json"
+    echo "EOF"
+  } >> "$GITHUB_OUTPUT"
+  echo "Processed PRs surfaced via processed-prs output: ${processed_count}"
 fi
 
 # The human-readable step summary is rendered by apply.sh (the final step), which


### PR DESCRIPTION
# Description

Expose a structured `processed-prs` output describing every in-scope Renovate PR the run processed — `{number, base, state, action, behind_by, age_hours, blockers, automerge}`, the same per-PR facts as the step summary.

Related:
- camunda/team-infrastructure#1053