### PR TITLE
docs: document fallback-base-ref and ancestor-staleness filter in dependency-vuln-check

### DIFF
--- a/dependency-vuln-check/README.md
+++ b/dependency-vuln-check/README.md
@@ -37,6 +37,7 @@ version shows up as `added` in the diff and is evaluated normally.
     base-ref: ${{ github.event.pull_request.base.ref }}
     snapshot-workflow: maven-dependency-snapshot.yml
     # optional — defaults shown
+    fallback-base-ref: main
     max-snapshot-lookback: "30"
     override-label: ci:vuln-gate-override
     config-file: .github/dependency-review-config.json
@@ -52,6 +53,7 @@ version shows up as `added` in the diff and is evaluated normally.
 | `base-sha` | yes | — | Base commit SHA of the PR |
 | `head-sha` | yes | — | Head commit SHA of the PR |
 | `base-ref` | yes | — | Base **branch** of the PR (e.g. `main`, `stable/8.8`). Used to find the nearest snapshotted ancestor on the correct branch |
+| `fallback-base-ref` | no | `main` | Branch to fall back to when `base-ref` has no dependency snapshots (e.g. stacked PRs targeting a feature branch). The gate searches this branch for the nearest snapshotted ancestor of `base-sha` instead of failing closed, and posts a notice to the PR comment |
 | `snapshot-workflow` | yes | — | Filename of the workflow that submits the base snapshot (e.g. `maven-dependency-snapshot.yml`). Its successful push-event runs are scanned to resolve the effective base |
 | `max-snapshot-lookback` | no | `30` | How many recent successful snapshot runs to scan when resolving the effective base |
 | `override-label` | no | `ci:vuln-gate-override` | PR label that bypasses the gate **only** when it cannot verify the PR (outage / no-ancestor). Never bypasses a real finding |
@@ -97,12 +99,27 @@ The gate **fails closed** when it cannot verify a PR:
 |-----------|--------|
 | GitHub API error, transient | retried (3 attempts, exponential backoff) |
 | API error survives retries | **fail closed** (block), reason named in the log |
-| No snapshotted ancestor found within `max-snapshot-lookback` | **fail closed** (block) |
+| No snapshotted ancestor on `base-ref`; `base-ref` differs from `fallback-base-ref` | retry on `fallback-base-ref`; notice posted to PR comment |
+| No snapshotted ancestor on either branch within `max-snapshot-lookback` | **fail closed** (block) |
 | API works, real vulnerable dependency added | block (normal finding) |
 | API works, no vulnerable dependency added | pass |
 
 Every run writes a summary trail (resolved base, runs scanned, verdict). Failure reasons are
 named explicitly in the log (rate-limit vs 5xx vs timeout vs permissions vs not-found).
+
+### Ancestor-staleness filter (Pattern A false positive prevention)
+
+After resolving `effective_base`, the gate compares `effective_base...latest_on_base_branch`
+to find dependency versions that were bumped on the base branch *after* the snapshot was taken
+(e.g. by a Renovate commit that landed on `main` while the PR was open). Any `(name, version,
+manifest)` triple present in that drift is treated as pre-existing and moved to the
+informational section of the PR comment rather than blocking. This prevents false positives
+where a PR that never touched a given dependency is blamed for a vulnerability introduced by
+an unrelated bump on `main`.
+
+The filter is manifest-level: if the same dep version is added to a *new* manifest by the PR,
+it is still evaluated normally. Fail-open: if the drift comparison API call fails, the filter
+returns empty and no real findings are silently suppressed.
 
 ### Override label (for sustained outages)
 


### PR DESCRIPTION
## What

Documents two behaviours introduced in #739 that were missing from the README.

### Changes

**1. `fallback-base-ref` input**

Added to the inputs table and the usage example. This input was shipped in #739 but never documented.

**2. Fail-closed table — stacked PR fallback**

The previous table said "no snapshotted ancestor → fail closed", which is no longer accurate. When `base-ref` has no snapshots and differs from `fallback-base-ref`, the gate retries on the fallback branch before failing closed. Updated the row to reflect this.

**3. Ancestor-staleness filter (Pattern A)**

New subsection under "Base-snapshot resolution & fail-closed contract" explaining the `effective_base...latest_on_base_branch` drift filter: dep versions bumped on the base branch after the snapshot was taken are moved to informational rather than blocking, preventing false positives on unrelated Renovate bumps.

## Related

- #739 — the PR that introduced these behaviours