### PR TITLE
fix: pin vault-action and create-github-app-token to full-length SHAs

### DIFF
--- a/generate-github-app-token-from-vault-secrets/action.yml
+++ b/generate-github-app-token-from-vault-secrets/action.yml
@@ -125,7 +125,7 @@ runs:
 
   - name: Import the GitHub App ID from vault
     id: app-id
-    uses: hashicorp/vault-action@v4.0.0
+    uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
     with:
       url: ${{ inputs.vault-url }}
       method: ${{ inputs.vault-auth-method }}
@@ -146,7 +146,7 @@ runs:
         }}
   - name: Import the GitHub App secret key from vault
     id: app-private-key
-    uses: hashicorp/vault-action@v4.0.0
+    uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
     with:
       url: ${{ inputs.vault-url }}
       method: ${{ inputs.vault-auth-method }}
@@ -186,7 +186,7 @@ runs:
 
   - name: Generate a Github App token
     id: github-token
-    uses: actions/create-github-app-token@v3
+    uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
     with:
       client-id: ${{ steps.app-id.outputs.id }}
       private-key: ${{ steps.app-private-key.outputs.private-key }}


### PR DESCRIPTION
## Problem

`generate-github-app-token-from-vault-secrets/action.yml` references three actions by tag:

* `hashicorp/vault-action@v4.0.0` (twice)
* `actions/create-github-app-token@v3`

Any repository that enables **Settings → Actions → General → Require actions to be pinned to a full-length commit SHA** can no longer run *a single job* that resolves this action. GitHub evaluates the policy over the whole dependency tree at *Set up job*, before any step executes:

```
##[error]The actions hashicorp/vault-action@v4.0.0 and actions/create-github-app-token@v3
are not allowed in camunda/infraex-terraform because all actions must be pinned to a
full-length commit SHA.
```

A consumer pinning its own call sites does not help: the offending reference lives here. In `camunda/infraex-terraform` this currently takes out `lint`, `terraform-drift-detection` and `certificate-renewal`, the last one being a scheduled Let's Encrypt renewal.

## Change

Pin the three references to the commit the tag points at today, with the version kept in a trailing comment so Renovate keeps updating them:

| Reference | SHA |
| --- | --- |
| `hashicorp/vault-action` v4.0.0 | `892a26828f195e65540a40b4768ae4571f51ebfc` |
| `actions/create-github-app-token` v3.2.0 (what `v3` resolves to) | `bcd2ba49218906704ab6c1aa796996da409d3eb1` |

No behaviour change: same code, immutable reference.

## Scope

Deliberately limited to the action that blocks consumers today. The rest of the repository is tag-pinned as well and will hit the same wall as the policy spreads, but that is a much larger change and belongs in its own PR. Related: #778, which covers the `actionlint` action (`curl | bash` from a mutable ref, plus `actions/checkout@v7`).