### PR TITLE
feat: capture per-job network egress/ingress bytes

### DIFF
--- a/submit-build-status/README.md
+++ b/submit-build-status/README.md
@@ -42,6 +42,8 @@ All data submitted by this action is stored as one record in the Big Query table
 | runner_name      | STRING     | NULLABLE   | Lowercase name of the runner executing the GHA workflow job |
 | runner_arch      | STRING     | NULLABLE   | Lowercase name of the runner's CPU architecture executing the GHA workflow job |
 | runner_os        | STRING     | NULLABLE   | Lowercase name of the runner's operating system executing the GHA workflow job |
+| network_egress_bytes  | INTEGER | NULLABLE | Cumulative bytes transmitted across non-loopback interfaces at job end; per-job on ephemeral runners, cumulative since interface-up on long-lived ones (Linux only) |
+| network_ingress_bytes | INTEGER | NULLABLE | Cumulative bytes received across non-loopback interfaces at job end (Linux only) |
 | user_reason      | STRING     | NULLABLE   | Based on user input |
 | user_description | STRING     | NULLABLE   | Based on user input |
 

--- a/submit-build-status/stop-and-collect-build-monitor.sh
+++ b/submit-build-status/stop-and-collect-build-monitor.sh
@@ -70,4 +70,22 @@ if [ -f "$PID_FILE" ]; then
   fi
 fi
 
+# ── Network bytes: cumulative tx/rx summed across non-loopback interfaces. ──
+# Runner pods are ephemeral (one job per pod), so the counters span the job;
+# on long-lived runners they are cumulative since interface-up.
+TX_BYTES=""; RX_BYTES=""
+if [ -r /proc/net/dev ]; then
+  read -r TX_BYTES RX_BYTES < <(
+    awk -F'[: ]+' '
+      NR > 2 && $2 != "lo" { rx += $3 + 0; tx += $11 + 0 }
+      END { printf "%.0f %.0f\n", tx, rx }
+    ' /proc/net/dev
+  ) || true
+  if [ -n "$TX_BYTES" ]; then
+    echo "Network: egress=${TX_BYTES}B, ingress=${RX_BYTES}B"
+    MONITOR_FIELDS=$(printf '%s, "network_egress_bytes": %s, "network_ingress_bytes": %s' \
+      "$MONITOR_FIELDS" "$TX_BYTES" "$RX_BYTES")
+  fi
+fi
+
 printf 'monitor_fields=%s\n' "$MONITOR_FIELDS" >> "$OUTPUT_FILE"


### PR DESCRIPTION
# Description

Captures per-job network egress for the STANDARD-tier experiment: reads cumulative eth0 tx/rx from `/proc/net/dev` at job end and submits them as `network_egress_bytes` / `network_ingress_bytes` to `build_status_v2`.

- Runner pods are ephemeral (one job per pod), so counters span the whole job — per-job upper bound (includes intra-cluster).
- Linux only; NULL elsewhere. BQ schema columns added in camunda/infra-core#13373.

Related:
- camunda/team-infrastructure#1044
