### PR TITLE
fix: key pre-existing dep filter on base-sha, not latest snapshot

### DIFF
--- a/dependency-vuln-check/README.md
+++ b/dependency-vuln-check/README.md
@@ -37,6 +37,7 @@ version shows up as `added` in the diff and is evaluated normally.
     base-ref: ${{ github.event.pull_request.base.ref }}
     snapshot-workflow: maven-dependency-snapshot.yml
     # optional — defaults shown
+    fallback-base-ref: main
     max-snapshot-lookback: "30"
     override-label: ci:vuln-gate-override
     config-file: .github/dependency-review-config.json
@@ -52,6 +53,7 @@ version shows up as `added` in the diff and is evaluated normally.
 | `base-sha` | yes | — | Base commit SHA of the PR |
 | `head-sha` | yes | — | Head commit SHA of the PR |
 | `base-ref` | yes | — | Base **branch** of the PR (e.g. `main`, `stable/8.8`). Used to find the nearest snapshotted ancestor on the correct branch |
+| `fallback-base-ref` | no | `main` | Branch to fall back to when `base-ref` has no dependency snapshots (e.g. stacked PRs targeting a feature branch). The gate searches this branch for the nearest snapshotted ancestor of `base-sha` instead of failing closed, and posts a notice to the PR comment |
 | `snapshot-workflow` | yes | — | Filename of the workflow that submits the base snapshot (e.g. `maven-dependency-snapshot.yml`). Its successful push-event runs are scanned to resolve the effective base |
 | `max-snapshot-lookback` | no | `30` | How many recent successful snapshot runs to scan when resolving the effective base |
 | `override-label` | no | `ci:vuln-gate-override` | PR label that bypasses the gate **only** when it cannot verify the PR (outage / no-ancestor). Never bypasses a real finding |
@@ -97,12 +99,53 @@ The gate **fails closed** when it cannot verify a PR:
 |-----------|--------|
 | GitHub API error, transient | retried (3 attempts, exponential backoff) |
 | API error survives retries | **fail closed** (block), reason named in the log |
-| No snapshotted ancestor found within `max-snapshot-lookback` | **fail closed** (block) |
+| No snapshotted ancestor on `base-ref`; `base-ref` differs from `fallback-base-ref` | retry on `fallback-base-ref`; notice posted to PR comment |
+| No snapshotted ancestor on either branch within `max-snapshot-lookback` | **fail closed** (block) |
 | API works, real vulnerable dependency added | block (normal finding) |
 | API works, no vulnerable dependency added | pass |
 
 Every run writes a summary trail (resolved base, runs scanned, verdict). Failure reasons are
 named explicitly in the log (rate-limit vs 5xx vs timeout vs permissions vs not-found).
+
+### Ancestor-staleness filter (Pattern A false-positive prevention)
+
+The head diff is `effective_base...head`, but `effective_base` is only the nearest
+*snapshotted* ancestor — it can lag behind what the base branch actually contains by the
+time the PR runs. When the base branch adds a dependency version **after** that snapshot
+(e.g. a Renovate bump lands on `main` while the PR is open), that version shows up as
+`added` in the PR diff even though the PR never touched it — a false positive.
+
+To suppress this, after resolving `effective_base` the gate computes the set of
+`(name, version, manifest)` triples the base branch itself introduced since
+`effective_base`, and moves any matching finding to an informational section of the PR
+comment instead of blocking. The drift is computed by diffing `effective_base` against
+**two** reference points and unioning the `added` triples:
+
+| Reference | Surfaces drift in |
+|-----------|-------------------|
+| Latest **snapshotted** commit on the base branch | Maven (submitted-snapshot ecosystems) |
+| `base-sha` — the PR's raw base tip | Natively-detected ecosystems (Go modules, npm, …) |
+
+Both are required because the dependency graph mixes two data sources with different
+coverage. **Maven** deps exist in the graph *only at snapshotted commits*, so the latest
+snapshot commit is the only reference that surfaces Maven base-branch drift. **Natively
+detected** ecosystems (Go, npm) are parsed from the file tree at any commit but never
+trigger the Maven snapshot workflow — so the latest snapshot commit can be stuck at
+`effective_base` even after such a dep was added, collapsing that drift window to nothing.
+`base-sha` reflects the true branch tip regardless of ecosystem and recovers it. Neither
+reference alone covers all ecosystems; the union covers both.
+
+Properties:
+
+- **Manifest-level matching** — a triple is only filtered where the base branch already has
+  it. If the PR adds the same `(name, version)` to a **new** manifest, it still blocks.
+- **Per-reference fail-open** — if one drift compare API call fails, only that reference is
+  skipped; the other still applies. A real finding is never suppressed by an API failure.
+- **Per-dep advisory coverage** — when a dep triple is pre-existing, all of its advisories
+  are suppressed (the PR did not introduce the version, so it owns none of them).
+- **Known limitation — concurrent bump**: if the PR and the base branch independently add
+  the *same* `(name, version, manifest)`, the filter cannot tell them apart and suppresses
+  the PR's finding. Inherent to triple-level matching without PR-authorship data.
 
 ### Override label (for sustained outages)
 

--- a/dependency-vuln-check/README.md
+++ b/dependency-vuln-check/README.md
@@ -107,19 +107,25 @@ The gate **fails closed** when it cannot verify a PR:
 Every run writes a summary trail (resolved base, runs scanned, verdict). Failure reasons are
 named explicitly in the log (rate-limit vs 5xx vs timeout vs permissions vs not-found).
 
-### Ancestor-staleness filter (Pattern A false-positive prevention)
+### Ignoring dependencies the base branch itself added
 
