### PR TITLE
ci: pin every GitHub Action to a commit SHA and enforce it with zizmor

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -53,6 +53,14 @@
       matchPackageNames: ["renovatebot/pre-commit-hooks"],
       schedule: ["on Saturday"],
     },
+    // Third-party actions are SHA-pinned (see docs/github-actions-pinning.md).
+    // Renovate derives the update type from the version comment on the `uses:`
+    // line, so pins must carry the FULL version (`# v4.6.0`), never a floating
+    // major (`# v4`): a full version keeps routine upgrades as minor/patch and
+    // auto-merging here, while a major-only comment downgrades every upstream
+    // release to a `digest` update that no rule below auto-merges.
+    // Digest updates are deliberately left out, so a digest-only PR means an
+    // upstream tag moved without a release — review it, don't rubber-stamp it.
     {
       matchUpdateTypes: ["minor", "patch"],
       matchManagers: ["github-actions"],

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - name: Import Secrets
       id: vault-secrets
-      uses: hashicorp/vault-action@v4.0.0
+      uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
       with:
         url: ${{ secrets.VAULT_ADDR }}
         method: approle
@@ -24,7 +24,7 @@ jobs:
           secret/data/products/infra/ci/infra-releases RELEASES_APP_KEY;
     - name: Generate a GitHub token
       id: app-token
-      uses: actions/create-github-app-token@v3
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       with:
         app-id: ${{ steps.vault-secrets.outputs.RELEASES_APP_ID }}
         private-key: ${{ steps.vault-secrets.outputs.RELEASES_APP_KEY }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,18 +12,18 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.x"
 
-      - uses: asdf-vm/actions/install@v4
+      - uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47 # v4.0.1
 
       - run: |
           echo "::add-matcher::actionlint/actionlint-matcher.json"
 
-      - uses: pre-commit/action@v3.0.1
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         with:
           extra_args: --all-files --verbose

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - name: Import Secrets
       id: vault-secrets
-      uses: hashicorp/vault-action@v4.0.0
+      uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
       with:
         url: ${{ secrets.VAULT_ADDR }}
         method: approle
@@ -25,7 +25,7 @@ jobs:
           secret/data/products/infra/ci/infra-releases RELEASES_APP_KEY;
     - name: Generate a GitHub token
       id: app-token
-      uses: actions/create-github-app-token@v3
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       with:
         app-id: ${{ steps.vault-secrets.outputs.RELEASES_APP_ID }}
         private-key: ${{ steps.vault-secrets.outputs.RELEASES_APP_KEY }}

--- a/.github/workflows/retry-worfklow-run-monitoring.yml
+++ b/.github/workflows/retry-worfklow-run-monitoring.yml
@@ -21,11 +21,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Import Secrets
         id: secrets
-        uses: hashicorp/vault-action@v4.0.0
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
         with:
           url: ${{ secrets.VAULT_ADDR }}
           method: approle
@@ -45,7 +45,7 @@ jobs:
 
       - name: Send Slack notification
         if: fromJson(steps.stats.outputs.stats)[0].failure > (inputs.max-failures || 5)
-        uses: slackapi/slack-github-action@v4
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
           payload: |
             {
@@ -92,7 +92,7 @@ jobs:
     steps:
     - name: Import Secrets
       id: secrets
-      uses: hashicorp/vault-action@v4.0.0
+      uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
       with:
         url: ${{ secrets.VAULT_ADDR }}
         method: approle
@@ -102,7 +102,7 @@ jobs:
         secrets: |
           secret/data/products/infra/ci/infra-core SLACK_WEBHOOK_INFRA_ALERTS;
     - name: Send Slack notification
-      uses: 8398a7/action-slack@v3
+      uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0
       with:
         text: ":no_entry: Failed GHA workflow run, see runbook: https://github.com/camunda/infra-core/wiki/GHA_Failure_Workflow_Retry_Workflow_Run"
         status: failure

--- a/.github/workflows/retry-worfklow-run.yml
+++ b/.github/workflows/retry-worfklow-run.yml
@@ -69,11 +69,11 @@ jobs:
         shell: bash
 
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Import Secrets
         id: secrets
-        uses: hashicorp/vault-action@v4.0.0
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
         with:
           url: ${{ secrets.VAULT_ADDR }}
           method: approle
@@ -85,7 +85,7 @@ jobs:
 
       - name: Generate a GitHub Access Token from Github App
         id: github-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ steps.secrets.outputs.RETRIGGER_APP_ID }}
           private-key: ${{ steps.secrets.outputs.RETRIGGER_APP_KEY }}

--- a/.github/workflows/test-common-tooling.yml
+++ b/.github/workflows/test-common-tooling.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.label }}
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Install if required common software tooling
       uses: ./common-tooling
     - name: Check that installed software is available

