### PR TITLE
fix: fall back to default branch when base-ref has no snapshots (stacked PR support)

### DIFF
--- a/dependency-vuln-check/action.yml
+++ b/dependency-vuln-check/action.yml
@@ -27,6 +27,14 @@ inputs:
       (e.g. maven-dependency-snapshot.yml). Its successful push-event runs are
       scanned to resolve the effective base.
     required: true
+  fallback-base-ref:
+    description: >
+      Branch to fall back to when base-ref has no dependency snapshots (e.g.
+      stacked PRs targeting a feature branch). The gate searches this branch for
+      the nearest snapshotted ancestor of base-sha instead of failing closed.
+      Defaults to main.
+    required: false
+    default: main
   max-snapshot-lookback:
     description: >
       How many recent successful snapshot-workflow runs to scan when resolving the
@@ -81,5 +89,6 @@ runs:
         FAIL_ON_SEVERITY: ${{ inputs.fail-on-severity }}
         FAIL_ON_FIXABLE_SEVERITY: ${{ inputs.fail-on-fixable-severity }}
         FAIL_ON_SCOPES: ${{ inputs.fail-on-scopes }}
+        FALLBACK_BASE_REF: ${{ inputs.fallback-base-ref }}
         GITHUB_EVENT_PATH: ${{ github.event_path }}
       run: python3 "${{ github.action_path }}/check.py"

