### PR TITLE
ci: inline pre-commit so the pinning gate can run

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -24,6 +24,30 @@ jobs:
       - run: |
           echo "::add-matcher::actionlint/actionlint-matcher.json"
 
-      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+      # pre-commit/action is deliberately not used: its action.yml resolves
+      # `actions/cache@v4`, an unpinned reference. GitHub evaluates "Require
+      # actions to be pinned to a full-length commit SHA" over the entire
+      # dependency tree at Set up job, so with that setting enabled this
+      # workflow -- the one enforcing the pinning policy -- would be refused
+      # before any step could run, and could not prove the gate works.
+      #
+      # Inlining also drops the `pip install pre-commit` the action performs,
+      # which installed the latest release over the version pinned in
+      # .tool-versions and already provided by the asdf step above.
+      - name: Check pre-commit is available
+        run: |
+          set -euo pipefail
+          if ! command -v pre-commit >/dev/null 2>&1; then
+            echo "::error::pre-commit is not installed. Add it to .tool-versions; the asdf step above installs it from there."
+            exit 1
+          fi
+          pre-commit --version
+
+      - name: Cache pre-commit hook environments
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          extra_args: --all-files --verbose
+          path: ~/.cache/pre-commit
+          key: pre-commit-1|${{ runner.os }}|${{ hashFiles('.pre-commit-config.yaml', '.tool-versions') }}
+
+      - name: Run pre-commit
+        run: pre-commit run --show-diff-on-failure --color=always --all-files --verbose

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -34,20 +34,43 @@ jobs:
       # Inlining also drops the `pip install pre-commit` the action performs,
       # which installed the latest release over the version pinned in
       # .tool-versions and already provided by the asdf step above.
-      - name: Check pre-commit is available
+      - name: Check pre-commit matches .tool-versions
         run: |
           set -euo pipefail
-          if ! command -v pre-commit >/dev/null 2>&1; then
-            echo "::error::pre-commit is not installed. Add it to .tool-versions; the asdf step above installs it from there."
+
+          expected="$(awk '$1 == "pre-commit" { print $2; exit }' .tool-versions)"
+          if [ -z "$expected" ]; then
+            echo "::error::.tool-versions does not pin pre-commit. Add a 'pre-commit <version>' line; the asdf step above installs it from there."
             exit 1
           fi
-          pre-commit --version
+
+          if ! command -v pre-commit >/dev/null 2>&1; then
+            echo "::error::pre-commit is not installed. The asdf step above should have provided ${expected} from .tool-versions."
+            exit 1
+          fi
+
+          # Not just a PATH check: a pre-commit shipped with the runner image would
+          # satisfy `command -v` while silently running a different version from the
+          # one this repository pins, which is the failure mode inlining is meant to
+          # remove.
+          actual="$(pre-commit --version | awk '{ print $2 }')"
+          if [ "$actual" != "$expected" ]; then
+            echo "::error::pre-commit ${actual} is on PATH but .tool-versions pins ${expected}. The asdf install did not take effect."
+            exit 1
+          fi
+          echo "pre-commit ${actual} matches .tool-versions"
 
       - name: Cache pre-commit hook environments
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/pre-commit
-          key: pre-commit-1|${{ runner.os }}|${{ hashFiles('.pre-commit-config.yaml', '.tool-versions') }}
+          # pythonLocation is load-bearing: this workflow resolves Python through
+          # `actions/setup-python` with a floating `3.x`, so a Python upgrade changes
+          # the interpreter the hook environments are built against while every other
+          # component of the key stays identical. Without it an upgrade restores the
+          # stale environments on an exact key hit, pre-commit rebuilds them, and the
+          # rebuild is never saved -- reinstalling on every run, forever.
+          key: pre-commit-1|${{ runner.os }}|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml', '.tool-versions') }}
 
       - name: Run pre-commit
         run: pre-commit run --show-diff-on-failure --color=always --all-files --verbose


### PR DESCRIPTION
Follow-up to #781, recorded there as out of scope. Rebased on `main` now that #781 has merged.

## Problem

`pre-commit/action` is pinned, but `action.yml` at `2c7b3805` carries:

```yaml
  - uses: actions/cache@v4
```

GitHub evaluates **Require actions to be pinned to a full-length commit SHA** over the entire dependency tree at `Set up job`. Enable that setting on this repository and this workflow — the one that runs the `zizmor` gate enforcing the pinning policy — is refused before any step executes. The gate could not run to prove itself.

Not hypothetical: the identical failure took down `lint.yml` in `camunda/infraex-common-config` and the branch scheduler plus docs watcher in `camunda/camunda-deployment-references`, in both cases via `pre-commit/action`.

Worth noting `zizmor` cannot catch this one. The reference is pinned, so `unpinned-uses` is satisfied; the unpinned edge lives one level down, inside a third-party action this repository does not control.

## Change

Inlined, replacing the action with what it actually does. Its `action.yml`:

```yaml
  - run: python -m pip install pre-commit
  - run: python -m pip freeze --local
  - uses: actions/cache@v4
    with:
      path: ~/.cache/pre-commit
      key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
  - run: pre-commit run --show-diff-on-failure --color=always ${{ inputs.extra_args }}
```

Reproduced as an explicit `actions/cache` step, SHA-pinned, plus the same `pre-commit run` invocation. **The command is byte-identical**: `--show-diff-on-failure --color=always` came from the action, `--all-files --verbose` from the `extra_args` this workflow already passed.

Two deliberate differences:

- **No `pip install pre-commit`.** `.tool-versions` pins `pre-commit 4.6.1` and the `asdf-vm/actions/install` step above already installs it; the action silently overwrote that with the latest release. A guard step now asserts the version on `PATH` matches `.tool-versions`, so a `pre-commit` shipped in the runner image cannot satisfy the check while running something else.
- **Cache key gains `.tool-versions`.** The action keyed on `.pre-commit-config.yaml` and `pythonLocation` only, so a `pre-commit` or hook-toolchain bump reused a stale environment. `pythonLocation` is kept — this workflow resolves Python through `actions/setup-python` with a floating `3.x`, so it is still what determines the interpreter the hook environments are built against.

## Review follow-ups

Both from Copilot, both real, both fixed in `2fb0f13`:

- The first revision dropped `pythonLocation` from the cache key on the reasoning that `.tool-versions` determines the toolchain. Wrong here: `.tool-versions` pins `actionlint`, `pre-commit` and `shellcheck`, not Python. A Python upgrade would have restored stale environments on an exact key hit, forcing a rebuild that is then never saved — reinstalling on every run.
- The guard only tested `command -v pre-commit`, which its own error message already implied was insufficient. It now compares against `.tool-versions` and fails with both versions named, plus a separate failure if `.tool-versions` stops pinning `pre-commit` at all.

## Verification

- `pre-commit run --all-files` green on the rebased branch, **`zizmor` included** now that its config is on `main`.
- `actionlint 1.7.12` — the version pinned in `.pre-commit-config.yaml` — exits 0 on the modified workflow.
- Guard confirmed live rather than assumed: my machine has `pre-commit 4.6.0` against the pinned `4.6.1`, and the new logic rejects it.
- No live `pre-commit/action` reference left in the repository; remaining matches are historical `CHANGELOG.md` entries.