-The head diff is `effective_base...head`, but `effective_base` is only the nearest
-*snapshotted* ancestor — it can lag behind what the base branch actually contains by the
-time the PR runs. When the base branch adds a dependency version **after** that snapshot
-(e.g. a Renovate bump lands on `main` while the PR is open), that version shows up as
-`added` in the PR diff even though the PR never touched it — a false positive.
+**What this prevents:** a PR being blocked for a vulnerable dependency it never touched,
+because the base branch (e.g. `main`) added that dependency after the gate's reference point
+was taken.
 
-To suppress this, after resolving `effective_base` the gate computes the set of
-`(name, version, manifest)` triples the base branch itself introduced since
-`effective_base`, and moves any matching finding to an informational section of the PR
-comment instead of blocking. The drift is computed by diffing `effective_base` against
-**two** reference points and unioning the `added` triples:
+**Why it happens:** the gate diffs the PR against `effective_base` — the nearest *snapshotted*
+ancestor, not the live tip of the base branch. Between that snapshot and the PR running, the
+base branch keeps moving: a Renovate bump (or any merge) can add a dependency version on
+`main` while the PR is open. Because the PR sits on top of that newer `main`, the dependency
+appears as `added` when compared to the older `effective_base` — so the gate would blame the
+PR for something `main` introduced. Example: `golang.org/x/crypto@0.51.0` landing on `main`
+via an unrelated bump, then blocking three PRs that only changed Java/JS files.
+
+**How it's fixed:** before deciding what to block, the gate works out which
+`(name, version, manifest)` dependencies the *base branch itself* added since `effective_base`,
+and moves any matching finding to an informational section of the PR comment instead of
+blocking. It works this out by comparing `effective_base` against **two** reference points and
+combining (union) the dependencies each reports as `added`:
 
 | Reference | Surfaces drift in |
 |-----------|-------------------|

--- a/dependency-vuln-check/README.md
+++ b/dependency-vuln-check/README.md
@@ -141,6 +141,12 @@ trigger the Maven snapshot workflow — so the latest snapshot commit can be stu
 `base-sha` reflects the true branch tip regardless of ecosystem and recovers it. Neither
 reference alone covers all ecosystems; the union covers both.
 
+On the **stacked-PR fallback** path (`base-ref` had no snapshots, so the base was resolved on
+`fallback-base-ref`), `base-sha` points at the *feature* branch — a different branch than the
+resolved base — so it is **not** used as a reference; only the snapshotted reference applies.
+Diffing against the feature-branch tip would otherwise suppress dependencies the parent branch
+introduced, which the stacked PR should still be gated on.
+
 Properties:
 
 - **Manifest-level matching** — a triple is only filtered where the base branch already has

--- a/dependency-vuln-check/check.py
+++ b/dependency-vuln-check/check.py
@@ -206,14 +206,15 @@ def latest_snapshotted_ancestor(
     Returns (effective_base_sha, run_id, scanned_count, latest_on_branch); the first
     three are (None, None, scanned) if no ancestor is found within the window.
     `latest_on_branch` is the head_sha of the most recent successful run on
-    `base_ref` (the very first run examined), regardless of ancestry — retained as
-    informational context (the latest *snapshotted* tip). NOTE: the pre-existing dep
-    filter no longer keys on this value; it uses the PR's base-sha instead, precisely
-    because this is the latest *snapshotted* commit rather than the actual branch tip.
-    When a push is path-filtered (e.g. a Go-only change that never triggers the Maven
-    snapshot workflow) this stays behind the branch tip, so keying the filter on it
-    made base-branch drift in natively-detected ecosystems invisible and produced
-    false-positive blocks. See `_base_branch_pre_existing`.
+    `base_ref` (the very first run examined), regardless of ancestry — the latest
+    *snapshotted* tip of the branch. The pre-existing dep filter diffs against this
+    (to surface Maven base-branch drift, which is only visible at snapshotted
+    commits) unioned with the PR's base-sha (to surface natively-detected
+    ecosystems like Go/npm at the true branch tip). NOTE: because this is the latest
+    *snapshotted* commit rather than the actual branch tip, a path-filtered push
+    (e.g. a Go-only change that never triggers the Maven snapshot workflow) leaves it
+    behind the branch tip — which is exactly why the filter also needs base-sha. See
+    `_base_branch_pre_existing`.
     Raises ApiError on API failure so the caller can fail closed.
 
     `lookback` is honored even beyond the API's 100-per-page cap by following
