### PR TITLE
feat: add matrix-outputs-read

### DIFF
--- a/.github/config/.release-please-manifest.json
+++ b/.github/config/.release-please-manifest.json
@@ -13,6 +13,7 @@
   "generate-github-app-token-from-vault-secrets": "1.1.0",
   "is-cache-enabled": "1.0.0",
   "kubernetes-image-replace": "0.0.0",
+  "matrix-outputs-read": "0.0.0",
   "preview-env": "1.0.11",
   "previous-version": "1.0.0",
   "renovate-pr-maintainer": "1.2.0",

--- a/.github/config/release-please-config.json
+++ b/.github/config/release-please-config.json
@@ -79,6 +79,9 @@
     "kubernetes-image-replace": {
       "package-name": "kubernetes-image-replace"
     },
+    "matrix-outputs-read": {
+      "package-name": "matrix-outputs-read"
+    },
     "preview-env": {
       "package-name": "preview-env"
     },

--- a/matrix-outputs-read/README.md
+++ b/matrix-outputs-read/README.md
@@ -45,7 +45,7 @@ jobs:
       matrix:
         cluster: [c1, c2]
     steps:
-      - uses: cloudposse/github-action-matrix-outputs-write@ed06cf3a6bf23b8dce36d1cf0d63123885bb8375 # v1
+      - uses: cloudposse/github-action-matrix-outputs-write@ed06cf3a6bf23b8dce36d1cf0d63123885bb8375 # v1.0.0
         with:
           matrix-step-name: prepare-clusters
           matrix-key: ${{ matrix.cluster }}