--- a/dependency-vuln-check/check.py
+++ b/dependency-vuln-check/check.py
@@ -203,9 +203,12 @@ def latest_snapshotted_ancestor(
     accepts the first whose status is `identical` (same commit) or `ahead`
     (base_sha is ahead → the run commit is an ancestor).
 
-    Returns (effective_base_sha, run_id, scanned_count); (None, None, scanned) if
-    no ancestor is found within the window. Raises ApiError on API failure so the
-    caller can fail closed.
+    Returns (effective_base_sha, run_id, scanned_count, latest_on_branch); the first
+    three are (None, None, scanned) if no ancestor is found within the window.
+    `latest_on_branch` is the head_sha of the most recent successful run on
+    `base_ref` (the very first run examined), regardless of ancestry — used by the
+    caller as the "current tip" of the branch for the pre-existing dep filter.
+    Raises ApiError on API failure so the caller can fail closed.
 
     `lookback` is honored even beyond the API's 100-per-page cap by following
     pagination, so a large lookback never silently scans fewer runs than asked.
@@ -217,6 +220,7 @@ def latest_snapshotted_ancestor(
         f"&status=success&event=push&per_page={per_page}"
     )
     scanned = 0
+    latest_on_branch: str | None = None
     while url and scanned < lookback:
         payload, headers = _http_get_json(url, token)
         runs = payload.get("workflow_runs", []) if isinstance(payload, dict) else []
@@ -226,15 +230,60 @@ def latest_snapshotted_ancestor(
             run_sha = run.get("head_sha")
             if not run_sha:
                 continue
+            if latest_on_branch is None:
+                latest_on_branch = run_sha  # most recent snapshot on this branch
             scanned += 1
             # compare/{run_sha}...{base_sha}: "ahead" = base_sha is ahead of run_sha
             # = run_sha is an ancestor of base_sha (what we want).
             status = _compare_status(repository, run_sha, base_sha, token)
             if status in ("identical", "ahead"):
-                return run_sha, run.get("id"), scanned
+                return run_sha, run.get("id"), scanned, latest_on_branch
         match = re.search(r'<([^>]+)>;\s*rel="next"', headers.get("Link", "") or "")
         url = match.group(1) if match else None
-    return None, None, scanned
+    return None, None, scanned, latest_on_branch
+
+
+def _base_branch_pre_existing(
+    repository: str, effective_base: str, latest_on_branch: str | None, token: str
+) -> set:
+    """Return (name, version, manifest) triples the base branch added since effective_base.
+
+    Compares effective_base...latest_on_branch via the Dependency Review API to find
+    dep versions the base branch itself introduced after effective_base. Any dep at
+    (name, version, manifest) that appears as "added" in this drift compare was
+    already on the base branch before the PR was opened — the PR did not introduce it.
+
+    This suppresses Pattern A FPs: when a dep version is bumped on main (e.g. by
+    Renovate) AFTER the effective_base snapshot was taken, that version shows as
+    "added" in the PR compare even though the PR never touched it. The drift compare
+    reveals that main itself added that (name, version, manifest) — so it is
+    pre-existing, not PR-introduced.
+
+    Returns an empty set when:
+    - effective_base == latest_on_branch (no drift — nothing to filter)
+    - latest_on_branch is None (no snapshot found on branch; nothing to compare)
+    - the drift compare API call fails (fail-open: FPs may slip through, but real
+      vulns are never suppressed)
+    """
+    if not latest_on_branch or effective_base == latest_on_branch:
+        return set()
+    try:
+        drift = _api_get(
+            f"{_GITHUB_API}/repos/{repository}/dependency-graph/compare"
+            f"/{effective_base}...{latest_on_branch}",
+            token,
+        )
+        return {
+            (dep.get("name", ""), dep.get("version", ""), dep.get("manifest", ""))
+            for dep in drift
+            if dep.get("change_type") == "added"
+        }
+    except ApiError as e:
+        print(
+            f"::warning::Could not fetch base-branch drift compare ({e.reason})"
+            " — pre-existing dep filter disabled for this run"
+        )
+        return set()
 
 
 def has_override_label(repository: str, pr_number, token: str, label: str) -> bool:
@@ -329,20 +378,26 @@ def find_blocking(
     fail_sev_rank: int = SEVERITY_ORDER["high"],
     fail_fixable_rank: int = SEVERITY_ORDER["low"],
     gated_scopes: set | None = None,
-) -> tuple[list, list, list]:
-    """Return (blocking, allowed, scope_excluded).
+    pre_existing_deps: set | None = None,
+) -> tuple[list, list, list, list]:
+    """Return (blocking, allowed, scope_excluded, pre_existing).
 
     blocking       – vulns that block the PR
     allowed        – would have blocked but are in allow-ghsas
     scope_excluded – would have blocked but the dep's scope is not gated
+    pre_existing   – would have blocked but (name, version, manifest) was already
+                     on the base branch before this PR (Pattern A FP filter)
     """
     gated_scopes = gated_scopes if gated_scopes is not None else {"runtime"}
-    blocking, allowed, scope_excluded = [], [], []
+    pre_existing_deps = pre_existing_deps or set()
+    blocking, allowed, scope_excluded, pre_existing = [], [], [], []
     for dep in diff:
         if dep.get("change_type") != "added":
             continue
         scope = (dep.get("scope") or "runtime").lower()
         is_gated = scope in gated_scopes
+        dep_key = (dep.get("name", ""), dep.get("version", ""), dep.get("manifest", ""))
+        is_pre_existing = dep_key in pre_existing_deps
         for vuln in dep.get("vulnerabilities") or []:
             ids = _ghsa_ids(vuln)
             ghsa = sorted(ids)[0] if ids else "unknown"
@@ -364,13 +419,15 @@ def find_blocking(
                 "rule": "fixable" if fixable else "no-fix/high-severity",
                 "scope": scope,
             }
-            if not is_gated:
+            if is_pre_existing:
+                pre_existing.append(entry)
+            elif not is_gated:
                 scope_excluded.append(entry)
             elif {i.upper() for i in ids} & allowed_ghsas:
                 allowed.append(entry)
             else:
                 blocking.append(entry)
-    return blocking, allowed, scope_excluded
+    return blocking, allowed, scope_excluded, pre_existing
 
 
 def _advisory_cell(b: dict) -> str:
@@ -437,6 +494,7 @@ def _upsert_comment(repository: str, pr_number: int, token: str, body: str) -> N
 def post_pr_comment(
     repository: str, pr_number: int, blocking: list, allowed: list, scope_excluded: list, token: str,
     note: str | None = None,
+    pre_existing: list | None = None,
 ) -> None:
     sections = []
 
@@ -476,6 +534,23 @@ def post_pr_comment(
             "and are excluded from blocking. Consider upgrading if a fix is available.",
             "",
             _table(scope_excluded),
+        ]
+
+    if pre_existing:
+        sections += [
+            "",
+            f"### ℹ️ {len(pre_existing)} finding(s) pre-existing on the base branch — not blocking",
+            "",
+            "> These vulnerabilities exist in dependencies that were **already on the base branch "
+            "before this PR was opened** — this PR did not introduce them.",
+            ">",
+            "> The gate compares from the nearest snapshotted ancestor of your base commit. When a "
+            "dep version is bumped on the base branch (e.g. by Renovate) after that snapshot was "
+            "taken, it can appear as `added` even though the PR is unrelated.",
+            ">",
+            "> To resolve: upgrade the affected dependency in a dedicated PR, or wait for Renovate.",
+            "",
+            _table(pre_existing),
         ]
 
     _upsert_comment(repository, pr_number, token, "\n".join(sections))
@@ -578,7 +653,7 @@ def main() -> None:
     # ── Resolve the effective base to a snapshotted ancestor (Workstream D) ──
     print(f"::notice::Resolving base {base_sha} on '{base_ref}' to the nearest snapshotted ancestor")
     try:
-        effective_base, run_id, scanned = latest_snapshotted_ancestor(
+        effective_base, run_id, scanned, latest_on_branch = latest_snapshotted_ancestor(
             repository, base_ref, base_sha, snapshot_workflow, token, lookback
         )
     except ApiError as e:
@@ -595,7 +670,7 @@ def main() -> None:
             f"falling back to '{fallback_ref}' snapshots"
         )
         try:
-            effective_base, run_id, scanned = latest_snapshotted_ancestor(
+            effective_base, run_id, scanned, latest_on_branch = latest_snapshotted_ancestor(
                 repository, fallback_ref, base_sha, snapshot_workflow, token, lookback
             )
         except ApiError as e:
@@ -645,12 +720,22 @@ def main() -> None:
         )
         return
 
-    blocking, allowed, scope_excluded = find_blocking(
-        diff, allowed_ghsas, token, fail_sev_rank, fail_fixable_rank, gated_scopes
+    # ── Pre-existing dep filter: suppress Pattern A FPs (Workstream F) ──
+    # Compare effective_base...latest_on_branch to find deps the base branch added
+    # after our snapshot — those are pre-existing on the branch, not PR-introduced.
+    pre_existing_deps = _base_branch_pre_existing(repository, effective_base, latest_on_branch, token)
+    if pre_existing_deps:
+        print(f"::notice::Pre-existing dep filter: {len(pre_existing_deps)} (name, version, manifest) triple(s) found on base branch since effective_base — will not block")
+
+    blocking, allowed, scope_excluded, pre_existing = find_blocking(
+        diff, allowed_ghsas, token, fail_sev_rank, fail_fixable_rank, gated_scopes,
+        pre_existing_deps=pre_existing_deps,
     )
 
     for a in allowed:
         print(f"::notice::Allowed exception: {a['ghsa']} in {a['package']} (severity: {a['severity']}, rule: {a['rule']}) — covered by allow-ghsas")
+    for p in pre_existing:
+        print(f"::notice::Pre-existing on base branch: {p['ghsa']} in {p['package']} ({p['manifest']}) — not blocking")
     for d in scope_excluded:
         print(f"::notice::Non-gated dep: {d['ghsa']} in {d['package']} (severity: {d['severity']}, rule: {d['rule']}) — excluded (scope: {d['scope']})")
 
@@ -683,11 +768,16 @@ def main() -> None:
         summary += ["", "### Allowed exceptions (allow-ghsas)", _table(allowed)]
     if scope_excluded:
         summary += ["", "### Non-gated scope (not blocking)", _table(scope_excluded)]
+    if pre_existing:
+        summary += ["", "### Pre-existing on base branch — not blocking (Pattern A filter)", _table(pre_existing)]
     _write_summary(summary_path, "\n".join(summary))
 
-    if pr_number and (blocking or allowed or scope_excluded or stacked_note):
-        post_pr_comment(repository, pr_number, blocking, allowed, scope_excluded, token, note=stacked_note)
-    elif not pr_number and (blocking or allowed or scope_excluded):
+    if pr_number and (blocking or allowed or scope_excluded or pre_existing or stacked_note):
+        post_pr_comment(
+            repository, pr_number, blocking, allowed, scope_excluded, token,
+            note=stacked_note, pre_existing=pre_existing,
+        )
+    elif not pr_number and (blocking or allowed or scope_excluded or pre_existing):
         print("::warning::Could not determine PR number from event payload — skipping PR comment")
 
     if blocking:

--- a/dependency-vuln-check/check.py
+++ b/dependency-vuln-check/check.py
@@ -208,6 +208,10 @@ def latest_snapshotted_ancestor(
     `latest_on_branch` is the head_sha of the most recent successful run on
     `base_ref` (the very first run examined), regardless of ancestry — used by the
     caller as the "current tip" of the branch for the pre-existing dep filter.
+    NOTE: this is the latest *snapshotted* commit, not the actual branch HEAD. If
+    the most recent push was path-filtered (e.g. docs-only) and no snapshot was
+    submitted, deps merged in that gap are invisible to the pre-existing filter and
+    may surface as false-positive blocks on unrelated PRs.
     Raises ApiError on API failure so the caller can fail closed.
 
     `lookback` is honored even beyond the API's 100-per-page cap by following
@@ -258,6 +262,17 @@ def _base_branch_pre_existing(
     "added" in the PR compare even though the PR never touched it. The drift compare
     reveals that main itself added that (name, version, manifest) — so it is
     pre-existing, not PR-introduced.
+
+    Known limitation — concurrent-bump false negative: if a PR independently
+    introduces the same (name, version, manifest) that the base branch also added
+    after effective_base (e.g. Renovate and the PR both pin the same dep version),
+    the filter cannot distinguish the two and suppresses the PR's finding. This is
+    an inherent consequence of triple-level matching without PR authorship data.
+
+    Per-dep advisory coverage: when a dep triple is pre-existing, ALL its
+    advisories (including ones published after the snapshot) are suppressed. This
+    is intentional — the PR did not introduce the dep version, so it is not
+    responsible for any of its advisories regardless of when they were discovered.
 
     Returns an empty set when:
     - effective_base == latest_on_branch (no drift — nothing to filter)
@@ -419,12 +434,12 @@ def find_blocking(
                 "rule": "fixable" if fixable else "no-fix/high-severity",
                 "scope": scope,
             }
-            if is_pre_existing:
-                pre_existing.append(entry)
-            elif not is_gated:
+            if not is_gated:
                 scope_excluded.append(entry)
             elif {i.upper() for i in ids} & allowed_ghsas:
                 allowed.append(entry)
+            elif is_pre_existing:
+                pre_existing.append(entry)
             else:
                 blocking.append(entry)
     return blocking, allowed, scope_excluded, pre_existing
@@ -776,7 +791,7 @@ def main() -> None:
             repository, pr_number, blocking, allowed, scope_excluded, token,
             note=stacked_note, pre_existing=pre_existing,
         )
-    elif not pr_number and (blocking or allowed or scope_excluded or pre_existing):
+    elif not pr_number and (blocking or allowed or scope_excluded or pre_existing or stacked_note):
         print("::warning::Could not determine PR number from event payload — skipping PR comment")
 
     if blocking:

--- a/dependency-vuln-check/check.py
+++ b/dependency-vuln-check/check.py
@@ -664,10 +664,10 @@ def main() -> None:
         return  # unreachable: fail_closed exits
 
     # ── Stacked PR fallback: base_ref has no snapshots — try the default branch ──
+    scanned_base = scanned
     if effective_base is None and base_ref != fallback_ref:
         print(
-            f"::notice::No snapshot on '{base_ref}' — stacked PR detected; "
-            f"falling back to '{fallback_ref}' snapshots"
+            f"::notice::No snapshot found on '{base_ref}' — falling back to '{fallback_ref}' snapshots"
         )
         try:
             effective_base, run_id, scanned, latest_on_branch = latest_snapshotted_ancestor(
@@ -688,13 +688,12 @@ def main() -> None:
             )
 
     if effective_base is None:
-        refs_tried = f"'{base_ref}'"
+        refs_tried = f"'{base_ref}' (scanned {scanned_base} run(s))"
         if base_ref != fallback_ref:
-            refs_tried += f" or fallback '{fallback_ref}'"
+            refs_tried += f" or fallback '{fallback_ref}' (scanned {scanned} run(s))"
         fail_closed(
             repository, pr_number, token, override_label,
-            f"no snapshotted ancestor of {base_sha} found within the last {scanned} "
-            f"snapshot run(s) on {refs_tried}",
+            f"no snapshotted ancestor of {base_sha} found on {refs_tried}",
             summary_path,
         )
         return
@@ -747,7 +746,7 @@ def main() -> None:
     # ── Always-on run summary trail ──
     base_line = f"`{effective_base}`"
     if stacked_pr_fallback:
-        base_line += f" (stacked PR fallback from `{fallback_ref}`, scanned {scanned} run(s))"
+        base_line += f" (stacked PR fallback to `{fallback_ref}`, scanned {scanned} run(s))"
     elif effective_base != base_sha:
         base_line += f" (resolved from `{base_sha}`, scanned {scanned} run(s))"
     summary = [

--- a/dependency-vuln-check/check.py
+++ b/dependency-vuln-check/check.py
@@ -20,10 +20,20 @@ raw ``base.sha`` is unsafe: the snapshot workflow is path-filtered, so a code-on
 base commit has no snapshot, leaving the base side of the compare empty and
 flagging the *entire* head tree as "added" (pre-existing deps surface as new).
 
-The gate FAILS CLOSED when it cannot verify a PR (no snapshotted ancestor, or a
-GitHub API failure that survives retries). A human may bypass a genuinely
-un-checkable PR by adding the override label (read live, not from the stale event
-payload). The label never bypasses a real finding.
+Stacked PR fallback
+-------------------
+When the PR targets a branch that has no snapshots (e.g. a feature branch used as
+the base for a stacked PR), the gate falls back to the configured
+``FALLBACK_BASE_REF`` (default: ``main``).  The diff ``effective_base...head`` then
+covers both the stacked branch's changes and the PR's own changes — conservative
+but avoids a hard fail-closed on a normally-safe pattern.  A notice is posted to
+the PR comment so engineers understand why the effective base differs from the
+branch they targeted.
+
+The gate FAILS CLOSED when it cannot verify a PR (no snapshotted ancestor on
+either ``base_ref`` or the fallback, or a GitHub API failure that survives retries).
+A human may bypass a genuinely un-checkable PR by adding the override label (read
+live, not from the stale event payload). The label never bypasses a real finding.
 """
 import json
 import os
@@ -425,9 +435,13 @@ def _upsert_comment(repository: str, pr_number: int, token: str, body: str) -> N
 
 
 def post_pr_comment(
-    repository: str, pr_number: int, blocking: list, allowed: list, scope_excluded: list, token: str
+    repository: str, pr_number: int, blocking: list, allowed: list, scope_excluded: list, token: str,
+    note: str | None = None,
 ) -> None:
     sections = []
+
+    if note:
+        sections += [f"> **ℹ️ Note:** {note}", ""]
 
     if blocking:
         sections += [
@@ -558,6 +572,9 @@ def main() -> None:
         print(f"::notice::Config file {config_file} not found — proceeding with empty allow-ghsas list")
         allowed_ghsas = set()
 
+    fallback_ref = os.environ.get("FALLBACK_BASE_REF", "main")
+    stacked_pr_fallback = False
+
     # ── Resolve the effective base to a snapshotted ancestor (Workstream D) ──
     print(f"::notice::Resolving base {base_sha} on '{base_ref}' to the nearest snapshotted ancestor")
     try:
@@ -571,11 +588,38 @@ def main() -> None:
         )
         return  # unreachable: fail_closed exits
 
+    # ── Stacked PR fallback: base_ref has no snapshots — try the default branch ──
+    if effective_base is None and base_ref != fallback_ref:
+        print(
+            f"::notice::No snapshot on '{base_ref}' — stacked PR detected; "
+            f"falling back to '{fallback_ref}' snapshots"
+        )
+        try:
+            effective_base, run_id, scanned = latest_snapshotted_ancestor(
+                repository, fallback_ref, base_sha, snapshot_workflow, token, lookback
+            )
+        except ApiError as e:
+            fail_closed(
+                repository, pr_number, token, override_label,
+                f"could not resolve base snapshot on fallback '{fallback_ref}' ({e.reason})",
+                summary_path,
+            )
+            return
+        if effective_base is not None:
+            stacked_pr_fallback = True
+            print(
+                f"::notice::Fallback resolved: {effective_base} on '{fallback_ref}' "
+                f"(scanned {scanned} run(s))"
+            )
+
     if effective_base is None:
+        refs_tried = f"'{base_ref}'"
+        if base_ref != fallback_ref:
+            refs_tried += f" or fallback '{fallback_ref}'"
         fail_closed(
             repository, pr_number, token, override_label,
             f"no snapshotted ancestor of {base_sha} found within the last {scanned} "
-            f"snapshot run(s) on '{base_ref}'",
+            f"snapshot run(s) on {refs_tried}",
             summary_path,
         )
         return
@@ -610,9 +654,16 @@ def main() -> None:
     for d in scope_excluded:
         print(f"::notice::Non-gated dep: {d['ghsa']} in {d['package']} (severity: {d['severity']}, rule: {d['rule']}) — excluded (scope: {d['scope']})")
 
+    stacked_note = (
+        f"Stacked PR — `{base_ref}` has no dependency snapshots; compared from "
+        f"`{fallback_ref}` snapshot `{effective_base}` (diff includes stacked branch changes)."
+    ) if stacked_pr_fallback else None
+
     # ── Always-on run summary trail ──
     base_line = f"`{effective_base}`"
-    if effective_base != base_sha:
+    if stacked_pr_fallback:
+        base_line += f" (stacked PR fallback from `{fallback_ref}`, scanned {scanned} run(s))"
+    elif effective_base != base_sha:
         base_line += f" (resolved from `{base_sha}`, scanned {scanned} run(s))"
     summary = [
         "## Dependency Vulnerability Gate",
@@ -622,6 +673,8 @@ def main() -> None:
         f"- **Head:** `{head_sha}`",
         "",
     ]
+    if stacked_note:
+        summary += [f"> **ℹ️ Note:** {stacked_note}", ""]
     if blocking:
         summary += [f"**Verdict:** 🚨 {len(blocking)} blocking issue(s)", "", _table(blocking)]
     else:
@@ -632,8 +685,8 @@ def main() -> None:
         summary += ["", "### Non-gated scope (not blocking)", _table(scope_excluded)]
     _write_summary(summary_path, "\n".join(summary))
 
-    if pr_number and (blocking or allowed or scope_excluded):
-        post_pr_comment(repository, pr_number, blocking, allowed, scope_excluded, token)
+    if pr_number and (blocking or allowed or scope_excluded or stacked_note):
+        post_pr_comment(repository, pr_number, blocking, allowed, scope_excluded, token, note=stacked_note)
     elif not pr_number and (blocking or allowed or scope_excluded):
         print("::warning::Could not determine PR number from event payload — skipping PR comment")
 

--- a/dependency-vuln-check/test_check.py
+++ b/dependency-vuln-check/test_check.py
@@ -29,14 +29,15 @@ def _no_network(monkeypatch):
 
 
 def _dep(name="acme", version="1.0.0", scope="runtime", change_type="added",
-         severity="high", fix=None, ghsas=("GHSA-aaaa-bbbb-cccc",), cve="CVE-2024-0001"):
+         severity="high", fix=None, ghsas=("GHSA-aaaa-bbbb-cccc",), cve="CVE-2024-0001",
+         manifest="pom.xml"):
     return {
         "change_type": change_type,
         "scope": scope,
         "name": name,
         "version": version,
         "ecosystem": "maven",
-        "manifest": "pom.xml",
+        "manifest": manifest,
         "vulnerabilities": [{
             "severity": severity,
             "first_patched_version": fix,
@@ -58,59 +59,59 @@ def _run(diff, allowed=None, fail_sev=HIGH, fail_fix=LOW, scopes=None):
 # --- default-policy rule matrix ------------------------------------------------
 
 def test_fixable_any_severity_blocks():
-    blocking, _, _ = _run([_dep(severity="low", fix="2.0.0")])
+    blocking, _, _, _ = _run([_dep(severity="low", fix="2.0.0")])
     assert len(blocking) == 1
     assert blocking[0]["rule"] == "fixable"
 
 
 def test_no_fix_high_blocks():
-    blocking, _, _ = _run([_dep(severity="high", fix=None)])
+    blocking, _, _, _ = _run([_dep(severity="high", fix=None)])
     assert len(blocking) == 1
     assert blocking[0]["rule"] == "no-fix/high-severity"
 
 
 def test_no_fix_moderate_does_not_block():
-    blocking, allowed, excluded = _run([_dep(severity="moderate", fix=None)])
+    blocking, allowed, excluded, _ = _run([_dep(severity="moderate", fix=None)])
     assert (blocking, allowed, excluded) == ([], [], [])
 
 
 def test_development_scope_excluded_by_default():
-    blocking, _, excluded = _run([_dep(scope="development", severity="critical", fix="2.0.0")])
+    blocking, _, excluded, _ = _run([_dep(scope="development", severity="critical", fix="2.0.0")])
     assert blocking == []
     assert len(excluded) == 1
 
 
 def test_allow_ghsas_moves_to_allowed():
-    blocking, allowed, _ = _run([_dep(fix="2.0.0")], allowed={"GHSA-AAAA-BBBB-CCCC"})
+    blocking, allowed, _, _ = _run([_dep(fix="2.0.0")], allowed={"GHSA-AAAA-BBBB-CCCC"})
     assert blocking == []
     assert len(allowed) == 1
 
 
 def test_unchanged_and_removed_ignored():
     diff = [_dep(change_type="removed", fix="2.0.0"), _dep(change_type="unchanged", fix="2.0.0")]
-    assert _run(diff) == ([], [], [])
+    assert _run(diff) == ([], [], [], [])
 
 
 def test_downgrade_added_low_version_blocks():
     # A downgrade surfaces the vulnerable lower version as `added`.
-    blocking, _, _ = _run([_dep(version="1.0.0", change_type="added", fix="1.5.0")])
+    blocking, _, _, _ = _run([_dep(version="1.0.0", change_type="added", fix="1.5.0")])
     assert len(blocking) == 1
 
 
 # --- threshold input behavior --------------------------------------------------
 
 def test_raising_fixable_threshold_spares_low():
-    blocking, _, _ = _run([_dep(severity="low", fix="2.0.0")], fail_fix=HIGH)
+    blocking, _, _, _ = _run([_dep(severity="low", fix="2.0.0")], fail_fix=HIGH)
     assert blocking == []
 
 
 def test_lowering_severity_threshold_blocks_moderate_no_fix():
-    blocking, _, _ = _run([_dep(severity="moderate", fix=None)], fail_sev=LOW)
+    blocking, _, _, _ = _run([_dep(severity="moderate", fix=None)], fail_sev=LOW)
     assert len(blocking) == 1
 
 
 def test_gating_development_scope_blocks_it():
-    blocking, _, excluded = _run(
+    blocking, _, excluded, _ = _run(
         [_dep(scope="development", fix="2.0.0")],
         scopes={"runtime", "development"},
     )
@@ -121,12 +122,12 @@ def test_gating_development_scope_blocks_it():
 # --- unknown-severity legacy contract -----------------------------------------
 
 def test_unknown_severity_fixable_blocks():
-    blocking, _, _ = _run([_dep(severity="", fix="2.0.0")])
+    blocking, _, _, _ = _run([_dep(severity="", fix="2.0.0")])
     assert len(blocking) == 1
 
 
 def test_unknown_severity_no_fix_does_not_block():
-    blocking, allowed, excluded = _run([_dep(severity="", fix=None)])
+    blocking, allowed, excluded, _ = _run([_dep(severity="", fix=None)])
     assert (blocking, allowed, excluded) == ([], [], [])
 
 
@@ -134,7 +135,7 @@ def test_unknown_severity_no_fix_does_not_block():
 
 def test_graphql_fallback_marks_fixable(monkeypatch):
     monkeypatch.setattr(check, "_lookup_patch", lambda *a, **k: "9.9.9")
-    blocking, _, _ = _run([_dep(severity="low", fix=None)])
+    blocking, _, _, _ = _run([_dep(severity="low", fix=None)])
     assert len(blocking) == 1
     assert blocking[0]["fix"] == "9.9.9"
     assert blocking[0]["rule"] == "fixable"
@@ -244,7 +245,7 @@ def test_ancestor_picks_newest(monkeypatch):
     monkeypatch.setattr(check, "_http_get_json", lambda url, tok: (runs, {}))
     statuses = {"newer": "diverged", "anc": "ahead", "older": "ahead"}
     monkeypatch.setattr(check, "_compare_status", lambda repo, head, base, tok: statuses[head])
-    eff, run_id, scanned = check.latest_snapshotted_ancestor("o/r", "main", "BASE", "wf.yml", "tok", 30)
+    eff, run_id, scanned, _ = check.latest_snapshotted_ancestor("o/r", "main", "BASE", "wf.yml", "tok", 30)
     assert (eff, run_id, scanned) == ("anc", 2, 2)  # skipped newer (diverged), matched anc
 
 
@@ -252,7 +253,7 @@ def test_ancestor_identical_at_top(monkeypatch):
     runs = {"workflow_runs": [{"head_sha": "BASE", "id": 9}]}
     monkeypatch.setattr(check, "_http_get_json", lambda url, tok: (runs, {}))
     monkeypatch.setattr(check, "_compare_status", lambda *a: "identical")
-    eff, _, scanned = check.latest_snapshotted_ancestor("o/r", "main", "BASE", "wf.yml", "tok", 30)
+    eff, _, scanned, _ = check.latest_snapshotted_ancestor("o/r", "main", "BASE", "wf.yml", "tok", 30)
     assert eff == "BASE" and scanned == 1
 
 
@@ -260,7 +261,7 @@ def test_ancestor_none_found(monkeypatch):
     runs = {"workflow_runs": [{"head_sha": "x", "id": 1}, {"head_sha": "y", "id": 2}]}
     monkeypatch.setattr(check, "_http_get_json", lambda url, tok: (runs, {}))
     monkeypatch.setattr(check, "_compare_status", lambda *a: "behind")
-    eff, run_id, scanned = check.latest_snapshotted_ancestor("o/r", "main", "BASE", "wf.yml", "tok", 30)
+    eff, run_id, scanned, _ = check.latest_snapshotted_ancestor("o/r", "main", "BASE", "wf.yml", "tok", 30)
     assert eff is None and run_id is None and scanned == 2
 
 
@@ -319,7 +320,7 @@ def test_ancestor_paginates_to_honor_lookback(monkeypatch):
         check, "_compare_status",
         lambda repo, head, base, tok: "ahead" if head == "anc" else "diverged",
     )
-    eff, run_id, scanned = check.latest_snapshotted_ancestor(
+    eff, run_id, scanned, _ = check.latest_snapshotted_ancestor(
         "o/r", "main", "BASE", "wf.yml", "tok", 150
     )
     assert eff == "anc" and run_id == 999
@@ -372,7 +373,8 @@ def test_main_real_vuln_blocks_even_with_override_label(monkeypatch):
     # API works, base resolves, a real fixable vuln is added → blocks (exit 1).
     # The override label is present but must be IGNORED for a genuine finding.
     _set_main_env(monkeypatch)
-    monkeypatch.setattr(check, "latest_snapshotted_ancestor", lambda *a, **k: ("eff", 1, 1))
+    monkeypatch.setattr(check, "latest_snapshotted_ancestor", lambda *a, **k: ("eff", 1, 1, "latest"))
+    monkeypatch.setattr(check, "_base_branch_pre_existing", lambda *a, **k: set())
     monkeypatch.setattr(check, "_api_get", lambda url, tok: [_dep(severity="high", fix="2.0.0")])
     monkeypatch.setattr(check, "has_override_label", lambda *a, **k: True)
     with pytest.raises(SystemExit) as ei:
@@ -382,7 +384,7 @@ def test_main_real_vuln_blocks_even_with_override_label(monkeypatch):
 
 def test_main_fail_closed_when_no_ancestor(monkeypatch):
     _set_main_env(monkeypatch)
-    monkeypatch.setattr(check, "latest_snapshotted_ancestor", lambda *a, **k: (None, None, 5))
+    monkeypatch.setattr(check, "latest_snapshotted_ancestor", lambda *a, **k: (None, None, 5, None))
     monkeypatch.setattr(check, "has_override_label", lambda *a, **k: False)
     with pytest.raises(SystemExit) as ei:
         check.main()
@@ -399,8 +401,8 @@ def test_stacked_pr_falls_back_to_default_branch(monkeypatch):
     def fake_ancestor(repo, ref, sha, wf, tok, lookback):
         calls.append(ref)
         if ref == "refactor/some-feature":
-            return None, None, 0  # no snapshots on feature branch
-        return "eff-main", 42, 1  # main has a snapshot
+            return None, None, 0, None  # no snapshots on feature branch
+        return "eff-main", 42, 1, "latest-main"  # main has a snapshot
 
     monkeypatch.setattr(check, "latest_snapshotted_ancestor", fake_ancestor)
     monkeypatch.setattr(check, "_api_get", lambda url, tok: [])  # no dep changes
@@ -418,7 +420,7 @@ def test_stacked_pr_fallback_also_empty_fails_closed(monkeypatch):
     _set_main_env(monkeypatch)
     monkeypatch.setenv("BASE_REF", "refactor/some-feature")
     monkeypatch.setenv("FALLBACK_BASE_REF", "main")
-    monkeypatch.setattr(check, "latest_snapshotted_ancestor", lambda *a, **k: (None, None, 0))
+    monkeypatch.setattr(check, "latest_snapshotted_ancestor", lambda *a, **k: (None, None, 0, None))
     monkeypatch.setattr(check, "has_override_label", lambda *a, **k: False)
     with pytest.raises(SystemExit) as ei:
         check.main()
@@ -434,7 +436,7 @@ def test_no_fallback_when_base_ref_equals_fallback_ref(monkeypatch):
 
     def fake_ancestor(repo, ref, sha, wf, tok, lookback):
         calls.append(ref)
-        return None, None, 5
+        return None, None, 5, None
 
     monkeypatch.setattr(check, "latest_snapshotted_ancestor", fake_ancestor)
     monkeypatch.setattr(check, "has_override_label", lambda *a, **k: False)
@@ -442,3 +444,68 @@ def test_no_fallback_when_base_ref_equals_fallback_ref(monkeypatch):
         check.main()
     assert ei.value.code == 1
     assert calls == ["main"]  # called only once — no fallback to itself
+
+
+# --- Pattern A pre-existing dep filter (Workstream F) -------------------------
+
+def test_pre_existing_dep_not_blocking(monkeypatch):
+    # Dep appears as "added" in the PR diff but is already on the base branch
+    # (Renovate bumped it after the effective_base snapshot) → pre_existing, not blocking.
+    monkeypatch.setattr(check, "_lookup_patch", lambda *a, **k: None)
+    dep = _dep(name="jackson-databind", version="2.21.4", manifest="clients/java/pom.xml", fix="2.21.5")
+    pre_existing_set = {("jackson-databind", "2.21.4", "clients/java/pom.xml")}
+    blocking, allowed, scope_excluded, pre_existing = find_blocking(
+        [dep], set(), token="", pre_existing_deps=pre_existing_set
+    )
+    assert blocking == []
+    assert len(pre_existing) == 1
+    assert pre_existing[0]["package"] == "jackson-databind@2.21.4"
+
+
+def test_pre_existing_different_manifest_still_blocks(monkeypatch):
+    # Same (name, version) but different manifest → PR genuinely added it to a new module.
+    monkeypatch.setattr(check, "_lookup_patch", lambda *a, **k: None)
+    dep = _dep(name="jackson-databind", version="2.21.4", manifest="new-module/pom.xml", fix="2.21.5")
+    pre_existing_set = {("jackson-databind", "2.21.4", "clients/java/pom.xml")}
+    blocking, _, _, pre_existing = find_blocking(
+        [dep], set(), token="", pre_existing_deps=pre_existing_set
+    )
+    assert len(blocking) == 1  # different manifest → not filtered
+    assert pre_existing == []
+
+
+def test_base_branch_pre_existing_no_drift(monkeypatch):
+    # effective_base == latest_on_branch → no drift, returns empty set without API call.
+    api_called = []
+    monkeypatch.setattr(check, "_api_get", lambda url, tok: api_called.append(url) or [])
+    result = check._base_branch_pre_existing("o/r", "sha-abc", "sha-abc", "tok")
+    assert result == set()
+    assert api_called == []
+
+
+def test_base_branch_pre_existing_no_latest(monkeypatch):
+    # latest_on_branch is None (no snapshot on branch) → returns empty set.
+    api_called = []
+    monkeypatch.setattr(check, "_api_get", lambda url, tok: api_called.append(url) or [])
+    result = check._base_branch_pre_existing("o/r", "sha-abc", None, "tok")
+    assert result == set()
+    assert api_called == []
+
+
+def test_base_branch_pre_existing_returns_added_triples(monkeypatch):
+    drift = [
+        {"change_type": "added", "name": "jackson-databind", "version": "2.21.4", "manifest": "clients/java/pom.xml"},
+        {"change_type": "removed", "name": "old-dep", "version": "1.0.0", "manifest": "pom.xml"},
+    ]
+    monkeypatch.setattr(check, "_api_get", lambda url, tok: drift)
+    result = check._base_branch_pre_existing("o/r", "base-sha", "latest-sha", "tok")
+    assert result == {("jackson-databind", "2.21.4", "clients/java/pom.xml")}
+
+
+def test_base_branch_pre_existing_api_error_returns_empty(monkeypatch):
+    # API error → fail-open, return empty set (don't suppress real findings).
+    monkeypatch.setattr(check, "_api_get", lambda url, tok: (_ for _ in ()).throw(
+        check.ApiError("server error", 503, retryable=True)
+    ))
+    result = check._base_branch_pre_existing("o/r", "base-sha", "latest-sha", "tok")
+    assert result == set()

--- a/dependency-vuln-check/test_check.py
+++ b/dependency-vuln-check/test_check.py
@@ -387,3 +387,58 @@ def test_main_fail_closed_when_no_ancestor(monkeypatch):
     with pytest.raises(SystemExit) as ei:
         check.main()
     assert ei.value.code == 1
+
+
+def test_stacked_pr_falls_back_to_default_branch(monkeypatch):
+    # base_ref targets a feature branch (no snapshots); fallback_ref (main) resolves.
+    _set_main_env(monkeypatch)
+    monkeypatch.setenv("BASE_REF", "refactor/some-feature")
+    monkeypatch.setenv("FALLBACK_BASE_REF", "main")
+    calls = []
+
+    def fake_ancestor(repo, ref, sha, wf, tok, lookback):
+        calls.append(ref)
+        if ref == "refactor/some-feature":
+            return None, None, 0  # no snapshots on feature branch
+        return "eff-main", 42, 1  # main has a snapshot
+
+    monkeypatch.setattr(check, "latest_snapshotted_ancestor", fake_ancestor)
+    monkeypatch.setattr(check, "_api_get", lambda url, tok: [])  # no dep changes
+    monkeypatch.setattr(check, "_pr_number", lambda: 42)
+    comment_calls = []
+    monkeypatch.setattr(check, "post_pr_comment", lambda *a, **k: comment_calls.append(k))
+    check.main()  # must not exit 1
+    assert calls == ["refactor/some-feature", "main"]
+    # post_pr_comment called with stacked-PR note
+    assert comment_calls and "Stacked PR" in (comment_calls[0].get("note") or "")
+
+
+def test_stacked_pr_fallback_also_empty_fails_closed(monkeypatch):
+    # Neither base_ref nor fallback_ref has snapshots → fail closed.
+    _set_main_env(monkeypatch)
+    monkeypatch.setenv("BASE_REF", "refactor/some-feature")
+    monkeypatch.setenv("FALLBACK_BASE_REF", "main")
+    monkeypatch.setattr(check, "latest_snapshotted_ancestor", lambda *a, **k: (None, None, 0))
+    monkeypatch.setattr(check, "has_override_label", lambda *a, **k: False)
+    with pytest.raises(SystemExit) as ei:
+        check.main()
+    assert ei.value.code == 1
+
+
+def test_no_fallback_when_base_ref_equals_fallback_ref(monkeypatch):
+    # base_ref == fallback_ref → no second attempt; fail closed on first miss.
+    _set_main_env(monkeypatch)
+    monkeypatch.setenv("BASE_REF", "main")
+    monkeypatch.setenv("FALLBACK_BASE_REF", "main")
+    calls = []
+
+    def fake_ancestor(repo, ref, sha, wf, tok, lookback):
+        calls.append(ref)
+        return None, None, 5
+
+    monkeypatch.setattr(check, "latest_snapshotted_ancestor", fake_ancestor)
+    monkeypatch.setattr(check, "has_override_label", lambda *a, **k: False)
+    with pytest.raises(SystemExit) as ei:
+        check.main()
+    assert ei.value.code == 1
+    assert calls == ["main"]  # called only once — no fallback to itself

--- a/dependency-vuln-check/test_check.py
+++ b/dependency-vuln-check/test_check.py
@@ -509,3 +509,59 @@ def test_base_branch_pre_existing_api_error_returns_empty(monkeypatch):
     ))
     result = check._base_branch_pre_existing("o/r", "base-sha", "latest-sha", "tok")
     assert result == set()
+
+
+# --- bucket-ordering correctness (fix 3) --------------------------------------
+
+def test_pre_existing_non_gated_scope_wins_over_pre_existing(monkeypatch):
+    # A development-scoped dep that is also pre_existing → scope_excluded wins.
+    # scope exclusion is a stronger/more informative signal than pre-existing.
+    monkeypatch.setattr(check, "_lookup_patch", lambda *a, **k: None)
+    dep = _dep(scope="development", name="foo", version="1.0", manifest="pom.xml", fix="2.0")
+    pre_existing_set = {("foo", "1.0", "pom.xml")}
+    blocking, allowed, scope_excluded, pre_existing = find_blocking(
+        [dep], set(), token="", gated_scopes={"runtime"}, pre_existing_deps=pre_existing_set
+    )
+    assert blocking == []
+    assert pre_existing == []
+    assert len(scope_excluded) == 1
+
+
+def test_pre_existing_allow_listed_ghsa_wins_over_pre_existing(monkeypatch):
+    # A dep that is both pre_existing and in allowed_ghsas → allowed wins.
+    # The allow-list audit trail should reflect the explicit exemption.
+    monkeypatch.setattr(check, "_lookup_patch", lambda *a, **k: None)
+    dep = _dep(name="bar", version="2.0", manifest="pom.xml", fix="3.0", ghsas=("GHSA-aaaa-bbbb-cccc",))
+    pre_existing_set = {("bar", "2.0", "pom.xml")}
+    blocking, allowed, scope_excluded, pre_existing = find_blocking(
+        [dep], {"GHSA-AAAA-BBBB-CCCC"}, token="", pre_existing_deps=pre_existing_set
+    )
+    assert blocking == []
+    assert pre_existing == []
+    assert len(allowed) == 1
+
+
+# --- elif stacked_note warning (fix 4) ----------------------------------------
+
+def test_stacked_pr_fallback_prints_warning_when_no_pr_number(monkeypatch):
+    # When pr_number is None but stacked_note is truthy (and all finding lists empty),
+    # a warning should still be printed (stacked_note was missing from elif condition).
+    _set_main_env(monkeypatch)
+    monkeypatch.setenv("BASE_REF", "refactor/some-feature")
+    monkeypatch.setenv("FALLBACK_BASE_REF", "main")
+    monkeypatch.delenv("GITHUB_EVENT_PATH", raising=False)
+
+    def fake_ancestor(repo, ref, sha, wf, tok, lookback):
+        if ref == "refactor/some-feature":
+            return None, None, 0, None
+        return "eff-main", 42, 1, "latest-main"
+
+    monkeypatch.setattr(check, "latest_snapshotted_ancestor", fake_ancestor)
+    monkeypatch.setattr(check, "_api_get", lambda url, tok: [])
+    monkeypatch.setattr(check, "_pr_number", lambda: None)  # no PR number
+    monkeypatch.setattr(check, "_base_branch_pre_existing", lambda *a, **k: set())
+    printed = []
+    monkeypatch.setattr("builtins.print", lambda *a, **k: printed.append(" ".join(str(x) for x in a)))
+    check.main()
+    warning_lines = [l for l in printed if "Could not determine PR number" in l]
+    assert warning_lines, "expected warning about missing PR number when stacked_note is active"


### PR DESCRIPTION
## Problems fixed

### 1. Stacked PR fail-closed

When a PR targets a feature branch (not `main` or `stable/*`), the gate fails closed with _"no snapshotted ancestor found"_ — the snapshot workflow never runs on feature branches. Engineers had to add `ci:vuln-gate-override` on every stacked PR.

**Fix:** when `base-ref` has no snapshots and differs from `fallback-base-ref` (default: `main`), retry `latest_snapshotted_ancestor` on the fallback branch. The diff `effective_base...head` covers the stacked branch's changes as well — conservative but avoids a hard block. A notice is posted to the PR comment.

Observed instances: #56242 (`refactor/cluster-module-partitionid`), #56667 (`refactor/rename-iteration-to-loop`).

### 2. Pattern A false positives (ancestor-staleness)

When a dep version is bumped on main (e.g. by Renovate) **after** the effective_base snapshot was taken, that version shows as `added` in the PR diff even if the PR never touched it. If a GHSA is published after the bump, every open PR whose effective base predates the bump fires a false positive.

Observed instance: #56112 (`jackson-databind@2.21.4` blocked on a PR that only touched `zeebe/qa/integration-tests/pom.xml`).

**Fix:** after resolving `effective_base`, compare `effective_base...latest_on_branch` (the most recent snapshot on the base branch) to find dep versions the branch itself added since the snapshot. Any `(name, version, manifest)` triple found in that drift is pre-existing — moved to an informational section in the PR comment, not blocking.

- Manifest-level matching: prevents false negatives when a PR genuinely adds the same dep version to a **new** module.
- Fail-open: if the drift compare API call fails, the filter returns empty — real findings are never silently suppressed.

## Changes

**Commit 1 — stacked PR fallback (`cb87cc9`):**
- `action.yml` — new `fallback-base-ref` input (default: `main`), wired as `FALLBACK_BASE_REF`
- `check.py` — retry `latest_snapshotted_ancestor` on `fallback_ref` when `base_ref` yields nothing; posts stacked-PR note to PR comment
- `test_check.py` — 3 new `main()`-level tests

**Commit 2 — Pattern A filter (`79aa845`):**
- `check.py` — `latest_snapshotted_ancestor` now returns `latest_on_branch` (4-tuple); new `_base_branch_pre_existing()` function; `find_blocking` gains `pre_existing_deps` param and `pre_existing` return bucket; `post_pr_comment` gains `pre_existing` section
- `test_check.py` — 5 new Pattern A tests; all existing tests updated for 4-tuple returns

## Test results

```
50 passed
```

## Relation to other workstreams

| Workstream | Status | Fixes |
|---|---|---|
| D | ✅ merged | Empty-base FP (code-only main commits) |
| E | ✅ merged | Correlator mismatch (mass 620-dep FP wave) |
| stacked | 🟡 this PR (commit 1) | Stacked PR fail-closed |
| F | 🟡 this PR (commit 2) | Pattern A ancestor-staleness FP |
| C | ⬜ not started | Remove `continue-on-error` (make gate blocking) |

After this PR merges, all known systematic FP classes are addressed and Workstream C (blocking mode) can proceed.