### PR TITLE
fix(renovate-pr-maintainer): flag conflicted human-edited PRs as stuck

### DIFF
--- a/renovate-pr-maintainer/README.md
+++ b/renovate-pr-maintainer/README.md
@@ -76,6 +76,7 @@ A few common situations and the action it takes (with the defaults: rebase once 
 | Up to date with base, even with an old head | Nothing — not behind, so no rebase (its checks are re-run if they fail) |
 | Green and fresh (few commits behind, recent head) | Nothing — leaves it alone |
 | Has a merge conflict | Nothing — Renovate rebases conflicts itself³ |
+| Has a merge conflict **and** human-pushed commits | Nothing — left for the human (Renovate won't auto-rebase an edited branch)⁴ |
 | Failing required check, fresh head¹ | Re-runs the failed jobs in place (no new SHA) |
 | Already carries the `rebase` label | Nothing — a rebase is already queued³ |
 | Branch has human-pushed commits | Nothing — leaves it for the human |
@@ -86,6 +87,8 @@ A few common situations and the action it takes (with the defaults: rebase once 
 ² With `require-up-to-date-strategy: automerge`, every behind auto-merging PR is rebased; with `automerge-optimized`, only one least-behind **mergeable** auto-merging PR per base branch is (blocked ones excluded).
 
 ³ Still left for Renovate to handle; its head age is recorded in the [`processed-prs`](#outputs) output so a **caller** can flag a PR stuck `dirty`/awaiting a rebase for too long — a sign Renovate is not processing the repo.
+
+⁴ A conflicted PR whose head carries human-pushed commits is the one case Renovate won't auto-rebase, so the conflict won't clear on its own; it is surfaced as stuck for a human rather than implying Renovate will recover it.
 
 See the [decision model](#decision-model) below for the exact rules.
 
@@ -139,7 +142,7 @@ stateDiagram-v2
 - **rebase** — add the Renovate `rebase` label; Renovate does the real rebase (regenerates lockfiles, pushes a fresh SHA). This action never pushes commits. With `require-up-to-date-strategy: all` every behind PR is rebased immediately; with `automerge`, every behind auto-merging PR is; with `automerge-optimized`, just one least-behind mergeable auto-merging PR per base branch is (see the note above).
 - **rerun** — re-run the failed required workflow run(s) in place, no new SHA; budget derives from `run_attempt`.
 - **no action** — the PR is left untouched this run; three states share that outcome but differ by reason and what comes next:
-  - **`skip`** — merge conflict (Renovate rebases it itself) or a human-edited head (a rebase would discard manual commits); stays skipped until that changes.
+  - **`skip`** — merge conflict (Renovate rebases it itself) or a human-edited head (a rebase would discard manual commits); a conflicted **and** human-edited PR is both at once — Renovate won't auto-rebase it, so it stays skipped until a human resolves the conflict.
   - **`pending`** — already carries the `rebase` label, so a rebase is queued; clears once Renovate acts on it.
   - **`none`** — fresh & green, mergeability not yet known, or the PR is in GitHub's merge queue (state `queued`, surfaced so it doesn't read as indeterminate); re-evaluated next run.
 

--- a/renovate-pr-maintainer/classify.sh
+++ b/renovate-pr-maintainer/classify.sh
@@ -8,7 +8,9 @@
 # Decision model (first match wins; a human-edited head always downgrades an
 # actionable state to skip, since Renovate won't auto-rebase it):
 #   rebase label present  -> pending (rebase already queued; report only, no fetch)
-#   dirty (conflict)      -> skip    (Renovate rebases conflicts itself)
+#   dirty (conflict)      -> skip    (Renovate rebases conflicts itself, unless the
+#                            head is human-edited: then Renovate won't, so it is
+#                            surfaced as stuck for a human)
 #   behind                -> rebase now if require-up-to-date-strategy=all, or =automerge and
 #                            the PR auto-merges; else treat like blocked
 #   blocked / unstable    -> rebase if stale, else rerun a failing required run, else none
@@ -542,8 +544,16 @@ classify_one_pr() {
       # Renovate owns the conflict rebase; we only READ staleness (head age +
       # behind_by) so a caller can flag a PR that has stayed conflicted too long /
       # far behind (Renovate not processing it). We never act on it ourselves.
+      # compute_staleness also sets head_modified: a human-edited head is the one
+      # case Renovate will NOT auto-rebase, so the "Renovate owns the rebase"
+      # assurance is false there — the conflict is stuck until a human resolves it.
       compute_staleness "$base" "$head_sha"
-      action="skip"; reason="merge conflict; Renovate owns the rebase" ;;
+      action="skip"
+      if [ "$head_modified" = "true" ]; then
+        reason="merge conflict on branch edited by non-Renovate author; leave for human (Renovate won't auto-rebase it)"
+      else
+        reason="merge conflict; Renovate owns the rebase"
+      fi ;;
     behind)
       # Rebase a behind PR immediately when require-up-to-date-strategy demands it: `all`
       # covers every PR, `automerge` only the auto-merging ones (so Renovate can


### PR DESCRIPTION
# Description

The maintainer reported every conflicted (`dirty`) Renovate PR as *"merge conflict; Renovate owns the rebase"*, reassuring operators it would self-heal. That's false when the PR's head also carries human-pushed commits: Renovate refuses to auto-rebase a branch it didn't author, so the conflict never clears and the PR sits silently stuck — exactly the situation in a case like camunda/camunda-hub#25297.

- Branch the `dirty` case on `head_modified` so a conflicted **and** human-edited PR is surfaced as *"left for human (Renovate won't auto-rebase it)"* instead of implying automatic recovery.
- Action stays `skip` on both paths, so `apply.sh` behavior is unchanged — only the surfaced reason differs (no regression).
- No extra API calls: `head_modified` is already computed for this case via `compute_staleness`.
- README and decision-model comment updated to document the conflicted-and-edited case.

Validated with `shellcheck`, `bash -n`, and the repo pre-commit hooks; both branches confirmed (unmodified path byte-identical to before).