--- a/matrix-outputs-read/README.md
+++ b/matrix-outputs-read/README.md
@@ -1,0 +1,86 @@
+# matrix-outputs-read
+
+This composite GitHub Action collects the per-job outputs written by a matrix step and merges them into a single JSON object, keyed by output name then by matrix key.
+
+It is a drop-in replacement for [`cloudposse/github-action-matrix-outputs-read`](https://github.com/cloudposse/github-action-matrix-outputs-read). Pair it with [`cloudposse/github-action-matrix-outputs-write`](https://github.com/cloudposse/github-action-matrix-outputs-write), which is unaffected and needs no replacement.
+
+## Why this exists
+
+The upstream action's own `action.yml` references two actions without pinning them:
+
+```yaml
+- uses: dcarbone/install-jq-action@v2.1.0
+- uses: actions/download-artifact@v4
+```
+
+GitHub evaluates the **Require actions to be pinned to a full-length commit SHA** repository setting over the *entire* dependency tree at `Set up job`. A caller with that setting enabled therefore has its job refused before any step runs, and cannot work around it by choosing a different revision of the upstream action:
+
+```
+The actions dcarbone/install-jq-action@v2.1.0 and actions/download-artifact@v4
+are not allowed in <repo> because all actions must be pinned to a full-length commit SHA.
+```
+
+Upstream's last release is `1.0.0` (2024-02-28) and its `main` branch is still unpinned, so there is no revision to move to.
+
+## Usage
+
+### Inputs
+
+| Input name | Description | Required | Default |
+| :--------: | :---------- | :------: | :-----: |
+| matrix-step-name | Name passed as `matrix-step-name` to the matching write step. It is also the artifact file name this action looks for. | :heavy_check_mark: | |
+
+### Outputs
+
+| Output name | Description |
+| :---------: | :---------- |
+| result | Merged JSON object. For a matrix writing `{"kube": "..."}` under keys `c1` and `c2`, the result is `{"kube": {"c1": "...", "c2": "..."}}`. |
+
+### Example
+
+```yaml
+jobs:
+  prepare-clusters:
+    strategy:
+      matrix:
+        cluster: [c1, c2]
+    steps:
+      - uses: cloudposse/github-action-matrix-outputs-write@ed06cf3a6bf23b8dce36d1cf0d63123885bb8375 # v1
+        with:
+          matrix-step-name: prepare-clusters
+          matrix-key: ${{ matrix.cluster }}
+          outputs: |
+            kube: ${{ steps.create.outputs.kubeconfig }}
+
+  access-info:
+    needs: prepare-clusters
+    runs-on: ubuntu-latest
+    outputs:
+      config: ${{ steps.read.outputs.result }}
+    steps:
+      - uses: camunda/infra-global-github-actions/matrix-outputs-read@main
+        id: read
+        with:
+          matrix-step-name: prepare-clusters
+```
+
+## Notes
+
+### No `actions/checkout` in the calling job
+
+This action downloads **every** artifact into the working directory and then walks it with `find . -maxdepth 2`. A checkout in the same job would place repository files inside that search path. Being a remote action, it needs no checkout of its own.
+
+### jq is taken from the runner
+
+The upstream action force-installs jq 1.6 through `dcarbone/install-jq-action`. That step is deliberately not reproduced: the GitHub-hosted runner images already ship jq, and both versions produce byte-identical output for this program, key ordering included.
+
+```
+jq 1.6    -> {"kube":{"c1":"x","c3":"z","c2":"y"},"extra":{"c1":1,"c2":2}}
+jq 1.7.1  -> {"kube":{"c1":"x","c3":"z","c2":"y"},"extra":{"c1":1,"c2":2}}
+```
+
+A guard reports a clear error if `jq` is missing, which can happen on a self-hosted runner.
+
+### Input handling
+
+`matrix-step-name` is passed through the environment rather than interpolated into the script, so a value containing shell metacharacters cannot reach the command line.

--- a/matrix-outputs-read/action.yml
+++ b/matrix-outputs-read/action.yml
@@ -1,0 +1,53 @@
+name: Matrix outputs - read
+
+description: |
+  Collect the per-job outputs written by a matrix step and merge them into a single JSON
+  object, keyed by output name then by matrix key. Pair it with
+  cloudposse/github-action-matrix-outputs-write, which is unaffected by the issue below.
+
+inputs:
+  matrix-step-name:
+    description: |
+      Name passed as `matrix-step-name` to the matching write step. It is also the
+      artifact file name this action looks for.
+    required: true
+
+outputs:
+  result:
+    description: |
+      Merged JSON object. For a matrix writing `{"kube": "..."}` under keys `c1` and `c2`,
+      the result is `{"kube": {"c1": "...", "c2": "..."}}`.
+    value: ${{ steps.context.outputs.result }}
+
+runs:
+  using: composite
+  steps:
+  - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+
+  # The upstream action force-installs jq 1.6 through dcarbone/install-jq-action. That
+  # step is deliberately not reproduced: the runner images already ship jq, and the two
+  # versions produce byte-identical output for this program. The install bought nothing
+  # and pulled in one of the two unpinned references this action exists to avoid.
+  - id: context
+    shell: bash
+    run: |
+      set -euo pipefail
+
+      if ! command -v jq >/dev/null 2>&1; then
+        echo "::error::jq is not available on this runner. It ships with the GitHub-hosted images; on a self-hosted runner, install it before calling this action."
+        exit 1
+      fi
+
+      # jq program kept verbatim from the upstream action, only split over several lines
+      # for readability. Single quotes are required: $matrix_key and $item are jq
+      # variables and must not be expanded by the shell, which is what SC2016 warns
+      # about and why it is disabled rather than "fixed".
+      # shellcheck disable=SC2016
+      jq_filter='map(to_entries | map(.key as $matrix_key | .value | map_values({($matrix_key): .})))
+        | flatten
+        | reduce .[] as $item ({}; . * $item)'
+
+      result="$(find . -name "$MATRIX_STEP_NAME" -maxdepth 2 -exec cat {} \; | jq -c --slurp "$jq_filter")"
+      echo "result=${result}" | tee -a "$GITHUB_OUTPUT"
+    env:
+      MATRIX_STEP_NAME: ${{ inputs.matrix-step-name }}

--- a/matrix-outputs-read/action.yml
+++ b/matrix-outputs-read/action.yml
@@ -42,9 +42,22 @@ runs:
       # far more than the intended artifact -- '*' would match every downloaded file and
       # every directory, and -exec cat on a directory then fails. A path separator would
       # silently never match, since -name only ever sees basenames.
+      #
+      # Each character is matched as its own quoted pattern rather than through a bracket
+      # expression: escaping [ and ] inside one is subtle enough that a reader cannot tell
+      # at a glance whether both are covered.
+      #
+      # Encoded once, up front, because every ::error:: below interpolates it. A raw newline
+      # would end the workflow command and let the remainder of the value be parsed as
+      # further workflow commands; % and CR are encoded for the same reason. The glob guard
+      # does not cover these characters, so it cannot be relied on to make the value safe.
+      safe_name="$(printf '%s' "$MATRIX_STEP_NAME" \
+        | sed -e 's/%/%25/g' -e 's/\r/%0D/g' \
+        | awk 'BEGIN { ORS = "" } NR > 1 { print "%0A" } { print }')"
+
       case "$MATRIX_STEP_NAME" in
-        "" | *[\*\?\[\]/]*)
-          echo "::error::matrix-step-name must be a plain artifact name: no glob characters (* ? [ ]) and no '/'. Got: ${MATRIX_STEP_NAME}"
+        "" | *"*"* | *"?"* | *"["* | *"]"* | *"/"*)
+          echo "::error::matrix-step-name must be a plain artifact name: no '*', '?', '[', ']' or '/', and not empty. Got: ${safe_name}"
           exit 1
           ;;
       esac