--- a/.github/workflows/test-dependency-vuln-check.yml
+++ b/.github/workflows/test-dependency-vuln-check.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v7
-    - uses: actions/setup-python@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: '3.x'
     - name: Install pytest

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,91 @@
+---
+# =============================================================================
+# zizmor.yml — GitHub Actions supply-chain policy for infra-global-github-actions
+#
+# Consumed by the `zizmor` pre-commit hook (see .pre-commit-config.yaml), which
+# runs locally on `pre-commit run -a` and in CI via the pre-commit workflow.
+#
+# This repository is public and its composite actions are consumed by other
+# Camunda teams, so an unpinned third-party action here is not just our own
+# exposure — every downstream repository inherits it transitively.
+#
+# Scope: this repository currently adopts a single zizmor audit, `unpinned-uses`.
+# Every other audit that fires here is explicitly disabled below. The audits are
+# disabled rather than left on because this repo has pre-existing findings for
+# all of them; a lint gate that is red on arrival gates nothing. Each
+# `disable: true` entry is a standing invitation to fix the underlying findings
+# and drop the entry.
+#
+# Docs: https://docs.zizmor.sh/configuration/
+# =============================================================================
+
+rules:
+  unpinned-uses:
+    config:
+      # `policies` maps action-owner globs to a pinning level. Globs are matched
+      # most-specific-first, so the `*` catch-all only applies to owners that no
+      # other entry claims.
+      #
+      #   any       — no constraint; any ref (SHA, tag, branch) is accepted.
+      #   ref-pin   — must carry an explicit ref, symbolic (tag/branch) or SHA.
+      #   hash-pin  — must be a 40-character commit SHA. Tags and branches fail.
+      #
+      # Local references (`uses: ./common-tooling`) are same-repo and are skipped
+      # by this audit entirely, so they need no policy entry.
+      policies:
+        # Everything is hash-pinned, including GitHub's own actions.
+        #
+        # camunda/camunda and infra-core exempt `actions/*` and `github/*` as
+        # "same trust boundary as the runners". That reasoning does not carry
+        # over to this repository, because the binding constraint here is not
+        # our own threat model but GitHub's `Require actions to be pinned to a
+        # full-length commit SHA` setting, which several consumers already
+        # enforce. That setting grants no namespace exemptions:
+        #
+        #   "all actions must be pinned to a full-length commit SHA to be used.
+        #    This includes actions from your organization and actions authored
+        #    by GitHub. Reusable workflows can still be referenced by tag."
+        #   -- https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository
+        #
+        # It is evaluated over the whole dependency tree, so an `actions/foo@v1`
+        # left on a tag inside a composite action here refuses the consumer's
+        # job at `Set up job`, before any step runs, and the consumer cannot
+        # work around it by choosing a different revision of this repository.
+        # A `ref-pin` policy for `actions/*` would therefore be weaker than the
+        # policy already binding on the repositories this gate exists to
+        # protect -- green here, broken downstream.
+        "*": hash-pin
+
+        # The one exemption, and it is a deliberate trade-off rather than a
+        # trust judgement. This repository references itself at `@main`
+        # (setup-yarn-cache -> is-cache-enabled, fossa/info -> setup-gh-cli,
+        # configure-maintenance-pull-request -> configure-pull-request), which
+        # is the contract its consumers rely on: they get the current `main`
+        # without a bump PR. Hash-pinning those would make every internal
+        # change a two-step merge-then-bump.
+        #
+        # KNOWN GAP: because the GitHub setting walks the whole tree, those
+        # three `@main` self-references are still refused for a consumer that
+        # enforces it, even after this change. Closing that means giving up the
+        # `@main` contract, which is a repository-design decision and is
+        # tracked separately rather than settled here.
+        camunda/*: ref-pin
+
+  # --- audits not adopted (yet) ----------------------------------------------
+  # Findings below are pre-existing and unrelated to tag mutability. Enabling
+  # any of them means fixing its findings in the same change. The counts are
+  # from the adopting change (`zizmor 1.29.0 --offline --no-config`, 155
+  # findings across these six audits) and are recorded to show the size of each
+  # backlog, not to be kept current.
+  archived-uses:            # 2 findings — both 8398a7/action-slack, upstream is archived
+    disable: true
+  artipacked:               # 8 findings
+    disable: true
+  excessive-permissions:    # 8 findings
+    disable: true
+  github-app:               # 6 findings
+    disable: true
+  github-env:               # 6 findings
+    disable: true
+  template-injection:       # 125 findings
+    disable: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,18 @@ repos:
     - id: actionlint
       args: ["-config-file", "actionlint/actionlint.yaml"]
 
+# Enforces the GitHub Actions pinning policy in .github/zizmor.yml: third-party
+# actions must be referenced by commit SHA, because a tag can be force-pushed by
+# a compromised upstream and silently change what our runners — and the runners
+# of every repository consuming these actions — execute.
+# --offline keeps the hook deterministic and token-free; the pinning audit needs
+# no network, and zizmor's online audits are not adopted here.
+- repo: https://github.com/zizmorcore/zizmor-pre-commit
+  rev: v1.29.0
+  hooks:
+    - id: zizmor
+      args: ["--no-progress", "--offline", "--config=.github/zizmor.yml"]
+
 - repo: https://github.com/renovatebot/pre-commit-hooks
   rev: 44.14.10
   hooks:

--- a/README.md
+++ b/README.md
@@ -16,8 +16,22 @@ pre-commit install --install-hooks -t commit-msg -t pre-commit
 ```
 
 This installs two types of hooks:
-- **pre-commit hooks** (`-t pre-commit`): Run linters (trailing whitespace, shellcheck, actionlint, etc.) before each commit.
+- **pre-commit hooks** (`-t pre-commit`): Run linters (trailing whitespace, shellcheck, actionlint, zizmor, etc.) before each commit.
 - **commit-msg hooks** (`-t commit-msg`): Validate that commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) format (e.g. `feat: ...`, `fix: ...`, `chore: ...`).
+
+### Pinning Third-Party Actions
+
+Every action used here — in a workflow or in a composite `action.yml`, **including GitHub's own `actions/*`** — must be referenced by a full commit SHA, with the full version in a trailing comment:
+
+```yaml
+- uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+```
+
+Two reasons. A tag is a mutable pointer that a compromised upstream can force-push, while a SHA cannot be moved. And several consuming repositories enforce GitHub's **Require actions to be pinned to a full-length commit SHA** setting, which exempts no namespace and is evaluated over the whole dependency tree — so an action left on a tag here refuses the consumer's job at `Set up job`, before any step runs.
+
+The only exemption is `camunda/*`, because this repository references itself at `@main` by contract. The rule is enforced by the `zizmor` pre-commit hook and configured in [`.github/zizmor.yml`](.github/zizmor.yml).
+
+See [docs/github-actions-pinning.md](docs/github-actions-pinning.md) for the full policy, why `actions/*` is not exempt here even though it is in `camunda/camunda` and `infra-core`, the known gap around `@main` self-references, how to resolve a tag to a SHA, and why the comment must carry the full version rather than a floating major.
 
 ### Conventional Commits
 

--- a/actionlint/action.yml
+++ b/actionlint/action.yml
@@ -17,7 +17,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - run: echo "::add-matcher::${{ github.action_path }}/actionlint-matcher.json"
       shell: bash

--- a/add-bug-to-quality-board/action.yml
+++ b/add-bug-to-quality-board/action.yml
@@ -20,7 +20,7 @@ runs:
   steps:
     - name: Add provided labels to issue
       if: ${{ inputs.labels != '' && github.event.action == 'opened' }}
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         github-token: ${{ inputs.github-token }}
         script: |
@@ -47,14 +47,14 @@ runs:
           console.log("Added labels:", parsed);
 
     - name: Add issue to Quality Board project
-      uses: actions/add-to-project@v2
+      uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
       with:
         project-url: https://github.com/orgs/${{ github.repository_owner }}/projects/${{ inputs.project-number }}
         github-token: ${{ inputs.github-token }}
 
     - name: Get project ID
       id: get-project-id
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         github-token: ${{ inputs.github-token }}
         script: |
@@ -74,7 +74,7 @@ runs:
 
     - name: Get project fields
       id: get-project-fields
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         github-token: ${{ inputs.github-token }}
         script: |
@@ -99,7 +99,7 @@ runs:
 
     - name: Get project item ID for issue
       id: get-item
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         github-token: ${{ inputs.github-token }}
         script: |
@@ -149,7 +149,7 @@ runs:
 
     - name: Update Component field
       if: steps.get-item.outputs.itemId != ''
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         github-token: ${{ inputs.github-token }}
         script: |

--- a/argocd-delete-applications/action.yml
+++ b/argocd-delete-applications/action.yml
@@ -48,7 +48,7 @@ runs:
         exit 1
 
     - name: Setup ArgoCD CLI
-      uses: clowdhaus/argo-cd-action@v4.2.0
+      uses: clowdhaus/argo-cd-action@946f488cf2607049c2e6ca86902ac50783927ec1 # v4.2.0
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
       with:

--- a/argocd-sync-applications/action.yml
+++ b/argocd-sync-applications/action.yml
@@ -35,7 +35,7 @@ runs:
   using: composite
   steps:
   - name: Sync of the ArgoCD application (app-name=${{ inputs.app-name }})
-    uses: clowdhaus/argo-cd-action@v4.2.0
+    uses: clowdhaus/argo-cd-action@946f488cf2607049c2e6ca86902ac50783927ec1 # v4.2.0
     env:
       # Only required for first step in job where API is called
       # All subsequent setps in a job will not re-download the CLI
@@ -50,7 +50,7 @@ runs:
         --server ${{ inputs.server }}
       version: ${{ inputs.cli-version }}
   - name: Wait for the ArgoCD application to be synced (app-name=${{ inputs.app-name }}, timeout=${{ inputs.max-waiting-time-sync }}s)
-    uses: clowdhaus/argo-cd-action@v4.2.0
+    uses: clowdhaus/argo-cd-action@946f488cf2607049c2e6ca86902ac50783927ec1 # v4.2.0
     if: inputs.max-waiting-time-sync != '0'
     with:
       command: app wait ${{ inputs.app-name }}
@@ -62,7 +62,7 @@ runs:
         --timeout ${{ inputs.max-waiting-time-sync }}
       version: ${{ inputs.cli-version }}
   - name: Wait for the ArgoCD application to be healthy (app-name=${{ inputs.app-name }}, timeout=${{ inputs.max-waiting-time-health }}s)
-    uses: clowdhaus/argo-cd-action@v4.2.0
+    uses: clowdhaus/argo-cd-action@946f488cf2607049c2e6ca86902ac50783927ec1 # v4.2.0
     if: inputs.max-waiting-time-health != '0'
     with:
       command: app wait ${{ inputs.app-name }}

--- a/assert-camunda-git-emails/action.yml
+++ b/assert-camunda-git-emails/action.yml
@@ -11,7 +11,7 @@ inputs:
 runs:
   using: composite
   steps:
-  - uses: actions/checkout@v7
+  - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     if: ${{ github.event.pull_request }}
     with:
       fetch-depth: 0

--- a/build-docker-image/action.yml
+++ b/build-docker-image/action.yml
@@ -128,7 +128,7 @@ runs:
 
   - name: Calculate Docker image name
     id: meta
-    uses: docker/metadata-action@v6
+    uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
     with:
       images: |
         ${{ inputs.registry_host }}/${{ inputs.image_name }}
@@ -152,14 +152,14 @@ runs:
     # https://github.com/docker/setup-qemu-action
   - name: Set up QEMU
     id: qemu
-    uses: docker/setup-qemu-action@v4
+    uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
     with:
       image: ${{ inputs.qemu_image }}
       platforms: ${{ inputs.qemu_platforms }}
 
   - name: Set up Docker Buildx
     id: buildx
-    uses: docker/setup-buildx-action@v4
+    uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
     with:
       version: ${{ inputs.buildx_version }}
       driver: ${{ inputs.buildx_driver }}
@@ -173,7 +173,7 @@ runs:
 
 
   - name: Login to Docker registry
-    uses: docker/login-action@v4
+    uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
     # Only attempt login when we want to push and use a conventional login.
     # (The login step is not needed for Google Workload Identity.)
     # This avoids depending on a 3rd party service when not needed.
@@ -186,7 +186,7 @@ runs:
 
   - name: Build and push Docker image
     id: build-push
-    uses: docker/build-push-action@v7
+    uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
     env:
       DOCKER_BUILD_SUMMARY: ${{ inputs.job_summary }}
     with:

--- a/check-copilot-commits/action.yml
+++ b/check-copilot-commits/action.yml
@@ -35,7 +35,7 @@ runs:
   using: composite
   steps:
   - name: Checkout repository
-    uses: actions/checkout@v7
+    uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     with:
       repository: ${{ inputs.repository || github.repository }}
       token: ${{ inputs.github-token }}

--- a/common-tooling/action.yml
+++ b/common-tooling/action.yml
@@ -211,14 +211,14 @@ runs:
   - name: Set up QEMU
     if: ${{ inputs.qemu-enabled == 'true' }}
     id: qemu
-    uses: docker/setup-qemu-action@v4
+    uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
     with:
       image: ${{ inputs.qemu-image }}
       platforms: ${{ inputs.qemu-platforms }}
   # Docker Buildx
   - name: Set up Docker Buildx
     if: ${{ inputs.buildx-enabled == 'true' && ( env.buildx_missing == 'true' || inputs.overwrite == 'true' ) }}
-    uses: docker/setup-buildx-action@v4
+    uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
     with:
       version: ${{ inputs.buildx-version }}
       driver: ${{ inputs.buildx-driver }}
@@ -243,7 +243,7 @@ runs:
       export PATH="$PATH:`yarn global bin`"
   # Install node
   - name: Install NodeJS
-    uses: actions/setup-node@v7
+    uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
     if: ${{ inputs.node-enabled == 'true' && ( env.node_missing == 'true' || inputs.overwrite == 'true' ) }}
     with:
       always-auth: ${{ inputs.node-always-auth }}
@@ -260,7 +260,7 @@ runs:
   # Setup Maven
   - name: Setup Maven Action
     if: ${{ inputs.java-enabled == 'true' && ( env.java_missing == 'true' || inputs.overwrite == 'true' ) }}
-    uses: s4u/setup-maven-action@v1.20.0
+    uses: s4u/setup-maven-action@ba34de01b7f4ba2ab8e2860df8993a29f4477056 # v1.20.0
     with:
       checkout-enabled: false
       java-version: ${{ inputs.java-version }}
@@ -272,7 +272,7 @@ runs:
 
   # Install Python, it's absent on self-hosted runners
   - name: Install Python3 (std install)
-    uses: actions/setup-python@v7
+    uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
     # actions/setup-python doesn't yet support ARM
     if: ${{ !contains(runner.arch, 'arm') && inputs.python-enabled == 'true' && ( env.python_missing == 'true' || inputs.overwrite == 'true' ) }}
     with:
@@ -287,7 +287,7 @@ runs:
       allow-prereleases: ${{ inputs.python-allow-prereleases }}
 
   - name: Install Python3 (arm install)
-    uses: deadsnakes/action@v3.2.0
+    uses: deadsnakes/action@e640ac8743173a67cca4d7d77cd837e514bf98e8 # v3.2.0
     # actions/setup-python doesn't yet support ARM, see https://github.com/actions/setup-python/issues/705#issuecomment-1756948951
     if: ${{ contains(runner.arch, 'arm') && inputs.python-enabled == 'true' && ( env.python_missing == 'true' || inputs.overwrite == 'true' ) }}
     with:

--- a/configure-pull-request/action.yml
+++ b/configure-pull-request/action.yml
@@ -29,26 +29,26 @@ runs:
   steps:
     - name: Set labels
       if: ${{ inputs.labels != '' }}
-      uses: buildsville/add-remove-label@v2.0.1
+      uses: buildsville/add-remove-label@ac59c9f0aeb66eb12d6366eb1d69ec1906e9ef9a # v2.0.1
       with:
         labels: ${{ inputs.labels }}
         token: ${{ inputs.github-token }}
         type: add
     - name: Set project
       if: ${{ inputs.project-url != '' }}
-      uses: actions/add-to-project@v2
+      uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
       with:
         github-token: ${{ inputs.github-token }}
         project-url: ${{ inputs.project-url }}
     - name: Set reviewers (users)
       if: ${{ inputs.reviewers != '' }}
-      uses: dannysauer/actions-assigner@v2.0.1
+      uses: dannysauer/actions-assigner@ca2ca780928294ee5126986cc31db6c2ee7d69b0 # v2.0.1
       with:
         reviewers: ${{ inputs.reviewers }}
         token: ${{ inputs.github-token }}
     - name: Set reviewers (teams)
       if: ${{ inputs.team-reviewers != '' }}
-      uses: dannysauer/actions-assigner@v2.0.1
+      uses: dannysauer/actions-assigner@ca2ca780928294ee5126986cc31db6c2ee7d69b0 # v2.0.1
       with:
         team-reviewers: ${{ inputs.team-reviewers }}
         token: ${{ inputs.github-token }}

--- a/docs/github-actions-pinning.md
+++ b/docs/github-actions-pinning.md
@@ -1,0 +1,120 @@
+# 📌 GitHub Actions pinning policy
+
+## 📌 What
+
+Every third-party GitHub Action referenced in this repository — in a workflow under `.github/workflows/` or in any composite `action.yml` — must be referenced by a full 40-character commit SHA, with the human-readable version kept in a trailing comment:
+
+```yaml
+- uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+```
+
+The policy lives in [`.github/zizmor.yml`](../.github/zizmor.yml) and is enforced by the [`zizmor`](https://docs.zizmor.sh/) [pre-commit](../.pre-commit-config.yaml) hook, which runs locally and in the `pre-commit` workflow.
+
+Pinning levels per owner:
+
+| Owner pattern | Level | Accepted refs |
+|:--------------|:------|:--------------|
+| `camunda/*` | `ref-pin` | tag, branch, or SHA (`@main` is the contract this repo offers its consumers) |
+| everything else, **including `actions/*` and `github/*`** | `hash-pin` | 40-character commit SHA only |
+
+Local references (`uses: ./common-tooling`) are same-repo and out of scope.
+
+> ℹ️ This is stricter than the equivalent policy in `camunda/camunda` and `camunda/infra-core`, which exempt `actions/*` and `github/*`. See [Why GitHub's own actions are not exempt](#why-githubs-own-actions-are-not-exempt).
+
+## 🤔 Why
+
+A git tag is a **mutable pointer**. An attacker who compromises an upstream repository can force-push an existing tag to malicious code, and every consumer executes it on the next run — with no pull request, no diff, and no notification. The [`tj-actions/changed-files` compromise](https://unit42.paloaltonetworks.com/github-actions-supply-chain-attack/) (March 2025) did exactly that and leaked CI secrets from thousands of repositories. A commit SHA cannot be moved, so a pinned reference always resolves to code somebody reviewed.
+
+This matters more here than in a normal repository, for two reasons:
+
+- **This repository is public and consumed by other teams.** Its composite actions run inside workflows across Camunda, frequently in jobs holding Vault, GCP, Teleport, and Artifactory credentials. An unpinned third-party action in a composite action is not just our exposure — every downstream repository inherits it transitively, and none of those consumers can see or gate it.
+- **Consumers reference this repository at `@main`.** They pick up whatever `main` holds at run time, so a compromised transitive dependency propagates immediately, without a Renovate PR anywhere in the chain.
+
+### Why GitHub's own actions are not exempt
+
+`camunda/camunda` and `camunda/infra-core` exempt `actions/*` and `github/*` on the reasoning that they sit inside the same trust boundary as the runners: if `actions/checkout` is compromised, SHA-pinning it elsewhere buys little, because GitHub already controls the environment the job runs in.
+
+That reasoning does not carry over here, because the binding constraint for this repository is not our own threat model but GitHub's **Require actions to be pinned to a full-length commit SHA** setting, which a number of consuming repositories already enforce. That setting grants no namespace exemptions:
+
+> all actions must be pinned to a full-length commit SHA to be used. This includes actions from your organization and actions authored by GitHub. Reusable workflows can still be referenced by tag.
+>
+> — [Managing GitHub Actions settings for a repository](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository)
+
+It is evaluated over the **whole dependency tree**, and refusal happens at `Set up job`, before any step executes. So an `actions/foo@v1` left on a tag inside a composite action here breaks the consumer's job outright, and the consumer cannot work around it by choosing a different revision of this repository. A `ref-pin` policy for `actions/*` would be weaker than the policy already binding on the repositories this gate exists to protect: green here, broken downstream.
+
+Note the carve-out is for **reusable workflows**, not for organization ownership — which is why `camunda/*` cannot be exempted on "it's ours" grounds either. See below.
+
+### The `camunda/*` exemption, and its known gap
+
+`camunda/*` stays at `ref-pin`, and this is a deliberate trade-off rather than a trust judgement. This repository references itself at `@main` in three composite actions — [`setup-yarn-cache`](../setup-yarn-cache/action.yml) → `is-cache-enabled`, [`fossa/info`](../fossa/info/action.yml) → `setup-gh-cli`, and [`teams/infra/configure-maintenance-pull-request`](../teams/infra/configure-maintenance-pull-request/action.yml) → `configure-pull-request`. That `@main` reference is the contract consumers rely on: they get current `main` without a bump PR. Hash-pinning it would turn every internal change into a two-step merge-then-bump.
+
+> ⚠️ **Known gap.** Because the GitHub setting walks the whole dependency tree, those three `@main` self-references are still refused for a consumer that enforces it, even with everything else pinned. Closing that gap means giving up the `@main` contract, which is a repository-design decision tracked separately rather than settled by this policy.
+
+### Alternatives considered
+
+- **Pin only new references, leave existing tags alone.** Cheaper, but leaves the actual exposure in place — the tags already on `main` are the ones a compromised upstream would move. Rejected.
+- **Enable zizmor's full default audit set.** 238 findings on arrival (template injection, excessive permissions, artipacked, …). A gate that is red from day one gates nothing. Rejected in favour of adopting audits one at a time; see [Scope](#scope-of-the-zizmor-adoption).
+- **Mirror the `camunda/camunda` and `infra-core` trust boundary exactly** (`actions/*` and `github/*` on `ref-pin`). Consistent across repositories, and defensible on pure threat-model grounds, but it would leave this repository's consumers broken under a setting they already enforce. Rejected; see [above](#why-githubs-own-actions-are-not-exempt).
+- **Renovate's `helpers:pinGitHubActionDigests` preset.** Pins digests automatically, but it is not a gate: nothing stops a contributor from adding an unpinned action, and it would also pin `actions/*` and `camunda/*` against the trust boundary above. Rejected.
+- **A hand-rolled pre-commit script.** No new dependency, but it reimplements a maintained tool and diverges from the policy the other Camunda repositories already run. Rejected.
+- **Floating major tags in the comment (`@<sha> # v4`).** Shorter, but it converts routine upstream releases into review toil — see below. Rejected.
+
+## 🔧 How
+
+### Adding or updating a third-party action
+
+Resolve the tag to its commit SHA and keep the version as a comment:
+
+```bash
+# annotated tags need the peeled ref (^{}), lightweight tags do not
+git ls-remote https://github.com/<owner>/<repo> 'refs/tags/<tag>*'
+```
+
+```yaml
+- uses: <owner>/<repo>@<40-char-sha> # <full version>
+```
+
+> 🚨 The comment must carry the **full** version (`# v4.6.0`), never a floating major (`# v4`), even when the floating major is the tag you resolved.
+
+This is load-bearing rather than cosmetic. Renovate derives the update type from that comment, and [`.github/renovate.json5`](../.github/renovate.json5) auto-merges `minor` and `patch` for the `github-actions` manager but not `digest`:
+
+| Comment | Upstream ships v4.6.0 | Update type | Auto-merged? |
+|:--------|:----------------------|:------------|:-------------|
+| `# v4.5.0` | comment and SHA both updated | `patch` | ✅ yes |
+| `# v4` | `v4` tag moves, comment unchanged | `digest` | ❌ no, costs a review |
+
+With full-version comments, ordinary upgrades keep auto-merging exactly as they did before pinning, so the policy adds no recurring review load. It also preserves the signal: a digest-only PR now genuinely means an upstream tag moved without a release, which is the event this policy exists to surface. Review those, don't rubber-stamp them.
+
+To find the precise version behind a floating major, list every tag pointing at the same commit:
+
+```bash
+git ls-remote --tags https://github.com/<owner>/<repo> \
+  | awk -v s=<40-char-sha> '$1==s {print $2}'
+```
+
+### Verifying locally
+
+```bash
+pre-commit run zizmor --all-files
+```
+
+### Exceptions
+
+If an action genuinely cannot be pinned, suppress it on the line itself so the justification sits next to the code:
+
+```yaml
+- uses: <owner>/<repo>@v1 # zizmor: ignore[unpinned-uses] vendor only ships moving tags
+```
+
+Whole-file exemptions go in the `rules.unpinned-uses.ignore` list in [`.github/zizmor.yml`](../.github/zizmor.yml).
+
+### Scope of the zizmor adoption
+
+Only the `unpinned-uses` audit is enabled. Every other audit that fires on this repository is explicitly disabled in [`.github/zizmor.yml`](../.github/zizmor.yml), each `disable: true` acting as a standing TODO with its finding count recorded. Enabling one means fixing its findings in the same change. The hook runs with `--offline`, so zizmor's network-backed audits never execute and no token is needed.
+
+## 📚 References
+
+- [zizmor `unpinned-uses` audit](https://docs.zizmor.sh/audits/#unpinned-uses)
+- [zizmor configuration](https://docs.zizmor.sh/configuration/)
+- [GitHub: using third-party actions securely](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
+- [Unit 42: the `tj-actions/changed-files` supply-chain attack](https://unit42.paloaltonetworks.com/github-actions-supply-chain-attack/)

--- a/download-center-upload/action.yml
+++ b/download-center-upload/action.yml
@@ -79,12 +79,12 @@ runs:
       echo "dc_repo=${dc_repo}" >> "$GITHUB_OUTPUT"
 
   - name: Authenticate to Google Cloud
-    uses: 'google-github-actions/auth@v3'
+    uses: 'google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093' # v3.0.0
     with:
       credentials_json: '${{ inputs.gcp_credentials }}'
 
   - name: Set up gcloud
-    uses: 'google-github-actions/setup-gcloud@v3'
+    uses: 'google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db' # v3.0.1
 
   - name: Upload files
     shell: bash

--- a/preview-env/comment/action.yml
+++ b/preview-env/comment/action.yml
@@ -9,7 +9,7 @@ runs:
   using: composite
   steps:
     - name: Download Deployment Status Artifacts
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         path: deployment_status
         pattern: deployment-status-${{ github.run_id }}-${{ github.run_attempt }}-*
@@ -24,7 +24,7 @@ runs:
         fi
     - name: Upsert Deployment Result Summary
       if: steps.deployment-status-artifacts.outputs.found == 'true'
-      uses: mshick/add-pr-comment@v3
+      uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59 # v3.12.0
       with:
         message-path: |
           ${{ github.action_path }}/templates/comment-header.md

--- a/preview-env/create/action.yml
+++ b/preview-env/create/action.yml
@@ -52,7 +52,7 @@ runs:
   using: composite
   steps:
   - name: Restore cache
-    uses: actions/cache@v6
+    uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
     id: tool-cache-argocd
     with:
       path: /usr/local/bin/argocd
@@ -69,11 +69,11 @@ runs:
       ARGOCD_OPTS: "--grpc-web"
       ARGOCD_SERVER: ${{ inputs.argocd_server }}
   - name: Ensure that jq is available
-    uses: dcarbone/install-jq-action@v4.0.1
+    uses: dcarbone/install-jq-action@4fcb5062d7ce9bc4382d1a352d19ba3ba2c317c1 # v4.0.1
     #########################################################################
     # Create a GitHub deployment that points to the URL we're going to deploy to.
     # If a Pull Request exists, it will show the status of this deployment.
-  - uses: bobheadxi/deployments@v1.5.0
+  - uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1.5.0
     name: Create GitHub deployment
     id: deployment
     with:
@@ -139,7 +139,7 @@ runs:
   - name: Install Teleport
     if: failure() && inputs.github_token != ''
     id: setup_teleport
-    uses: teleport-actions/setup@v1
+    uses: teleport-actions/setup@b638ff596557cc3959eb6b5287d5e58e0c8ac6a6 # v1.1.1
     with:
       proxy: camunda.teleport.sh:443
       version: auto
@@ -148,7 +148,7 @@ runs:
     id: auth_teleport
     env:
       GITHUB_TOKEN: ${{ inputs.github_token }}
-    uses: teleport-actions/auth-k8s@v2
+    uses: teleport-actions/auth-k8s@0f46164469ae4fcd4d359d40e06bab17d4be17c9 # v2.0.6
     with:
       proxy: camunda.teleport.sh:443
       token: infra-ci-prod-github-action-preview-env-infra
@@ -176,7 +176,7 @@ runs:
     # `always()` ensures that the deployment status
     # is updated regardless of previous steps failing.
     if: always()
-    uses: bobheadxi/deployments@v1.5.0
+    uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1.5.0
     with:
       step: finish
       token: ${{ github.token }}
@@ -211,7 +211,7 @@ runs:
       echo "$template" >> $GITHUB_STEP_SUMMARY
   - name: Upload deployment status as artifact
     if: always()
-    uses: actions/upload-artifact@v7
+    uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
     with:
       name: deployment-status-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.app_name }}
       path: status_${{ inputs.app_name }}.md

--- a/preview-env/destroy/action.yml
+++ b/preview-env/destroy/action.yml
@@ -39,7 +39,7 @@ runs:
   using: composite
   steps:
   - name: Restore cache
-    uses: actions/cache@v6
+    uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
     id: tool-cache-argocd
     with:
       path: /usr/local/bin/argocd
@@ -64,7 +64,7 @@ runs:
       ARGOCD_OPTS: "--grpc-web"
       ARGOCD_SERVER: ${{ inputs.argocd_server  }}
 
-  - uses: bobheadxi/deployments@v1.5.0
+  - uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1.5.0
     if: always()
     name: Deactivate GitHub Deployment environment
     with:
@@ -96,7 +96,7 @@ runs:
       fi
       echo "is-removable=$is_removable" | tee -a $GITHUB_OUTPUT
 
-  - uses: bobheadxi/deployments@v1.5.0
+  - uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1.5.0
     if: ${{ steps.removable-environment.outputs.is-removable == 'true' }}
     name: Delete GitHub Environment
     with:

--- a/rerun-failed-run/action.yml
+++ b/rerun-failed-run/action.yml
@@ -108,7 +108,7 @@ runs:
 
     - name: Import Secrets
       id: vault-secrets
-      uses: hashicorp/vault-action@v4.0.0
+      uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
       with:
         url: ${{ inputs.vault-addr }}
         method: ${{ inputs.vault-auth-method }}
@@ -123,7 +123,7 @@ runs:
 
     - name: Generate a GitHub token for infra-rerun camunda/infra-global-github-actions
       id: github-token
-      uses: actions/create-github-app-token@v3
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       with:
         app-id: ${{ steps.vault-secrets.outputs.RETRIGGER_APP_ID }}
         private-key: ${{ steps.vault-secrets.outputs.RETRIGGER_APP_KEY }}
@@ -153,7 +153,7 @@ runs:
       shell: bash
 
     - name: Trigger retry-worfklow-run.yml
-      uses: codex-/return-dispatch@v3
+      uses: codex-/return-dispatch@08365b69369e9eb639ce4c4cbbd29598bc52ca3a # v3.0.3
       id: dispatch
       with:
         owner: camunda

--- a/setup-yarn-cache/action.yml
+++ b/setup-yarn-cache/action.yml
@@ -62,7 +62,7 @@ runs:
 
   - name: Save global Yarn cache on non-PRs
     if: ${{ steps.is-cache-create-branch.outputs.result == 'true' }}
-    uses: actions/cache@v6
+    uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
     with:
       # need to use an environment variable here, thx to https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7415
       path: "${{ env.CUSTOM_YARN_GLOBAL_CACHE_DIR }}"
@@ -75,7 +75,7 @@ runs:
   - name: Restore global Yarn cache always
     # Restore cache (but don't save it) if we're not on main or stable/* branches and cache is not disabled
     if: ${{ steps.is-cache-create-branch.outputs.result != 'true' && steps.is-cache-enabled.outputs.is-cache-enabled == 'true' }}
-    uses: actions/cache/restore@v6
+    uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
     with:
       path: "${{ env.CUSTOM_YARN_GLOBAL_CACHE_DIR }}"
       key: ${{ runner.environment }}-${{ runner.os }}-yarn-${{ hashFiles(format('{0}/yarn.lock', inputs.directory)) }}

--- a/submit-aborted-gha-status/action.yml
+++ b/submit-aborted-gha-status/action.yml
@@ -27,7 +27,7 @@ runs:
 
   - name: Login to Google Cloud
     id: auth
-    uses: google-github-actions/auth@v3
+    uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
     with:
       credentials_json: '${{ inputs.gcp_credentials_json }}'
       token_format: 'access_token'

--- a/submit-build-status/action.yml
+++ b/submit-build-status/action.yml
@@ -72,7 +72,7 @@ runs:
 
   - name: Login to Google Cloud
     id: auth
-    uses: google-github-actions/auth@v3
+    uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
     with:
       credentials_json: '${{ inputs.gcp_credentials_json }}'
       token_format: 'access_token'

--- a/submit-test-status/action.yml
+++ b/submit-test-status/action.yml
@@ -51,7 +51,7 @@ runs:
       echo "-----"
 
   - name: ensure that jq is available
-    uses: dcarbone/install-jq-action@v4.0.1
+    uses: dcarbone/install-jq-action@4fcb5062d7ce9bc4382d1a352d19ba3ba2c317c1 # v4.0.1
 
   - name: load input
     shell: bash
@@ -116,13 +116,13 @@ runs:
   - name: login to Google Cloud
     if: env.PROCEED_WITH_SUBMISSION == 'true'
     id: auth
-    uses: google-github-actions/auth@v3
+    uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
     with:
       credentials_json: '${{ inputs.gcp_credentials_json }}'
 
   - name: setup Google Cloud SDK
     if: env.PROCEED_WITH_SUBMISSION == 'true'
-    uses: google-github-actions/setup-gcloud@v3
+    uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
 
   - name: Print Google Cloud SDK version used
     if: env.PROCEED_WITH_SUBMISSION == 'true'

--- a/teams/infra/configure-maintenance-pull-request/action.yml
+++ b/teams/infra/configure-maintenance-pull-request/action.yml
@@ -103,7 +103,7 @@ runs:
 
   - name: Alert Infra team medic on security Pull Requests
     if: steps.pr-event-info.outputs.action == 'opened' && steps.pr-event-info.outputs.vendor == 'snyk'
-    uses: 8398a7/action-slack@v3
+    uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0
     with:
       text: ":snyk: Security Pull Request opened"
       status: failure

--- a/teams/infra/pull-request/automerge/action.yml
+++ b/teams/infra/pull-request/automerge/action.yml
@@ -20,7 +20,7 @@ runs:
   using: composite
   steps:
   - name: automerge
-    uses: pascalgn/automerge-action@v0.16.4
+    uses: pascalgn/automerge-action@7961b8b5eec56cc088c140b56d864285eabd3f67 # v0.16.4
     env:
       GITHUB_TOKEN: "${{ inputs.github-token }}"
       MERGE_METHOD: "squash"

--- a/teams/infra/pull-request/release/action.yml
+++ b/teams/infra/pull-request/release/action.yml
@@ -37,7 +37,7 @@ runs:
         echo "config-filename=${{ inputs.config-filename }}" >> $GITHUB_ENV
       fi
   - name: Manage Release
-    uses: googleapis/release-please-action@v5
+    uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
     with:
       config-file: ${{ env.config-filename }}
       manifest-file: ${{ inputs.manifest-filename }}

--- a/yq-yaml-processor/action.yml
+++ b/yq-yaml-processor/action.yml
@@ -22,7 +22,7 @@ runs:
   using: composite
   steps:
   - name: Process patches
-    uses: mikefarah/yq@v4.53.3
+    uses: mikefarah/yq@1b9b4ac5187171d2e5e3129be0cfa827c7f9d53d # v4.53.3
     id: process
     env:
       OPTIONS: ${{ inputs.options }}


### PR DESCRIPTION
## Summary

Pins **every** action used in this repo — workflows and composite actions, **including GitHub's own `actions/*`** — to a 40-character commit SHA, with the full version in a trailing comment. Enforced by `zizmor` as a pre-commit hook, running locally and in the existing `pre-commit` CI workflow.

Two reasons a tag is not good enough here: a tag is a mutable pointer a compromised upstream can force-push, and several consuming repositories already enforce GitHub's *Require actions to be pinned to a full-length commit SHA* setting, which exempts no namespace and is evaluated over the whole dependency tree. An action left on a tag here refuses the **consumer's** job at `Set up job`, before any step runs.

| | |
|:--|:--|
| **Policy** | `hash-pin` everything, including `actions/*` and `github/*`. Only `camunda/*` is exempt (`@main` self-reference contract). |
| **Scale** | 75 occurrences pinned; 37 unique refs; 34 files |
| **Verified** | 38/38 pins re-resolved against upstream, **0 mismatches**; 35/35 replaced refs still point at the SHA they were pinned to; gate confirmed to fail on an unpinned ref in both workflows and composite actions |
| **Behavior change** | None. Every SHA is what its ref resolved to already, and the diff touches `uses:` lines only. |
| **Stricter than** | `camunda/camunda` and `infra-core`, deliberately — see below |
| **⚠️ Known gap** | Three `@main` self-references remain refused downstream — see below |

<details>
<summary><b>Why <code>actions/*</code> is not exempt here, unlike in <code>camunda/camunda</code> and <code>infra-core</code></b></summary>

Those repos exempt `actions/*` and `github/*` as sitting inside the same trust boundary as the runners. Sound for them; it does not carry over here, because the binding constraint is not our own threat model but GitHub's setting, which grants no namespace exemption:

> all actions must be pinned to a full-length commit SHA to be used. This includes actions from your organization and actions authored by GitHub. Reusable workflows can still be referenced by tag.
>
> — [Managing GitHub Actions settings for a repository](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository)

Evaluated over the **whole dependency tree**, refused at `Set up job`. A consumer cannot work around it by pinning a different revision of this repo. A `ref-pin` policy for `actions/*` would be weaker than the policy already binding on the repositories this gate exists to protect: green here, broken downstream.

This repo is the wrong place for that gap — it is public, its composite actions run inside other teams' workflows, and consumers reference it at `@main`.

</details>

<details>
<summary><b>⚠️ Known gap: <code>camunda/*</code> <code>@main</code> self-references</b></summary>

Note the docs carve-out is for **reusable workflows**, not organization ownership — so `camunda/*` gets no exemption on "it's ours" grounds either. Every `camunda/*` reference here is a step-level composite action.

Three composite actions self-reference this repo at `@main`:

| File | Line |
|---|---|
| `setup-yarn-cache/action.yml` → `is-cache-enabled` | 43 |
| `fossa/info/action.yml` → `setup-gh-cli` | 49 |
| `teams/infra/configure-maintenance-pull-request/action.yml` → `configure-pull-request` | 97 |

**These three are still refused for a consumer enforcing the setting, even after this PR.** So this PR unblocks consumers reaching `build-docker-image`, `rerun-failed-run` and `common-tooling`, but not those three.

Closing the gap means giving up the `@main` contract — every internal change becomes a merge-then-bump two-step — which is a repository-design decision, not something to settle in a lint policy. Documented as an open gap in `.github/zizmor.yml` and the docs rather than silently ignored.

</details>

<details>
<summary><b>Changes</b></summary>

1. `.github/zizmor.yml` — `unpinned-uses` policy; the six other audits that fire here are explicitly disabled with backlog counts recorded as standing TODOs (155 findings across the six, largest 125 `template-injection`)
2. `zizmor` pre-commit hook in `.pre-commit-config.yaml` — picked up by the existing `pre-commit` workflow, so no CI change needed
3. 75 references pinned (46 third-party, then 29 `actions/*`)
4. `docs/github-actions-pinning.md` — policy, rationale, rejected alternatives, known gap
5. README section on pinning
6. `.github/renovate.json5` — comment documenting the full-version-comment coupling (no behavior change)

</details>

<details>
<summary><b>Counts</b></summary>

| Measure | Count |
|:--------|------:|
| Occurrences newly pinned by this PR | **75** (46 third-party + 29 `actions/*`) |
| Pre-existing pins on `main` | 4 |
| Total pinned occurrences on the branch | **79** |
| Unique pinned refs | **37** |
| YAML files containing at least one pin | 31 |
| Files changed | 34 |

</details>

<details>
<summary><b>✅ Why this adds no Renovate toil</b></summary>

Pin comments record the **full** version (`# v4.6.0`), never a floating major (`# v4`). Load-bearing, because Renovate derives the update type from the comment:

| Comment | Upstream ships v4.6.0 | Update type | Auto-merged? |
|:--------|:----------------------|:------------|:-------------|
| `# v4.5.0` | comment and SHA both updated | `patch` | ✅ yes |
| `# v4` | `v4` tag moves, comment unchanged | `digest` | ❌ no, costs a review |

`.github/renovate.json5` auto-merges `minor`/`patch` for the `github-actions` manager, not `digest`. Floating-major comments would have turned every routine upstream release into a hand-reviewed PR for zero security gain, and destroyed the signal value of a digest-only PR — which now genuinely means an upstream tag moved without a release.

</details>

<details>
<summary><b>Verification</b></summary>

Two independent passes, both reading pins back out of the working tree rather than from the table used to write them:

- **Do the SHAs match their comments?** 38/38 unique pins re-resolved via `git ls-remote`, annotated tags dereferenced: **38 exact, 0 mismatches.**
- **Did anything silently change version?** Stronger check, and the one that matters: each replaced ref re-resolved to confirm it still points at the SHA it was pinned to. **35/35 identical.** Matching a tag only proves the SHA is real; this proves the pin is the same code that ran before. `actions/create-github-app-token@v3` resolves to `bcd2ba49…`, the same SHA already hand-pinned in `generate-github-app-token-from-vault-secrets`. (`8398a7/action-slack@v3` is a *branch*, not a tag; its head is the pinned SHA, which also carries `v3.19.0`.)
- **Nothing else moved.** The diff across `.github/workflows/*` and every `action.yml` contains `uses:` lines exclusively — no functional change hidden in 34 files.
- **Gate bites.** Reverting `actions/create-github-app-token`, `actions/setup-node` or `mikefarah/yq` to a tag each fails the hook; `camunda/*@main` still passes, as intended. Works in workflows **and** composite `action.yml` files.
- **Backlog counts re-derived** from `zizmor --format json`: 155 across the six disabled audits (as recorded), 238 for the full default audit set on `main`.
- `pre-commit run -a` green on actionlint, zizmor, renovate-config-validator.

</details>

<details>
<summary><b>Out of scope, tracked separately</b></summary>

- **`pre-commit/action` resolves `actions/cache@v4` internally.** If the setting is ever enabled on *this* repo, the workflow enforcing the policy would itself be refused at `Set up job`. Needs the inlined-`pre-commit` treatment used in `infraex-common-config` (#557, #561). Own issue.
- **`8398a7/action-slack` is an archived upstream** (2 uses). Pinned, but it will never receive security fixes. Replacing it is a behavioral change.
- **`codex-/return-dispatch` v4** left to #772; this PR pins it at v3.0.3, i.e. what runs today.

</details>

<details>
<summary><b>Why no ADR</b></summary>

This repo has no `adr/` convention, and it is public while `infra-core` is private — so a pointer to that ADR would be unreadable to exactly the external consumers who most need the rationale. The decision record, including rejected alternatives, is folded into `docs/github-actions-pinning.md`, which links only to public sources.

</details>
