### PR TITLE
fix: make preview-env clean catch-all step best-effort

### DIFF
--- a/preview-env/clean/cleanup.sh
+++ b/preview-env/clean/cleanup.sh
@@ -323,5 +323,10 @@ preview_environment_cleanup \
   "$WARNING_MESSAGE"
 
 log "\nCleaning inconsistent comments (catch-all step) ..." false
+# Best-effort, non-fatal: anything missed is swept up by the next scheduled run.
+catch_all_exit_code=0
 cleanup_inconsistent_comments \
-  "$LABELS"
+  "$LABELS" || catch_all_exit_code=$?
+if [ "$catch_all_exit_code" != 0 ]; then
+  echo "::warning::Catch-all comment cleanup failed (exit ${catch_all_exit_code}); it is best-effort and self-heals on the next scheduled run."
+fi


### PR DESCRIPTION
## Problem

The scheduled **Preview Env Clean** job (which calls this repo's `preview-env/clean` action) failed on a transient GitHub GraphQL **HTTP 502**.

Source of the failure (in `camunda/camunda`): https://github.com/camunda/camunda/actions/runs/30245284280/job/89910865578

```
Cleaning inconsistent comments (catch-all step) ...
gh: We had issues producing the response to your request. ... (HTTP 502)
jq: error (at <stdin>:1): Cannot iterate over null (null)
Process completed with exit code 5.
```

The 502 hit mid-pagination inside `cleanup_inconsistent_comments` (via `get_pull_requests_by_states_with_last_100_comments`). `gh` exited non-zero, and under `set -o errexit -o pipefail` the whole job went red — even though the **primary** cleanup had already completed successfully (`0 preview environment(s) cleaned!` appears just above in the log).

This is rare (1 failure in the last ~20 runs) and self-healed on the next scheduled run.

## Reasoning / why this fix

`cleanup_inconsistent_comments` is documented in `cleanup.sh` itself as *"a catch-all safety step"*. Two properties make an in-script retry unnecessary:

- The job runs on a **schedule** (twice daily) and is **idempotent** — anything a run misses is swept up by the next run. The schedule already provides retry.
- The failure was in the best-effort catch-all, *after* the primary work succeeded.

So a transient upstream 5xx in this step should not fail the job. Rather than adding retry machinery (per-call backoff) or `jq` null-tolerance — both of which duplicate what the schedule already does — this simply makes the catch-all invocation **non-fatal**:

- on failure it emits a `::warning::` annotation (so a *persistent* failure stays visible), and the job stays green;
- the primary `preview_environment_cleanup` is **unchanged** and still fails loudly if it breaks.

## Change

```diff
 log "\nCleaning inconsistent comments (catch-all step) ..." false
-cleanup_inconsistent_comments \
-  "$LABELS"
+# Best-effort, non-fatal: anything missed is swept up by the next scheduled run.
+catch_all_exit_code=0
+cleanup_inconsistent_comments \
+  "$LABELS" || catch_all_exit_code=$?
+if [ "$catch_all_exit_code" != 0 ]; then
+  echo "::warning::Catch-all comment cleanup failed (exit ${catch_all_exit_code}); it is best-effort and self-heals on the next scheduled run."
+fi
```

## Testing

- Reproduced the original `jq: Cannot iterate over null` crash and confirmed `gh`'s non-zero 502 exit independently sinks the pipeline under `pipefail`.
- Verified the new tail: failure → warning with the real exit code + script continues past `errexit` + exit 0; success → silent.
- `shellcheck preview-env/clean/cleanup.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)