@@ -61,6 +74,14 @@ runs:
       # -maxdepth is a global option: GNU find accepts it after -name, but placing it
       # first is the documented form and avoids relying on that leniency.
       result="$(find . -maxdepth 2 -name "$MATRIX_STEP_NAME" -exec cat {} \; | jq -c --slurp "$jq_filter")"
+
+      # An artifact name that matches nothing is not an error to jq: the filter reduces an
+      # empty input to {}, so a typo would hand downstream jobs an empty config and fail
+      # somewhere far from the cause. Fail here instead.
+      if [ "$result" = "{}" ]; then
+        echo "::error::no artifact named '${safe_name}' was found among the downloaded artifacts. Check that matrix-step-name matches the value given to the matching write step, and that the writing jobs completed."
+        exit 1
+      fi
 
       # Written straight to GITHUB_OUTPUT, never echoed. The merged object carries whatever
       # the matrix jobs wrote, which in practice includes kubeconfigs and other credentials.

--- a/matrix-outputs-read/action.yml
+++ b/matrix-outputs-read/action.yml
@@ -38,6 +38,17 @@ runs:
         exit 1
       fi
 
+      # find -name treats its argument as a glob, so an unconstrained value could match
+      # far more than the intended artifact -- '*' would match every downloaded file and
+      # every directory, and -exec cat on a directory then fails. A path separator would
+      # silently never match, since -name only ever sees basenames.
+      case "$MATRIX_STEP_NAME" in
+        "" | *[\*\?\[\]/]*)
+          echo "::error::matrix-step-name must be a plain artifact name: no glob characters (* ? [ ]) and no '/'. Got: ${MATRIX_STEP_NAME}"
+          exit 1
+          ;;
+      esac
+
       # jq program kept verbatim from the upstream action, only split over several lines
       # for readability. Single quotes are required: $matrix_key and $item are jq
       # variables and must not be expanded by the shell, which is what SC2016 warns
@@ -47,7 +58,12 @@ runs:
         | flatten
         | reduce .[] as $item ({}; . * $item)'
 
-      result="$(find . -name "$MATRIX_STEP_NAME" -maxdepth 2 -exec cat {} \; | jq -c --slurp "$jq_filter")"
-      echo "result=${result}" | tee -a "$GITHUB_OUTPUT"
+      # -maxdepth is a global option: GNU find accepts it after -name, but placing it
+      # first is the documented form and avoids relying on that leniency.
+      result="$(find . -maxdepth 2 -name "$MATRIX_STEP_NAME" -exec cat {} \; | jq -c --slurp "$jq_filter")"
+
+      # Written straight to GITHUB_OUTPUT, never echoed. The merged object carries whatever
+      # the matrix jobs wrote, which in practice includes kubeconfigs and other credentials.
+      echo "result=${result}" >> "$GITHUB_OUTPUT"
     env:
       MATRIX_STEP_NAME: ${{ inputs.matrix-step-name }}


### PR DESCRIPTION
Adds `matrix-outputs-read`, a pinned replacement for `cloudposse/github-action-matrix-outputs-read`.

## Why

The upstream action is pinned by SHA where it is used, but its own `action.yml` is not:

```yaml
- name: 'Setup jq'
  uses: dcarbone/install-jq-action@v2.1.0
- uses: actions/download-artifact@v4
```

Since #781, this is exactly the failure mode we now know well: GitHub evaluates **Require actions to be pinned to a full-length commit SHA** over the **whole** dependency tree at `Set up job`, so a caller with that setting on is refused before any step runs:

```
The actions dcarbone/install-jq-action@v2.1.0 and actions/download-artifact@v4
are not allowed in <repo> because all actions must be pinned to a full-length commit SHA.
```

This is currently breaking integration test workflows in `camunda/camunda-deployment-references`, on `main` and on five maintenance branches.