@@ -250,29 +251,36 @@ def latest_snapshotted_ancestor(
 
 
 def _base_branch_pre_existing(
-    repository: str, effective_base: str, base_tip: str | None, token: str
+    repository: str, effective_base: str, snapshot_tip: str | None,
+    base_tip: str | None, token: str,
 ) -> set:
     """Return (name, version, manifest) triples the base branch added since effective_base.
 
-    Compares effective_base...base_tip via the Dependency Review API to find dep
-    versions the base branch itself introduced after effective_base. `base_tip` is
-    the PR's actual base commit (base-sha) — the tip of the base branch the PR is
-    measured against, NOT the latest snapshot commit. Any dep at (name, version,
-    manifest) that appears as "added" in this drift compare was already on the base
-    branch before the PR was opened — the PR did not introduce it.
+    Compares effective_base against two reference points via the Dependency Review
+    API and unions the "added" triples from both. Any dep at (name, version,
+    manifest) that appears as "added" in either drift compare was already on the
+    base branch before the PR was opened — the PR did not introduce it.
 
     This suppresses Pattern A FPs: when a dep version is bumped on main (e.g. by
     Renovate) AFTER the effective_base snapshot was taken, that version shows as
-    "added" in the PR compare even though the PR never touched it. The drift compare
-    reveals that main itself added that (name, version, manifest) — so it is
-    pre-existing, not PR-introduced.
+    "added" in the PR's effective_base...head compare even though the PR never
+    touched it. The drift compare reveals that main itself added that
+    (name, version, manifest) — so it is pre-existing, not PR-introduced.
 
-    Keying on base_tip (base-sha) rather than the latest snapshot commit is what
-    makes this work for natively-detected ecosystems (Go, npm, …). Those never
-    trigger the Maven snapshot workflow, so the latest snapshot commit can equal
-    effective_base even after the branch added such a dep — collapsing the drift
-    window to nothing and letting the FP through. base-sha always reflects the true
-    branch tip regardless of which ecosystem changed.
+    Two reference points are required because the dependency graph mixes two data
+    sources with different coverage:
+    - `snapshot_tip` — the latest *snapshotted* commit on the base branch (from
+      `latest_snapshotted_ancestor`). Maven deps exist in the graph only at commits
+      where a snapshot was submitted, so a snapshotted tip is the only reference
+      that surfaces Maven base-branch drift.
+    - `base_tip` — the PR's raw base-sha (the true branch tip). Natively-detected
+      ecosystems (Go modules, npm, …) are parsed from the file tree at any commit,
+      but they never trigger the Maven snapshot workflow — so `snapshot_tip` can be
+      stuck at effective_base even after such a dep was added on the branch,
+      collapsing that drift window to nothing. base-sha reflects the true tip
+      regardless of which ecosystem changed and recovers the native-ecosystem drift.
+    Unioning both covers Maven (via snapshot_tip) and native ecosystems (via
+    base_tip); neither alone is sufficient.
 
     Known limitation — concurrent-bump false negative: if a PR independently
     introduces the same (name, version, manifest) that the base branch also added
@@ -285,31 +293,36 @@ def _base_branch_pre_existing(
     is intentional — the PR did not introduce the dep version, so it is not
     responsible for any of its advisories regardless of when they were discovered.
 
-    Returns an empty set when:
-    - effective_base == base_tip (base is itself snapshotted — no drift to filter)
-    - base_tip is falsy (nothing to compare)
-    - the drift compare API call fails (fail-open: FPs may slip through, but real
-      vulns are never suppressed)
+    Per-reference fail-open: if a drift compare API call fails, that reference is
+    skipped (its FPs may slip through) but the other reference's results still
+    apply. Real vulns are never suppressed by a failure. A reference equal to
+    effective_base or falsy is skipped (no drift to compute); duplicate references
+    are compared once.
     """
-    if not base_tip or effective_base == base_tip:
-        return set()
-    try:
-        drift = _api_get(
-            f"{_GITHUB_API}/repos/{repository}/dependency-graph/compare"
-            f"/{effective_base}...{base_tip}",
-            token,
-        )
-        return {
+    result: set = set()
+    seen: set = set()
+    for tip in (snapshot_tip, base_tip):
+        if not tip or tip == effective_base or tip in seen:
+            continue
+        seen.add(tip)
+        try:
+            drift = _api_get(
+                f"{_GITHUB_API}/repos/{repository}/dependency-graph/compare"
+                f"/{effective_base}...{tip}",
+                token,
+            )
+        except ApiError as e:
+            print(
+                f"::warning::Could not fetch base-branch drift compare "
+                f"({effective_base}...{tip}): {e.reason} — this reference skipped"
+            )
+            continue
+        result |= {
             (dep.get("name", ""), dep.get("version", ""), dep.get("manifest", ""))
             for dep in drift
             if dep.get("change_type") == "added"
         }
-    except ApiError as e:
-        print(
-            f"::warning::Could not fetch base-branch drift compare ({e.reason})"
-            " — pre-existing dep filter disabled for this run"
-        )
-        return set()
+    return result
 
 
 def has_override_label(repository: str, pr_number, token: str, label: str) -> bool:
@@ -746,14 +759,17 @@ def main() -> None:
         return
 
     # ── Pre-existing dep filter: suppress Pattern A FPs (Workstream F) ──
-    # Compare effective_base...base_sha (the PR's actual base tip) to find deps the
-    # base branch added after our snapshot — those are pre-existing on the branch,
-    # not PR-introduced. We use base_sha rather than the latest *snapshot* commit
-    # (latest_on_branch) so that natively-detected ecosystems (Go, npm, …) — which
-    # never trigger the Maven snapshot workflow — are still compared against the true
-    # branch tip. Keying on the latest snapshot left those ecosystems' base-branch
-    # drift invisible and produced false-positive blocks on unrelated PRs.
-    pre_existing_deps = _base_branch_pre_existing(repository, effective_base, base_sha, token)
+    # Find deps the base branch itself added after our snapshot — those are
+    # pre-existing on the branch, not PR-introduced. We diff effective_base against
+    # BOTH the latest snapshot commit (latest_on_branch — the only reference that
+    # surfaces Maven drift, since Maven deps exist only at snapshotted commits) AND
+    # base_sha (the true branch tip — recovers natively-detected ecosystems like Go
+    # and npm, which never trigger the Maven snapshot so latest_on_branch can be
+    # stuck at effective_base). Unioning both is required; neither alone covers all
+    # ecosystems.
+    pre_existing_deps = _base_branch_pre_existing(
+        repository, effective_base, latest_on_branch, base_sha, token
+    )
     if pre_existing_deps:
         print(f"::notice::Pre-existing dep filter: {len(pre_existing_deps)} (name, version, manifest) triple(s) found on base branch since effective_base — will not block")
 

--- a/dependency-vuln-check/check.py
+++ b/dependency-vuln-check/check.py
@@ -206,12 +206,14 @@ def latest_snapshotted_ancestor(
     Returns (effective_base_sha, run_id, scanned_count, latest_on_branch); the first
     three are (None, None, scanned) if no ancestor is found within the window.
     `latest_on_branch` is the head_sha of the most recent successful run on
-    `base_ref` (the very first run examined), regardless of ancestry — used by the
-    caller as the "current tip" of the branch for the pre-existing dep filter.
-    NOTE: this is the latest *snapshotted* commit, not the actual branch HEAD. If
-    the most recent push was path-filtered (e.g. docs-only) and no snapshot was
-    submitted, deps merged in that gap are invisible to the pre-existing filter and
-    may surface as false-positive blocks on unrelated PRs.
+    `base_ref` (the very first run examined), regardless of ancestry — retained as
+    informational context (the latest *snapshotted* tip). NOTE: the pre-existing dep
+    filter no longer keys on this value; it uses the PR's base-sha instead, precisely
+    because this is the latest *snapshotted* commit rather than the actual branch tip.
+    When a push is path-filtered (e.g. a Go-only change that never triggers the Maven
+    snapshot workflow) this stays behind the branch tip, so keying the filter on it
+    made base-branch drift in natively-detected ecosystems invisible and produced
+    false-positive blocks. See `_base_branch_pre_existing`.
     Raises ApiError on API failure so the caller can fail closed.
 
     `lookback` is honored even beyond the API's 100-per-page cap by following
@@ -248,20 +250,29 @@ def latest_snapshotted_ancestor(
 
 
 def _base_branch_pre_existing(
-    repository: str, effective_base: str, latest_on_branch: str | None, token: str
+    repository: str, effective_base: str, base_tip: str | None, token: str
 ) -> set:
     """Return (name, version, manifest) triples the base branch added since effective_base.
 
-    Compares effective_base...latest_on_branch via the Dependency Review API to find
-    dep versions the base branch itself introduced after effective_base. Any dep at
-    (name, version, manifest) that appears as "added" in this drift compare was
-    already on the base branch before the PR was opened — the PR did not introduce it.
+    Compares effective_base...base_tip via the Dependency Review API to find dep
+    versions the base branch itself introduced after effective_base. `base_tip` is
+    the PR's actual base commit (base-sha) — the tip of the base branch the PR is
+    measured against, NOT the latest snapshot commit. Any dep at (name, version,
+    manifest) that appears as "added" in this drift compare was already on the base
+    branch before the PR was opened — the PR did not introduce it.
 
     This suppresses Pattern A FPs: when a dep version is bumped on main (e.g. by
     Renovate) AFTER the effective_base snapshot was taken, that version shows as
     "added" in the PR compare even though the PR never touched it. The drift compare
     reveals that main itself added that (name, version, manifest) — so it is
     pre-existing, not PR-introduced.
+
+    Keying on base_tip (base-sha) rather than the latest snapshot commit is what
+    makes this work for natively-detected ecosystems (Go, npm, …). Those never
+    trigger the Maven snapshot workflow, so the latest snapshot commit can equal
+    effective_base even after the branch added such a dep — collapsing the drift
+    window to nothing and letting the FP through. base-sha always reflects the true
+    branch tip regardless of which ecosystem changed.
 
     Known limitation — concurrent-bump false negative: if a PR independently
     introduces the same (name, version, manifest) that the base branch also added
@@ -275,17 +286,17 @@ def _base_branch_pre_existing(
     responsible for any of its advisories regardless of when they were discovered.
 
     Returns an empty set when:
-    - effective_base == latest_on_branch (no drift — nothing to filter)
-    - latest_on_branch is None (no snapshot found on branch; nothing to compare)
+    - effective_base == base_tip (base is itself snapshotted — no drift to filter)
+    - base_tip is falsy (nothing to compare)
     - the drift compare API call fails (fail-open: FPs may slip through, but real
       vulns are never suppressed)
     """
-    if not latest_on_branch or effective_base == latest_on_branch:
+    if not base_tip or effective_base == base_tip:
         return set()
     try:
         drift = _api_get(
             f"{_GITHUB_API}/repos/{repository}/dependency-graph/compare"
-            f"/{effective_base}...{latest_on_branch}",
+            f"/{effective_base}...{base_tip}",
             token,
         )
         return {
@@ -735,9 +746,14 @@ def main() -> None:
         return
 
     # ── Pre-existing dep filter: suppress Pattern A FPs (Workstream F) ──
-    # Compare effective_base...latest_on_branch to find deps the base branch added
-    # after our snapshot — those are pre-existing on the branch, not PR-introduced.
-    pre_existing_deps = _base_branch_pre_existing(repository, effective_base, latest_on_branch, token)
+    # Compare effective_base...base_sha (the PR's actual base tip) to find deps the
+    # base branch added after our snapshot — those are pre-existing on the branch,
+    # not PR-introduced. We use base_sha rather than the latest *snapshot* commit
+    # (latest_on_branch) so that natively-detected ecosystems (Go, npm, …) — which
+    # never trigger the Maven snapshot workflow — are still compared against the true
+    # branch tip. Keying on the latest snapshot left those ecosystems' base-branch
+    # drift invisible and produced false-positive blocks on unrelated PRs.
+    pre_existing_deps = _base_branch_pre_existing(repository, effective_base, base_sha, token)
     if pre_existing_deps:
         print(f"::notice::Pre-existing dep filter: {len(pre_existing_deps)} (name, version, manifest) triple(s) found on base branch since effective_base — will not block")
 

--- a/dependency-vuln-check/check.py
+++ b/dependency-vuln-check/check.py
@@ -250,6 +250,16 @@ def latest_snapshotted_ancestor(
     return None, None, scanned, latest_on_branch
 
 
+def _dep_triple(dep: dict) -> tuple:
+    """Identity of a dependency for pre-existing matching: (name, version, manifest).
+
+    Shared by the base-branch drift filter and find_blocking so the two always agree
+    on what "the same dependency" means — if they diverge, the pre-existing set stops
+    matching find_blocking's keys and suppression silently breaks.
+    """
+    return (dep.get("name", ""), dep.get("version", ""), dep.get("manifest", ""))
+
+
 def _base_branch_pre_existing(
     repository: str, effective_base: str, snapshot_tip: str | None,
     base_tip: str | None, token: str,
@@ -282,6 +292,14 @@ def _base_branch_pre_existing(
     Unioning both covers Maven (via snapshot_tip) and native ecosystems (via
     base_tip); neither alone is sufficient.
 
+    IMPORTANT — both references must live on the SAME branch as effective_base.
+    `base_tip` is only meaningful when effective_base was resolved on the PR's own
+    base branch. On the stacked-PR fallback path effective_base is resolved on the
+    default branch while base-sha is the (different) feature-branch tip, so diffing
+    effective_base...base-sha would fold the entire feature branch's dependency delta
+    into the pre-existing set and suppress vulns the PR legitimately surfaces. The
+    caller passes base_tip=None in that case.
+
     Known limitation — concurrent-bump false negative: if a PR independently
     introduces the same (name, version, manifest) that the base branch also added
     after effective_base (e.g. Renovate and the PR both pin the same dep version),
@@ -299,12 +317,21 @@ def _base_branch_pre_existing(
     effective_base or falsy is skipped (no drift to compute); duplicate references
     are compared once.
     """
+    # Unique references worth comparing: drop falsy tips and any equal to
+    # effective_base (no drift window), preserving order and de-duplicating.
+    tips = list(dict.fromkeys(
+        tip for tip in (snapshot_tip, base_tip) if tip and tip != effective_base
+    ))
+    if not tips:
+        print(
+            "::notice::Pre-existing dep filter: base is itself snapshotted "
+            "(no drift window between effective_base and either reference) — "
+            "no base-branch filtering applied"
+        )
+        return set()
+
     result: set = set()
-    seen: set = set()
-    for tip in (snapshot_tip, base_tip):
-        if not tip or tip == effective_base or tip in seen:
-            continue
-        seen.add(tip)
+    for tip in tips:
         try:
             drift = _api_get(
                 f"{_GITHUB_API}/repos/{repository}/dependency-graph/compare"
@@ -318,9 +345,7 @@ def _base_branch_pre_existing(
             )
             continue
         result |= {
-            (dep.get("name", ""), dep.get("version", ""), dep.get("manifest", ""))
-            for dep in drift
-            if dep.get("change_type") == "added"
+            _dep_triple(dep) for dep in drift if dep.get("change_type") == "added"
         }
     return result
 
@@ -435,7 +460,7 @@ def find_blocking(
             continue
         scope = (dep.get("scope") or "runtime").lower()
         is_gated = scope in gated_scopes
-        dep_key = (dep.get("name", ""), dep.get("version", ""), dep.get("manifest", ""))
+        dep_key = _dep_triple(dep)
         is_pre_existing = dep_key in pre_existing_deps
         for vuln in dep.get("vulnerabilities") or []:
             ids = _ghsa_ids(vuln)
@@ -758,7 +783,7 @@ def main() -> None:
         )
         return
 
-    # ── Pre-existing dep filter: suppress Pattern A FPs (Workstream F) ──
+    # ── Pre-existing dep filter: suppress base-branch-added deps (Workstream F) ──
     # Find deps the base branch itself added after our snapshot — those are
     # pre-existing on the branch, not PR-introduced. We diff effective_base against
     # BOTH the latest snapshot commit (latest_on_branch — the only reference that
@@ -767,8 +792,17 @@ def main() -> None:
     # and npm, which never trigger the Maven snapshot so latest_on_branch can be
     # stuck at effective_base). Unioning both is required; neither alone covers all
     # ecosystems.
+    #
+    # On the stacked-PR fallback path effective_base + latest_on_branch are resolved
+    # on fallback_ref (main) while base_sha is the *feature* branch tip — a different
+    # branch. Diffing effective_base(main)...base_sha(feature) would fold the whole
+    # feature branch's dependency delta into the pre-existing set and suppress vulns
+    # the stacked PR legitimately surfaces (the parent branch is not independently
+    # gated). So base_sha is only a valid native-ecosystem reference when we did NOT
+    # fall back; otherwise pass None and rely on the snapshot reference alone.
+    native_tip = None if stacked_pr_fallback else base_sha
     pre_existing_deps = _base_branch_pre_existing(
-        repository, effective_base, latest_on_branch, base_sha, token
+        repository, effective_base, latest_on_branch, native_tip, token
     )
     if pre_existing_deps:
         print(f"::notice::Pre-existing dep filter: {len(pre_existing_deps)} (name, version, manifest) triple(s) found on base branch since effective_base — will not block")

--- a/dependency-vuln-check/test_check.py
+++ b/dependency-vuln-check/test_check.py
@@ -590,6 +590,53 @@ def test_main_filter_keys_on_both_snapshot_and_base_sha(monkeypatch):
     assert captured["base_tip"] == "B"          # base_sha (native side)
 
 
+def test_stacked_fallback_does_not_pass_base_sha_as_native_tip(monkeypatch):
+    # Regression: on the stacked-PR fallback, base_sha is the *feature* branch tip
+    # while effective_base + latest_on_branch resolve on main. Passing base_sha as
+    # base_tip would diff effective_base(main)...tip_of_feature and fold the whole
+    # feature branch's dep delta into pre_existing — suppressing vulns the stacked PR
+    # legitimately surfaces. main() must pass base_tip=None on the fallback path.
+    _set_main_env(monkeypatch)  # BASE_SHA = "B" (the feature branch tip)
+    monkeypatch.setenv("BASE_REF", "refactor/some-feature")
+    monkeypatch.setenv("FALLBACK_BASE_REF", "main")
+
+    def fake_ancestor(repo, ref, sha, wf, tok, lookback):
+        if ref == "refactor/some-feature":
+            return None, None, 0, None          # feature branch has no snapshots
+        return "eff-main", 42, 1, "main-tip"    # fallback resolves on main
+
+    monkeypatch.setattr(check, "latest_snapshotted_ancestor", fake_ancestor)
+    monkeypatch.setattr(check, "_lookup_patch", lambda *a, **k: None)
+    monkeypatch.setattr(check, "_pr_number", lambda: None)
+    captured = {}
+
+    def fake_filter(repository, effective_base, snapshot_tip, base_tip, token):
+        captured["snapshot_tip"] = snapshot_tip
+        captured["base_tip"] = base_tip
+        return set()
+
+    monkeypatch.setattr(check, "_base_branch_pre_existing", fake_filter)
+    monkeypatch.setattr(check, "_api_get", lambda url, tok: [])  # no PR-diff findings
+    check.main()  # must not exit 1
+    assert captured["snapshot_tip"] == "main-tip"  # Maven reference still applied
+    assert captured["base_tip"] is None            # base_sha NOT used on fallback
+
+
+def test_base_branch_pre_existing_no_refs_logs_notice(capsys):
+    # When both references collapse to effective_base, the filter is a no-op — it
+    # must emit a notice so an operator can tell it ran and found nothing.
+    result = check._base_branch_pre_existing("o/r", "eff", "eff", "eff", "tok")
+    assert result == set()
+    assert "no base-branch filtering applied" in capsys.readouterr().out
+
+
+def test_dep_triple_matches_find_blocking_key():
+    # The shared identity helper must produce the (name, version, manifest) triple
+    # both the drift filter and find_blocking key on.
+    dep = {"name": "acme", "version": "1.2.3", "manifest": "pom.xml", "extra": "ignored"}
+    assert check._dep_triple(dep) == ("acme", "1.2.3", "pom.xml")
+
+
 # --- bucket-ordering correctness (fix 3) --------------------------------------
 
 def test_pre_existing_non_gated_scope_wins_over_pre_existing(monkeypatch):

--- a/dependency-vuln-check/test_check.py
+++ b/dependency-vuln-check/test_check.py
@@ -511,6 +511,49 @@ def test_base_branch_pre_existing_api_error_returns_empty(monkeypatch):
     assert result == set()
 
 
+def test_base_branch_pre_existing_compares_against_base_tip(monkeypatch):
+    # The drift compare URL must use base_tip as the head side, not the latest
+    # snapshot commit. Regression guard for the native-ecosystem FP fix.
+    captured = {}
+    monkeypatch.setattr(
+        check, "_api_get",
+        lambda url, tok: captured.update(url=url) or [],
+    )
+    check._base_branch_pre_existing("o/r", "eff-base", "base-tip-sha", "tok")
+    assert "eff-base...base-tip-sha" in captured["url"]
+
+
+def test_main_filter_keys_on_base_sha_not_latest_snapshot(monkeypatch):
+    # Regression: a natively-detected dep (Go) added on the base branch after the
+    # snapshot must still be filtered even when latest_on_branch == effective_base
+    # (a Go-only change never triggers the Maven snapshot). main() must key the
+    # pre-existing filter on base_sha — the true branch tip — not the stale snapshot.
+    _set_main_env(monkeypatch)  # BASE_SHA = "B"
+    # effective_base and latest_on_branch are the SAME stale snapshot commit.
+    monkeypatch.setattr(check, "latest_snapshotted_ancestor", lambda *a, **k: ("eff", 1, 1, "eff"))
+    monkeypatch.setattr(check, "_lookup_patch", lambda *a, **k: None)
+    captured = {}
+
+    def fake_filter(repository, effective_base, base_tip, token):
+        captured["effective_base"] = effective_base
+        captured["base_tip"] = base_tip
+        # main added the Go dep between eff...B → report it as pre-existing.
+        return {("golang.org/x/crypto", "0.51.0", "load-tests/metrics-exporter/go.mod")}
+
+    monkeypatch.setattr(check, "_base_branch_pre_existing", fake_filter)
+    # The PR diff surfaces that same Go dep as "added" (inherited from main),
+    # critical + no fix — would block if the filter used the stale snapshot commit.
+    go_dep = _dep(
+        name="golang.org/x/crypto", version="0.51.0",
+        manifest="load-tests/metrics-exporter/go.mod", severity="critical", fix=None,
+    )
+    monkeypatch.setattr(check, "_api_get", lambda url, tok: [go_dep])
+    monkeypatch.setattr(check, "_pr_number", lambda: None)
+    check.main()  # must NOT exit 1 — the FP is filtered
+    assert captured["base_tip"] == "B"          # keyed on base_sha, not "eff"
+    assert captured["effective_base"] == "eff"
+
+
 # --- bucket-ordering correctness (fix 3) --------------------------------------
 
 def test_pre_existing_non_gated_scope_wins_over_pre_existing(monkeypatch):

--- a/dependency-vuln-check/test_check.py
+++ b/dependency-vuln-check/test_check.py
@@ -475,19 +475,19 @@ def test_pre_existing_different_manifest_still_blocks(monkeypatch):
 
 
 def test_base_branch_pre_existing_no_drift(monkeypatch):
-    # effective_base == latest_on_branch → no drift, returns empty set without API call.
+    # Both references == effective_base → no drift, returns empty set without API call.
     api_called = []
     monkeypatch.setattr(check, "_api_get", lambda url, tok: api_called.append(url) or [])
-    result = check._base_branch_pre_existing("o/r", "sha-abc", "sha-abc", "tok")
+    result = check._base_branch_pre_existing("o/r", "sha-abc", "sha-abc", "sha-abc", "tok")
     assert result == set()
     assert api_called == []
 
 
-def test_base_branch_pre_existing_no_latest(monkeypatch):
-    # latest_on_branch is None (no snapshot on branch) → returns empty set.
+def test_base_branch_pre_existing_no_refs(monkeypatch):
+    # Both references falsy (no snapshot on branch, no base tip) → returns empty set.
     api_called = []
     monkeypatch.setattr(check, "_api_get", lambda url, tok: api_called.append(url) or [])
-    result = check._base_branch_pre_existing("o/r", "sha-abc", None, "tok")
+    result = check._base_branch_pre_existing("o/r", "sha-abc", None, None, "tok")
     assert result == set()
     assert api_called == []
 
@@ -498,51 +498,86 @@ def test_base_branch_pre_existing_returns_added_triples(monkeypatch):
         {"change_type": "removed", "name": "old-dep", "version": "1.0.0", "manifest": "pom.xml"},
     ]
     monkeypatch.setattr(check, "_api_get", lambda url, tok: drift)
-    result = check._base_branch_pre_existing("o/r", "base-sha", "latest-sha", "tok")
+    # Only a snapshot tip given (base_tip None) → single compare, Maven triple surfaced.
+    result = check._base_branch_pre_existing("o/r", "base-sha", "latest-sha", None, "tok")
     assert result == {("jackson-databind", "2.21.4", "clients/java/pom.xml")}
 
 
-def test_base_branch_pre_existing_api_error_returns_empty(monkeypatch):
-    # API error → fail-open, return empty set (don't suppress real findings).
+def test_base_branch_pre_existing_unions_both_references(monkeypatch):
+    # snapshot_tip surfaces the Maven drift; base_tip surfaces the Go drift.
+    # The result must be the UNION of both compares.
+    maven = [{"change_type": "added", "name": "jackson-databind", "version": "2.21.4", "manifest": "clients/java/pom.xml"}]
+    go = [{"change_type": "added", "name": "golang.org/x/crypto", "version": "0.51.0", "manifest": "load-tests/metrics-exporter/go.mod"}]
+    calls = []
+
+    def fake_get(url, tok):
+        calls.append(url)
+        return maven if "snap-tip" in url else go
+
+    monkeypatch.setattr(check, "_api_get", fake_get)
+    result = check._base_branch_pre_existing("o/r", "eff", "snap-tip", "base-tip", "tok")
+    assert result == {
+        ("jackson-databind", "2.21.4", "clients/java/pom.xml"),
+        ("golang.org/x/crypto", "0.51.0", "load-tests/metrics-exporter/go.mod"),
+    }
+    assert any("eff...snap-tip" in u for u in calls)
+    assert any("eff...base-tip" in u for u in calls)
+
+
+def test_base_branch_pre_existing_dedupes_equal_references(monkeypatch):
+    # snapshot_tip == base_tip → compared once, not twice.
+    calls = []
+    monkeypatch.setattr(check, "_api_get", lambda url, tok: calls.append(url) or [])
+    check._base_branch_pre_existing("o/r", "eff", "same-tip", "same-tip", "tok")
+    assert len(calls) == 1
+
+
+def test_base_branch_pre_existing_one_ref_fails_other_still_applies(monkeypatch):
+    # Per-reference fail-open: the snapshot compare errors, the base-tip compare
+    # succeeds → its triples still apply (real vulns never suppressed by a failure,
+    # but a partial failure must not discard the working reference's results).
+    go = [{"change_type": "added", "name": "golang.org/x/crypto", "version": "0.51.0", "manifest": "load-tests/metrics-exporter/go.mod"}]
+
+    def fake_get(url, tok):
+        if "snap-tip" in url:
+            raise check.ApiError("server error", 503, retryable=True)
+        return go
+
+    monkeypatch.setattr(check, "_api_get", fake_get)
+    result = check._base_branch_pre_existing("o/r", "eff", "snap-tip", "base-tip", "tok")
+    assert result == {("golang.org/x/crypto", "0.51.0", "load-tests/metrics-exporter/go.mod")}
+
+
+def test_base_branch_pre_existing_all_refs_fail_returns_empty(monkeypatch):
+    # Every compare fails → fail-open, empty set (don't suppress real findings).
     monkeypatch.setattr(check, "_api_get", lambda url, tok: (_ for _ in ()).throw(
         check.ApiError("server error", 503, retryable=True)
     ))
-    result = check._base_branch_pre_existing("o/r", "base-sha", "latest-sha", "tok")
+    result = check._base_branch_pre_existing("o/r", "eff", "snap-tip", "base-tip", "tok")
     assert result == set()
 
 
-def test_base_branch_pre_existing_compares_against_base_tip(monkeypatch):
-    # The drift compare URL must use base_tip as the head side, not the latest
-    # snapshot commit. Regression guard for the native-ecosystem FP fix.
-    captured = {}
-    monkeypatch.setattr(
-        check, "_api_get",
-        lambda url, tok: captured.update(url=url) or [],
-    )
-    check._base_branch_pre_existing("o/r", "eff-base", "base-tip-sha", "tok")
-    assert "eff-base...base-tip-sha" in captured["url"]
-
-
-def test_main_filter_keys_on_base_sha_not_latest_snapshot(monkeypatch):
+def test_main_filter_keys_on_both_snapshot_and_base_sha(monkeypatch):
     # Regression: a natively-detected dep (Go) added on the base branch after the
     # snapshot must still be filtered even when latest_on_branch == effective_base
-    # (a Go-only change never triggers the Maven snapshot). main() must key the
-    # pre-existing filter on base_sha — the true branch tip — not the stale snapshot.
+    # (a Go-only change never triggers the Maven snapshot). main() must pass BOTH
+    # the snapshot tip and base_sha (the true branch tip) to the pre-existing filter.
     _set_main_env(monkeypatch)  # BASE_SHA = "B"
     # effective_base and latest_on_branch are the SAME stale snapshot commit.
     monkeypatch.setattr(check, "latest_snapshotted_ancestor", lambda *a, **k: ("eff", 1, 1, "eff"))
     monkeypatch.setattr(check, "_lookup_patch", lambda *a, **k: None)
     captured = {}
 
-    def fake_filter(repository, effective_base, base_tip, token):
+    def fake_filter(repository, effective_base, snapshot_tip, base_tip, token):
         captured["effective_base"] = effective_base
+        captured["snapshot_tip"] = snapshot_tip
         captured["base_tip"] = base_tip
         # main added the Go dep between eff...B → report it as pre-existing.
         return {("golang.org/x/crypto", "0.51.0", "load-tests/metrics-exporter/go.mod")}
 
     monkeypatch.setattr(check, "_base_branch_pre_existing", fake_filter)
     # The PR diff surfaces that same Go dep as "added" (inherited from main),
-    # critical + no fix — would block if the filter used the stale snapshot commit.
+    # critical + no fix — would block if the filter missed the true branch tip.
     go_dep = _dep(
         name="golang.org/x/crypto", version="0.51.0",
         manifest="load-tests/metrics-exporter/go.mod", severity="critical", fix=None,
@@ -550,8 +585,9 @@ def test_main_filter_keys_on_base_sha_not_latest_snapshot(monkeypatch):
     monkeypatch.setattr(check, "_api_get", lambda url, tok: [go_dep])
     monkeypatch.setattr(check, "_pr_number", lambda: None)
     check.main()  # must NOT exit 1 — the FP is filtered
-    assert captured["base_tip"] == "B"          # keyed on base_sha, not "eff"
     assert captured["effective_base"] == "eff"
+    assert captured["snapshot_tip"] == "eff"    # latest_on_branch (Maven side)
+    assert captured["base_tip"] == "B"          # base_sha (native side)
 
 
 # --- bucket-ordering correctness (fix 3) --------------------------------------


### PR DESCRIPTION
## Problem

The pre-existing-dependency filter (`_base_branch_pre_existing`, added in #739) compared `effective_base ... latest_snapshot_commit` to find deps the base branch introduced after the snapshot.

Natively-detected ecosystems (Go modules, npm) **never trigger the Maven snapshot workflow** (`maven-dependency-snapshot.yml` is path-filtered to poms). So after such a dep is bumped on `main`, the latest snapshot commit stays equal to `effective_base` — the filter's precondition short-circuits, the drift window collapses to nothing, and the false positive slips through.

### Observed incident (camunda/camunda, 2026-07-08)

`golang.org/x/crypto@0.51.0` (9 advisories, critical/high, no fix) in `load-tests/metrics-exporter/go.mod` falsely blocked **3 Renovate PRs that never touched Go files**:

| PR | Update | Ecosystem |
|----|--------|-----------|
| camunda/camunda#57110 | react-hook-form 7.81.0 | JS |
| camunda/camunda#57054 | langchain4j-bom 1.17.1 | Java |
| camunda/camunda#56937 | jnr-ffi 2.3.0 | Java |

`crypto@0.51.0` was introduced on `main` by an unrelated testcontainers bump **after** the effective-base snapshot — none of the three PRs added it.

## Fix

Diff `effective_base` against **two** reference points and union the `added` triples. The references have complementary coverage:

| Reference | Maven drift | Go/npm drift |
|-----------|:-----------:|:------------:|
| latest snapshot commit (`latest_on_branch`) | ✅ | ❌ (window collapses) |
| `base_sha` (true branch tip) | ❌ (not snapshotted) | ✅ |

Maven deps exist in the dependency graph **only at snapshotted commits**, so the snapshot tip is the only reference that surfaces Maven base-branch drift (the case #739 fixed — e.g. jackson-databind). `base_sha` is usually not a snapshot commit, so Maven deps there show as `removed` and escape the filter — but it reflects the true tip for natively-detected ecosystems. **Neither alone is sufficient; the union covers both.**

- No extra work beyond one more compare — `base_sha` is already resolved in `main()`.
- No coverage loss — genuinely PR-introduced vulns still block (including shipped Go like `c8run`).
- **Per-reference fail-open**: if one compare fails, only that reference is skipped; the other still applies. Real vulns are never suppressed by a failure.

## Tests

`57 passed`. New tests cover: union of both references, dedupe when the two tips are equal, per-reference partial failure, all-references failure (fail-open), and a `main()` regression driving the exact Go false-positive scenario (asserts both the snapshot tip and base_sha are passed).

## Docs

This PR also updates the `dependency-vuln-check` README (folded in from the now-closed #740): documents the `fallback-base-ref` input, the stacked-PR row in the fail-closed contract, and the section **"Ignoring dependencies the base branch itself added"** — the filter that stops a PR being blamed for a dependency `main` introduced — described with the union (latest-snapshot + base-sha) behaviour introduced here.

## Not a revert of #739

All of #739's filter machinery is retained (`_base_branch_pre_existing`, the `pre_existing` bucket, the PR-comment section, the stacked-PR fallback). This only changes *which* reference commits the filter diffs against.

## Related

- #739 — introduced the pre-existing-dependency filter this hardens
- #740 — README docs originally split out; now **closed and folded into this PR** (see Docs above)