### PR TITLE
feat: self-mint app tokens and classify failures in ensure-pr-passes-merge-queue

### DIFF
--- a/ensure-pr-passes-merge-queue/README.md
+++ b/ensure-pr-passes-merge-queue/README.md
@@ -6,8 +6,10 @@ This composite GitHub Action (GHA) is intended for Camunda engineers to monitor 
 
 - Polls PR and merge queue state every 2 minutes.
 - Succeeds when the PR is merged.
-- Fails when the PR is closed, evicted too many times, or timeout is reached.
+- Fails when the PR is closed, evicted too many times, the timeout is reached, or the API keeps failing.
 - Re-enables auto-merge after eviction (unless `dry-run` is `true`).
+- Before reporting any non-merged outcome, rechecks the PR once with a fresh token and reports `merged` if the merge landed in the meantime.
+- When given `app-id` + `private-key`, mints GitHub App installation tokens itself and refreshes them before the 1-hour expiry, so long monitoring windows keep working.
 
 ## Usage
 
@@ -16,7 +18,9 @@ This composite GitHub Action (GHA) is intended for Camunda engineers to monitor 
 | Input | Required | Default | Description |
 |---|---|---|---|
 | `pr-number` | Yes | - | Pull request number to monitor. |
-| `app-token` | Yes | - | GitHub App installation token used for GraphQL queries and re-enabling auto-merge. |
+| `app-id` | No | - | GitHub App ID. Together with `private-key`, enables self-minted, auto-refreshed installation tokens. |
+| `private-key` | No | - | GitHub App private key (PEM). Together with `app-id`, enables self-minted, auto-refreshed installation tokens. |
+| `app-token` | No | - | Pre-minted GitHub App installation token. Expires after 1 hour, so prefer `app-id` + `private-key` for timeouts beyond ~50 minutes. |
 | `repository-owner` | Yes | - | Repository owner, for example `camunda`. |
 | `repository-name` | Yes | - | Repository name, for example `infra-core`. |
 | `timeout-minutes` | No | `180` | Maximum minutes to wait for merge completion. |
@@ -24,11 +28,18 @@ This composite GitHub Action (GHA) is intended for Camunda engineers to monitor 
 | `merge-method` | No | `squash` | Merge method used when re-enabling auto-merge: `squash`, `merge`, `rebase`, or `default` (omit method flag). |
 | `dry-run` | No | `false` | If `true`, does not re-enable auto-merge, only observes. |
 
+Either `app-id` + `private-key` or `app-token` must be provided.
+
 ### Outputs
 
 | Output | Description |
 |---|---|
-| `result` | Final outcome: `merged`, `closed`, `evicted`, or `timeout`. |
+| `result` | Final outcome: `merged`, `closed`, `evicted`, `timeout`, or `api_failure`. Empty when input validation fails before monitoring starts. |
+| `queue-state` | Last observed merge queue entry state (e.g. `AWAITING_CHECKS`, `MERGEABLE`, `NOT_IN_QUEUE`, `UNKNOWN`). |
+| `queue-position` | Last observed merge queue position, or `N/A`. |
+| `merge-state-status` | Last observed PR `mergeStateStatus` (e.g. `CLEAN`, `BLOCKED`, `UNKNOWN`). |
+
+`timeout` means the time budget ran out while the PR was still open (check `queue-state` to see whether it was still progressing); `api_failure` means the GitHub API kept failing (or auto-merge could not be re-enabled) and the monitor lost visibility — the PR itself may still merge.
 
 ### Workflow example
 
@@ -50,7 +61,8 @@ jobs:
         uses: camunda/infra-global-github-actions/ensure-pr-passes-merge-queue@main
         with:
           pr-number: ${{ github.event.pull_request.number }}
-          app-token: ${{ secrets.MERGE_QUEUE_APP_TOKEN }}
+          app-id: ${{ secrets.MERGE_QUEUE_APP_ID }}
+          private-key: ${{ secrets.MERGE_QUEUE_APP_PRIVATE_KEY }}
           repository-owner: ${{ github.repository_owner }}
           repository-name: ${{ github.event.repository.name }}
           timeout-minutes: "180"
@@ -58,10 +70,16 @@ jobs:
           merge-method: "default"
 
       - name: Print result