There is nothing to bump to: upstream's last release is **1.0.0, 2024-02-28**, and its `main` is still unpinned today. `cloudposse/github-action-matrix-outputs-write` is unaffected — at its current release it contains no `uses:` at all — so only the read half needs replacing.

## Why here

The alternative was inlining the three steps at each call site: six per branch, across six branches, so roughly thirty copies of the same pin. The consumer repository would then own a pin it did not choose.

It is not an InfraEx-specific problem either — any repository doing matrix fan-out hits it — and #781 already made this repository the one place where the full action tree is pinned. A **remote** action also needs no `actions/checkout` in the calling job, which matters here (see below).

## Differences from upstream

**The `Setup jq` step is dropped, not pinned.** It force-installed jq 1.6 through the very third-party action that pulled in the unpinned reference. The runner images already ship jq. Both versions were run against the same fixture:

```
jq 1.6    -> {"kube":{"c1":"x","c3":"z","c2":"y"},"extra":{"c1":1,"c2":2}}
jq 1.7.1  -> {"kube":{"c1":"x","c3":"z","c2":"y"},"extra":{"c1":1,"c2":2}}
```

Byte-identical, key ordering included. A guard reports a clear error if `jq` is absent, which can happen on a self-hosted runner.

**`download-artifact` is on `v8.0.1`**, the revision already pinned elsewhere in this repository, rather than upstream's `v4`. This action depends on the download *layout*, so the majors in between were checked rather than assumed:

| release | breaking change | affects us |
|---|---|---|
| v5 | path behavior for single artifact downloads **by ID** | no, we download all artifacts |
| v6 | Node 24 runtime, flagged out of caution | no |
| v7 | none flagged | no |
| v8 | `digest-mismatch` defaults to `error` instead of warning | yes, deliberately |

The layout is unchanged: with no `name` input, each artifact still lands in its own directory, so the tree stays `./<artifact-name>/<file>` and `find . -maxdepth 2` still matches. `merge-multiple` is left at its default, which is what preserves that structure.

The one behavioural difference is v8 failing instead of warning on a digest mismatch. That is stricter than the cloudposse action and the right default for something feeding a kubeconfig into downstream jobs.

**`matrix-step-name` goes through the environment** instead of being interpolated into the script, so a value containing shell metacharacters cannot reach the command line.

The jq program itself is unchanged.

## Hardening added during review

Three defects were found after the first version, two by Copilot and one while retesting its findings. Each is verified rather than assumed:

| defect | consequence | state |
|---|---|---|
| the merged object was written with `tee -a` | the JSON, which carries kubeconfigs, was printed to the job log | `>>` only; stdout verified empty |
| `matrix-step-name` interpolated raw into `::error::` | a newline ends the workflow command and the remainder is parsed as further commands | encoded once up front (`%`->`%25`, CR->`%0D`, LF->`%0A`) |
| an artifact name matching nothing | jq reduces empty input to `{}` and exits 0, so a typo handed downstream jobs an empty config | fails at the source, naming the input |

The glob guard is also written as one quoted pattern per character rather than a bracket expression. The bracket form was correct — it rejected `]` in both `dash` and `bash`, contrary to the review comment — but escaping `[` and `]` inside one is subtle enough that a reviewer cannot verify it at a glance.

Test battery re-run after every change: valid name, `*`, `a]b`, `a/b`, empty, a name matching nothing, and an injection attempt.

```
prepare-clusters -> result={"kube":{"c1":"x","c2":"y"}}    (stdout empty)
*  a]b  a/b  ""  -> rejected with an actionable message
typo-name        -> ::error::no artifact named 'typo-name' was found ...
$'ev%il\n::add-mask::x' -> ::error::... 'ev%25il%0A::add-mask::x' ...   (one line, nothing injected)
```

## Note for callers

The calling job must **not** run `actions/checkout`. This action downloads every artifact into the working directory and then walks it with `find . -maxdepth 2`; a checkout would put repository files inside that search path. Being remote, the action needs no checkout of its own. This is documented in the README.

## Verification

- `pre-commit run --all-files` green, `zizmor` and `actionlint` included.
- Gate confirmed to cover the new file: reverting `download-artifact` to `@v8` makes `zizmor` fail.
- The step logic was executed against a two-artifact fixture and writes the expected merged object:
  ```
  result={"kube":{"c1":"x","c2":"y"}}
  ```
- Registered in `release-please-config.json` and the manifest, so it gets a version like every other action here.


