### PR TITLE
ci: pin the actions/* namespace to commit SHAs

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -24,7 +24,7 @@ jobs:
           secret/data/products/infra/ci/infra-releases RELEASES_APP_KEY;
     - name: Generate a GitHub token
       id: app-token
-      uses: actions/create-github-app-token@v3
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       with:
         app-id: ${{ steps.vault-secrets.outputs.RELEASES_APP_ID }}
         private-key: ${{ steps.vault-secrets.outputs.RELEASES_APP_KEY }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.x"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           secret/data/products/infra/ci/infra-releases RELEASES_APP_KEY;
     - name: Generate a GitHub token
       id: app-token
-      uses: actions/create-github-app-token@v3
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       with:
         app-id: ${{ steps.vault-secrets.outputs.RELEASES_APP_ID }}
         private-key: ${{ steps.vault-secrets.outputs.RELEASES_APP_KEY }}

--- a/.github/workflows/retry-worfklow-run-monitoring.yml
+++ b/.github/workflows/retry-worfklow-run-monitoring.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Import Secrets
         id: secrets

--- a/.github/workflows/retry-worfklow-run.yml
+++ b/.github/workflows/retry-worfklow-run.yml
@@ -69,7 +69,7 @@ jobs:
         shell: bash
 
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Import Secrets
         id: secrets
@@ -85,7 +85,7 @@ jobs:
 
       - name: Generate a GitHub Access Token from Github App
         id: github-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ steps.secrets.outputs.RETRIGGER_APP_ID }}
           private-key: ${{ steps.secrets.outputs.RETRIGGER_APP_KEY }}

--- a/.github/workflows/test-common-tooling.yml
+++ b/.github/workflows/test-common-tooling.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.label }}
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Install if required common software tooling
       uses: ./common-tooling
     - name: Check that installed software is available

--- a/.github/workflows/test-dependency-vuln-check.yml
+++ b/.github/workflows/test-dependency-vuln-check.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v7
-    - uses: actions/setup-python@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: '3.x'
     - name: Install pytest

--- a/actionlint/action.yml
+++ b/actionlint/action.yml
@@ -17,7 +17,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - run: echo "::add-matcher::${{ github.action_path }}/actionlint-matcher.json"
       shell: bash

--- a/add-bug-to-quality-board/action.yml
+++ b/add-bug-to-quality-board/action.yml
@@ -20,7 +20,7 @@ runs:
   steps:
     - name: Add provided labels to issue
       if: ${{ inputs.labels != '' && github.event.action == 'opened' }}
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         github-token: ${{ inputs.github-token }}
         script: |
@@ -47,14 +47,14 @@ runs:
           console.log("Added labels:", parsed);
 
     - name: Add issue to Quality Board project
-      uses: actions/add-to-project@v2
+      uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
       with:
         project-url: https://github.com/orgs/${{ github.repository_owner }}/projects/${{ inputs.project-number }}
         github-token: ${{ inputs.github-token }}
 
     - name: Get project ID
       id: get-project-id
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         github-token: ${{ inputs.github-token }}
         script: |
@@ -74,7 +74,7 @@ runs:
 
     - name: Get project fields
       id: get-project-fields
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         github-token: ${{ inputs.github-token }}
         script: |
@@ -99,7 +99,7 @@ runs:
 
     - name: Get project item ID for issue
       id: get-item
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         github-token: ${{ inputs.github-token }}
         script: |
@@ -149,7 +149,7 @@ runs:
 
     - name: Update Component field
       if: steps.get-item.outputs.itemId != ''
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         github-token: ${{ inputs.github-token }}
         script: |

--- a/assert-camunda-git-emails/action.yml
+++ b/assert-camunda-git-emails/action.yml
@@ -11,7 +11,7 @@ inputs:
 runs:
   using: composite
   steps:
-  - uses: actions/checkout@v7
+  - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     if: ${{ github.event.pull_request }}
     with:
       fetch-depth: 0

--- a/check-copilot-commits/action.yml
+++ b/check-copilot-commits/action.yml
@@ -35,7 +35,7 @@ runs:
   using: composite
   steps:
   - name: Checkout repository
-    uses: actions/checkout@v7
+    uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     with:
       repository: ${{ inputs.repository || github.repository }}
       token: ${{ inputs.github-token }}

--- a/common-tooling/action.yml
+++ b/common-tooling/action.yml
@@ -243,7 +243,7 @@ runs:
       export PATH="$PATH:`yarn global bin`"
   # Install node
   - name: Install NodeJS
-    uses: actions/setup-node@v7
+    uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
     if: ${{ inputs.node-enabled == 'true' && ( env.node_missing == 'true' || inputs.overwrite == 'true' ) }}
     with:
       always-auth: ${{ inputs.node-always-auth }}
@@ -272,7 +272,7 @@ runs:
 
   # Install Python, it's absent on self-hosted runners
   - name: Install Python3 (std install)
-    uses: actions/setup-python@v7
+    uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
     # actions/setup-python doesn't yet support ARM
     if: ${{ !contains(runner.arch, 'arm') && inputs.python-enabled == 'true' && ( env.python_missing == 'true' || inputs.overwrite == 'true' ) }}
     with:

--- a/configure-pull-request/action.yml
+++ b/configure-pull-request/action.yml
@@ -36,7 +36,7 @@ runs:
         type: add
     - name: Set project
       if: ${{ inputs.project-url != '' }}
-      uses: actions/add-to-project@v2
+      uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
       with:
         github-token: ${{ inputs.github-token }}
         project-url: ${{ inputs.project-url }}

--- a/preview-env/comment/action.yml
+++ b/preview-env/comment/action.yml
@@ -9,7 +9,7 @@ runs:
   using: composite
   steps:
     - name: Download Deployment Status Artifacts
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         path: deployment_status
         pattern: deployment-status-${{ github.run_id }}-${{ github.run_attempt }}-*

--- a/preview-env/create/action.yml
+++ b/preview-env/create/action.yml
@@ -52,7 +52,7 @@ runs:
   using: composite
   steps:
   - name: Restore cache
-    uses: actions/cache@v6
+    uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
     id: tool-cache-argocd
     with:
       path: /usr/local/bin/argocd
@@ -211,7 +211,7 @@ runs:
       echo "$template" >> $GITHUB_STEP_SUMMARY
   - name: Upload deployment status as artifact
     if: always()
-    uses: actions/upload-artifact@v7
+    uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
     with:
       name: deployment-status-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.app_name }}
       path: status_${{ inputs.app_name }}.md

--- a/preview-env/destroy/action.yml
+++ b/preview-env/destroy/action.yml
@@ -39,7 +39,7 @@ runs:
   using: composite
   steps:
   - name: Restore cache
-    uses: actions/cache@v6
+    uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
     id: tool-cache-argocd
     with:
       path: /usr/local/bin/argocd

--- a/rerun-failed-run/action.yml
+++ b/rerun-failed-run/action.yml
@@ -123,7 +123,7 @@ runs:
 
     - name: Generate a GitHub token for infra-rerun camunda/infra-global-github-actions
       id: github-token
-      uses: actions/create-github-app-token@v3
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       with:
         app-id: ${{ steps.vault-secrets.outputs.RETRIGGER_APP_ID }}
         private-key: ${{ steps.vault-secrets.outputs.RETRIGGER_APP_KEY }}

--- a/setup-yarn-cache/action.yml
+++ b/setup-yarn-cache/action.yml
@@ -62,7 +62,7 @@ runs:
 
   - name: Save global Yarn cache on non-PRs
     if: ${{ steps.is-cache-create-branch.outputs.result == 'true' }}
-    uses: actions/cache@v6
+    uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
     with:
       # need to use an environment variable here, thx to https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7415
       path: "${{ env.CUSTOM_YARN_GLOBAL_CACHE_DIR }}"
@@ -75,7 +75,7 @@ runs:
   - name: Restore global Yarn cache always
     # Restore cache (but don't save it) if we're not on main or stable/* branches and cache is not disabled
     if: ${{ steps.is-cache-create-branch.outputs.result != 'true' && steps.is-cache-enabled.outputs.is-cache-enabled == 'true' }}
-    uses: actions/cache/restore@v6
+    uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
     with:
       path: "${{ env.CUSTOM_YARN_GLOBAL_CACHE_DIR }}"
       key: ${{ runner.environment }}-${{ runner.os }}-yarn-${{ hashFiles(format('{0}/yarn.lock', inputs.directory)) }}


### PR DESCRIPTION
Draft, complement to #781. Independent of it on purpose: no shared lines, either can land first.

## Why

GitHub's **Require actions to be pinned to a full-length commit SHA** does not exempt `actions/*`. A repository with that setting on refuses by name:

```
The actions hashicorp/vault-action@v4.0.0 and actions/create-github-app-token@v3
are not allowed in <repo> because all actions must be pinned to a full-length
commit SHA.
```

The check runs at `Set up job`, before any step, and is evaluated over the **whole** dependency tree. A consumer of these composite actions cannot work around it by choosing a different revision of this repository — so every `actions/*` reference left on a tag here is a hard block downstream, not a style preference.

#781 covers third-party actions and leaves `actions/*` on `ref-pin`. That leaves `rerun-failed-run`, `common-tooling`, `preview-env/*`, `setup-yarn-cache`, `add-bug-to-quality-board`, `configure-pull-request`, `actionlint`, `assert-camunda-git-emails` and `check-copilot-commits` still refused, while `build-docker-image` comes out clean. This closes that gap.

## Changes

29 references across 18 files. Nothing else touched.

| action | pin | comment |
|---|---|---|
| `actions/add-to-project` | `5afcf98f` | `v2.0.0` |
| `actions/cache`, `actions/cache/restore` | `55cc8345` | `v6.1.0` |
| `actions/checkout` | `3d3c42e5` | `v7.0.1` |
| `actions/create-github-app-token` | `bcd2ba49` | `v3.2.0` |
| `actions/download-artifact` | `3e5f45b2` | `v8.0.1` |
| `actions/github-script` | `3a2844b7` | `v9.0.0` |
| `actions/setup-node` | `820762786` | `v7.0.0` |
| `actions/setup-python` | `5fda3b95` | `v7.0.0` |
| `actions/upload-artifact` | `043fb46d` | `v7.0.1` |

Full-semver comments, not floating majors, following the convention #781 argues for: Renovate derives the update type from the comment, so `# v7.0.1` keeps ordinary upgrades classified as `patch`/`minor` instead of `digest`.

## Verification

- **Every pin is the SHA its floating major tag points at today: 9/9 no-op.** Nothing is upgraded or downgraded by this PR.
- **Pins read back out of the working tree and re-resolved upstream against the tag in their comment: 10/10 exact, 0 mismatches.** The verifier reads the tree, not the table used to write it.
- `actions/create-github-app-token@bcd2ba49 # v3.2.0` independently reproduces the pin #779 already landed on `main`, which is a useful control on the method.
- No `actions/*` or `github/*` reference left unpinned.
- `pre-commit run --all-files` green: `actionlint`, `renovate-config-validator`, shell and whitespace hooks.

## Follow-up, not in this PR

Once this and #781 are both in, `.github/zizmor.yml` should move `actions/*` and `github/*` from `ref-pin` to `hash-pin`, otherwise nothing stops the next `actions/foo@v1` from reintroducing the gap. Happy to fold that in here if #781 lands first, or leave it to #781 if you prefer to keep the policy file in one place.

Kept as a draft until you tell me which way you want the two PRs sequenced.