-        run: echo "Merge queue result: ${{ steps.monitor_mq.outputs.result }}"
+        run: |
+          echo "Merge queue result: ${{ steps.monitor_mq.outputs.result }}"
+          echo "Last queue state: ${{ steps.monitor_mq.outputs.queue-state }} (pos: ${{ steps.monitor_mq.outputs.queue-position }})"
 ```
 
 ## Notes
 
-- Use a GitHub App installation token with at least `Pull requests: Write` permission.
+- Use a GitHub App with at least `Pull requests: Write` permission. GitHub exposes a
+  separate `Merge queues` permission and does not document which one gates the GraphQL
+  `mergeQueueEntry` field this action polls — grant `Merge queues: Read` as well if
+  queue state comes back empty.
 - The GitHub App must be installed on the target repository.
+- With `app-id` + `private-key` there is no need for a separate token-minting step (for example `tibdex/github-app-token` or `actions/create-github-app-token`) in the calling job, and no risk of the 1-hour installation-token expiry killing long monitoring windows.

--- a/ensure-pr-passes-merge-queue/action.yml
+++ b/ensure-pr-passes-merge-queue/action.yml
@@ -11,8 +11,20 @@ inputs:
     description: 'The pull request number to monitor'
     required: true
   app-token:
-    description: 'GitHub App installation token used for GraphQL queries and re-enabling auto-merge'
-    required: true
+    description: >
+      Pre-minted GitHub App installation token used for GraphQL queries and re-enabling
+      auto-merge. Installation tokens expire after 1 hour, so prefer app-id + private-key
+      for timeouts beyond ~50 minutes.
+    required: false
+    default: ''
+  app-id:
+    description: 'GitHub App ID; with private-key, the action mints and refreshes installation tokens itself'
+    required: false
+    default: ''
+  private-key:
+    description: 'GitHub App private key (PEM); with app-id, the action mints and refreshes installation tokens itself'
+    required: false
+    default: ''
   repository-owner:
     description: 'Repository owner (e.g. camunda)'
     required: true
@@ -38,8 +50,19 @@ inputs:
 
 outputs:
   result:
-    description: 'The outcome: "merged", "closed", "evicted", or "timeout"'
+    description: >
+      The outcome: "merged", "closed", "evicted", "timeout", or "api_failure".
+      Empty when input validation fails before monitoring starts.
     value: ${{ steps.monitor.outputs.result }}
+  queue-state:
+    description: 'Last observed merge queue entry state (e.g. AWAITING_CHECKS, MERGEABLE, NOT_IN_QUEUE, UNKNOWN)'
+    value: ${{ steps.monitor.outputs.queue-state }}
+  queue-position:
+    description: 'Last observed merge queue position, or N/A'
+    value: ${{ steps.monitor.outputs.queue-position }}
+  merge-state-status:
+    description: 'Last observed PR mergeStateStatus (e.g. CLEAN, BLOCKED, UNKNOWN)'
+    value: ${{ steps.monitor.outputs.merge-state-status }}
 
 runs:
   using: composite
@@ -49,6 +72,8 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.app-token }}
+        GH_APP_ID: ${{ inputs.app-id }}
+        GH_APP_PRIVATE_KEY: ${{ inputs.private-key }}
         PR_NUMBER: ${{ inputs.pr-number }}
         TIMEOUT_MINUTES: ${{ inputs.timeout-minutes }}
         MAX_EVICTIONS: ${{ inputs.max-evictions }}

--- a/ensure-pr-passes-merge-queue/monitor-merge-queue.sh
+++ b/ensure-pr-passes-merge-queue/monitor-merge-queue.sh
@@ -2,6 +2,22 @@
 
 set -euo pipefail
 
+# Authentication modes:
+# - GH_APP_ID + GH_APP_PRIVATE_KEY set: the script mints GitHub App installation
+#   tokens itself and re-mints them before they hit the 1-hour expiry, so runs
+#   longer than an hour keep working.
+# - GH_TOKEN set (pre-minted installation token): used as-is; such tokens expire
+#   after 1 hour, so timeouts beyond ~50 minutes are unreliable in this mode.
+if [ -n "${GH_APP_ID:-}" ] || [ -n "${GH_APP_PRIVATE_KEY:-}" ]; then
+  if [ -z "${GH_APP_ID:-}" ] || [ -z "${GH_APP_PRIVATE_KEY:-}" ]; then
+    echo "Both app-id and private-key must be provided to enable self-minted tokens."
+    exit 1
+  fi
+elif [ -z "${GH_TOKEN:-}" ]; then
+  echo "Either app-token or the app-id + private-key pair must be provided."
+  exit 1
+fi
+
 if [ "$DRY_RUN" = "true" ]; then
   echo "[DRY RUN] Monitoring merge queue status (read-only) for PR #${PR_NUMBER}"
 else
@@ -15,6 +31,12 @@ PREVIOUS_QUEUE_STATE=""
 API_FAILURE_COUNT=0
 MAX_CONSECUTIVE_API_FAILURES=5 # 5 failures x 2 minutes = 10 minutes
 REPOSITORY="${REPO_OWNER}/${REPO_NAME}"
+API_URL="${GITHUB_API_URL:-https://api.github.com}"
+TOKEN_MINTED_AT=0
+TOKEN_REFRESH_SECONDS=3000 # Installation tokens expire after 60 minutes; re-mint at 50.
+LAST_QUEUE_STATE=""
+LAST_QUEUE_POSITION=""
+LAST_MERGE_STATUS=""
 MERGE_ARGS=(--auto)
 
 case "$MERGE_METHOD" in
@@ -35,13 +57,65 @@ case "$MERGE_METHOD" in
     ;;
 esac
 
-echo "Timeout configured: ${TIMEOUT_MINUTES} minutes (${MAX_ATTEMPTS} attempts)"
+base64url() {
+  openssl base64 -A | tr '+/' '-_' | tr -d '='
+}
 
-while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
-  # Query PR and merge queue status via GraphQL.
-  set +e
+mint_installation_token() {
+  local now header payload signature jwt installation_id token
+  now=$(date +%s)
+  header=$(printf '{"alg":"RS256","typ":"JWT"}' | base64url) || return 1
+  payload=$(printf '{"iat":%s,"exp":%s,"iss":"%s"}' "$((now - 60))" "$((now + 540))" "$GH_APP_ID" | base64url) || return 1
+  signature=$(printf '%s.%s' "$header" "$payload" \
+    | openssl dgst -sha256 -sign <(printf '%s' "$GH_APP_PRIVATE_KEY") -binary | base64url) || return 1
+  jwt="${header}.${payload}.${signature}"
+  echo "::add-mask::${jwt}"
+
+  installation_id=$(curl -sSf \
+    -H "Authorization: Bearer ${jwt}" \
+    -H "Accept: application/vnd.github+json" \
+    "${API_URL}/repos/${REPOSITORY}/installation" | jq -r '.id // empty') || return 1
+  if [ -z "$installation_id" ]; then
+    echo "Could not resolve the GitHub App installation for ${REPOSITORY}."
+    return 1
+  fi
+
+  token=$(curl -sSf -X POST \
+    -H "Authorization: Bearer ${jwt}" \
+    -H "Accept: application/vnd.github+json" \
+    "${API_URL}/app/installations/${installation_id}/access_tokens" | jq -r '.token // empty') || return 1
+  if [ -z "$token" ]; then
+    echo "Could not mint an installation token for installation ${installation_id}."
+    return 1
+  fi
+
+  echo "::add-mask::${token}"
+  export GH_TOKEN="$token"
+  TOKEN_MINTED_AT=$now
+  echo "Minted a fresh GitHub App installation token (installation ${installation_id})"
+}
+
+ensure_fresh_token() {
+  [ -n "${GH_APP_ID:-}" ] || return 0
+  local age
+  age=$(($(date +%s) - TOKEN_MINTED_AT))
+  if [ "$age" -ge "$TOKEN_REFRESH_SECONDS" ]; then
+    mint_installation_token || echo "Token mint failed; continuing with the current token."
+  fi
+}
+
+write_outputs() {
+  {
+    echo "result=$1"
+    echo "queue-state=${LAST_QUEUE_STATE:-UNKNOWN}"
+    echo "queue-position=${LAST_QUEUE_POSITION:-N/A}"
+    echo "merge-state-status=${LAST_MERGE_STATUS:-UNKNOWN}"
+  } >> "$GITHUB_OUTPUT"
+}
+
+query_pr_state() {
   # shellcheck disable=SC2016
-  PR_DATA=$(gh api graphql -f query='
+  gh api graphql -f query='
     query($owner: String!, $repo: String!, $number: Int!) {
       repository(owner: $owner, name: $repo) {
         pullRequest(number: $number) {
@@ -54,34 +128,50 @@ while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
           }
         }
       }
-    }' -f owner="$REPO_OWNER" -f repo="$REPO_NAME" -F number="$PR_NUMBER" 2>&1)
+    }' -f owner="$REPO_OWNER" -f repo="$REPO_NAME" -F number="$PR_NUMBER"
+}
+
+# Emits a non-merged result unless a final fresh-token recheck finds the PR
+# merged (the merge can land between the last poll and the conclusion).
+conclude_not_merged() {
+  local result=$1 final_state
+  ensure_fresh_token
+  final_state=$(query_pr_state 2>/dev/null | jq -r '.data.repository.pullRequest.state' 2>/dev/null) || final_state=""
+  if [ "$final_state" = "MERGED" ]; then
+    echo "Final recheck: PR was merged after all"
+    write_outputs "merged"
+    exit 0
+  fi
+  write_outputs "$result"
+  exit 1
+}
+
+echo "Timeout configured: ${TIMEOUT_MINUTES} minutes (${MAX_ATTEMPTS} attempts)"
+
+while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
+  ensure_fresh_token
+
+  # Query PR and merge queue status via GraphQL.
+  set +e
+  PR_DATA=$(query_pr_state 2>&1)
   GH_STATUS=$?
   set -e
 
-  if [ $GH_STATUS -ne 0 ]; then
+  if [ $GH_STATUS -ne 0 ] || ! PR_STATE=$(echo "$PR_DATA" | jq -e -r '.data.repository.pullRequest.state' 2>/dev/null); then
     API_FAILURE_COUNT=$((API_FAILURE_COUNT + 1))
-    echo "GraphQL API call failed (${API_FAILURE_COUNT}/${MAX_CONSECUTIVE_API_FAILURES}): $PR_DATA"
+    echo "API call failed (${API_FAILURE_COUNT}/${MAX_CONSECUTIVE_API_FAILURES}): $PR_DATA"
 
-    if [ $API_FAILURE_COUNT -ge $MAX_CONSECUTIVE_API_FAILURES ]; then
-      echo "API calls failed ${MAX_CONSECUTIVE_API_FAILURES} times consecutively (10 minutes) - aborting"
-      echo "result=timeout" >> "$GITHUB_OUTPUT"
-      exit 1
+    # A 401 means the installation token expired or was revoked; re-mint right
+    # away when app credentials are available (retried next attempt on failure).
+    if [ -n "${GH_APP_ID:-}" ] && echo "$PR_DATA" | grep -q "HTTP 401"; then
+      echo "Token looks expired - re-minting"
+      TOKEN_MINTED_AT=0
+      mint_installation_token || echo "Token mint failed; will retry on the next attempt."
     fi
 
-    ATTEMPT=$((ATTEMPT + 1))
-    sleep 120
-    continue
-  fi
-
-  # Validate API response and parse PR state.
-  if ! PR_STATE=$(echo "$PR_DATA" | jq -e -r '.data.repository.pullRequest.state' 2>/dev/null); then
-    API_FAILURE_COUNT=$((API_FAILURE_COUNT + 1))
-    echo "API call failed (${API_FAILURE_COUNT}/${MAX_CONSECUTIVE_API_FAILURES})"
-
     if [ $API_FAILURE_COUNT -ge $MAX_CONSECUTIVE_API_FAILURES ]; then
       echo "API calls failed ${MAX_CONSECUTIVE_API_FAILURES} times consecutively (10 minutes) - aborting"
-      echo "result=timeout" >> "$GITHUB_OUTPUT"
-      exit 1
+      conclude_not_merged "api_failure"
     fi
 
     ATTEMPT=$((ATTEMPT + 1))
@@ -96,6 +186,9 @@ while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
   MERGE_STATUS=$(echo "$PR_DATA" | jq -r '.data.repository.pullRequest.mergeStateStatus')
   QUEUE_STATE=$(echo "$PR_DATA" | jq -r '.data.repository.pullRequest.mergeQueueEntry.state // "NOT_IN_QUEUE"')
   QUEUE_POSITION=$(echo "$PR_DATA" | jq -r '.data.repository.pullRequest.mergeQueueEntry.position // "N/A"')
+  LAST_QUEUE_STATE="$QUEUE_STATE"
+  LAST_QUEUE_POSITION="$QUEUE_POSITION"
+  LAST_MERGE_STATUS="$MERGE_STATUS"
 
   AUTO_MERGE_STATUS="disabled"
   if [ "$AUTO_MERGE" != "null" ]; then
@@ -105,13 +198,13 @@ while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
 
   if [ "$PR_STATE" = "MERGED" ]; then
     echo "PR merged successfully via merge queue"
-    echo "result=merged" >> "$GITHUB_OUTPUT"
+    write_outputs "merged"
     exit 0
   fi
 
   if [ "$PR_STATE" = "CLOSED" ]; then
     echo "PR was closed without merging"
-    echo "result=closed" >> "$GITHUB_OUTPUT"
+    write_outputs "closed"
     exit 1
   fi
 
@@ -130,7 +223,7 @@ while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
 
     if [ $EVICTION_COUNT -ge "$MAX_EVICTIONS" ]; then
       echo "PR evicted $MAX_EVICTIONS times - giving up"
-      echo "result=evicted" >> "$GITHUB_OUTPUT"
+      write_outputs "evicted"
       exit 1
     fi
 
@@ -142,7 +235,7 @@ while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
       if ! gh pr merge "$PR_NUMBER" -R "$REPOSITORY" "${MERGE_ARGS[@]}"; then
         echo "Failed to enable auto-merge for PR #${PR_NUMBER} in ${REPOSITORY}"
         echo "Check that the GitHub App is installed on ${REPOSITORY} and has Pull requests: Write permission."
-        exit 1
+        conclude_not_merged "api_failure"
       fi
       echo "Auto-merge re-enabled - PR sent back to merge queue"
     fi
@@ -154,5 +247,4 @@ while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
 done
 
 echo "Timeout waiting for merge (${TIMEOUT_MINUTES} minutes) - manual intervention required"
-echo "result=timeout" >> "$GITHUB_OUTPUT"
-exit 1
+conclude_not_merged "timeout"

--- a/ensure-pr-passes-merge-queue/monitor-merge-queue.sh
+++ b/ensure-pr-passes-merge-queue/monitor-merge-queue.sh
@@ -204,8 +204,7 @@ while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
 
   if [ "$PR_STATE" = "CLOSED" ]; then
     echo "PR was closed without merging"
-    write_outputs "closed"
-    exit 1
+    conclude_not_merged "closed"
   fi
 
   if [ "$QUEUE_STATE" = "AWAITING_CHECKS" ] || [ "$QUEUE_STATE" = "QUEUED" ]; then
@@ -223,8 +222,7 @@ while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
 
     if [ $EVICTION_COUNT -ge "$MAX_EVICTIONS" ]; then
       echo "PR evicted $MAX_EVICTIONS times - giving up"
-      write_outputs "evicted"
-      exit 1
+      conclude_not_merged "evicted"
     fi
 
     if [ "$DRY_RUN" = "true" ]; then


### PR DESCRIPTION
Closes #753.

## What

- New optional inputs `app-id` + `private-key`: the monitor script mints GitHub App installation tokens itself (JWT via openssl, per the [documented bash pattern](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app)) and re-mints at 50 minutes or immediately on HTTP 401 — monitoring windows beyond the 1-hour installation-token TTL now survive. `app-token` remains supported for backward compatibility (short windows only).
- Consecutive-API-failure aborts now report `result=api_failure` instead of `timeout`.
- Before any non-merged result, one final fresh-token recheck: if the PR merged between the last poll and the abort, the action reports `merged` (this exact false-alarm hit camunda/camunda-platform-helm 14.7.0, see #753).
- New outputs `queue-state`, `queue-position`, `merge-state-status` (last observed) so callers can build informative alerts.
- Failure to re-enable auto-merge after an eviction also concludes via the recheck path instead of exiting without a `result`.

## Testing

- shellcheck clean (`--external-sources`).
- Offline harness (stubbed `gh`/`curl`/`sleep`, real RSA key so the JWT/openssl path runs for real): 14 cases covering validation, static-token mode, self-mint mode, 401 storms with re-mint, timeout-with-recheck rescue, and all eviction paths (re-queue + merge, eviction limit, auto-merge re-enable failure) — all pass, each asserting exactly one `result=` write.
- Callers keep working unchanged with `app-token`; camunda/camunda-platform-helm will switch both its shepherd workflows to `app-id`/`private-key` (camunda/camunda-platform-helm#6634).
