### PR TITLE
feat: add observe-build-status

### DIFF
--- a/.github/config/.release-please-manifest.json
+++ b/.github/config/.release-please-manifest.json
@@ -14,6 +14,7 @@
   "is-cache-enabled": "1.0.0",
   "kubernetes-image-replace": "0.0.0",
   "matrix-outputs-read": "0.0.0",
+  "observe-build-status": "0.0.0",
   "preview-env": "1.0.11",
   "previous-version": "1.0.0",
   "renovate-pr-maintainer": "1.2.0",

--- a/.github/config/release-please-config.json
+++ b/.github/config/release-please-config.json
@@ -82,6 +82,9 @@
     "matrix-outputs-read": {
       "package-name": "matrix-outputs-read"
     },
+    "observe-build-status": {
+      "package-name": "observe-build-status"
+    },
     "preview-env": {
       "package-name": "preview-env"
     },

--- a/observe-build-status/README.md
+++ b/observe-build-status/README.md
@@ -1,6 +1,6 @@
 # observe-build-status
 
-This composite Github Action (GHA) reports a job's outcome, duration and runner resource usage to [CI Analytics](https://confluence.camunda.com/display/HAN/CI+Analytics).
+This composite GitHub Action (GHA) reports a job's outcome, duration and runner resource usage to [CI Analytics](https://confluence.camunda.com/display/HAN/CI+Analytics).
 
 It wraps [`start-build-monitor`](../start-build-monitor) and [`submit-build-status`](../submit-build-status) together with the Vault plumbing that fetches the CI Analytics credentials, so a repository needs two workflow steps rather than a vendored copy of that plumbing.
 
@@ -69,7 +69,7 @@ For a repository still on AppRole, swap the last three inputs:
 | `job_name` | Optional. Value recorded in the `job_name` column; defaults to `$GITHUB_JOB` |
 | `user_reason` | Optional string (200 chars max) categorising why the job ended this way, e.g. `flaky-tests` |
 | `user_description` | Optional string (1000 chars max) detailing `user_reason`, e.g. the list of flaky tests |
-| `ci_analytics_secret_path` | Vault path holding the CI Analytics service-account key under `gcloud_sa_key`. By convention `secret/data/products/<product>/ci/ci-analytics` |
+| `ci_analytics_secret_path` | Vault path holding the CI Analytics service-account key under `gcloud_sa_key`. By convention `secret/data/products/<product>/ci/ci-analytics`. Needed whenever `secret_vault_address` is set |
 | `secret_vault_address` | Vault server URL. The opt-in switch: leave empty to disable reporting entirely |
 | `secret_vault_jwt_path` | Vault JWT auth mount path |
 | `secret_vault_jwt_role` | Vault JWT auth role. Setting it selects JWT authentication |

--- a/observe-build-status/README.md
+++ b/observe-build-status/README.md
@@ -71,7 +71,7 @@ For a repository still on AppRole, swap the last three inputs:
 | `user_description` | Optional string (1000 chars max) detailing `user_reason`, e.g. the list of flaky tests |
 | `ci_analytics_secret_path` | Vault path holding the CI Analytics service-account key under `gcloud_sa_key`. By convention `secret/data/products/<product>/ci/ci-analytics`. Needed whenever `secret_vault_address` is set |
 | `secret_vault_address` | Vault server URL. The opt-in switch: leave empty to disable reporting entirely |
-| `secret_vault_jwt_path` | Vault JWT auth mount path |
+| `secret_vault_jwt_path` | Vault JWT auth mount path. Part of the complete JWT set |
 | `secret_vault_jwt_role` | Vault JWT auth role. Setting it selects JWT authentication |
 | `secret_vault_jwt_audience` | Vault JWT GitHub audience |
 | `secret_vault_roleId` | Vault AppRole role ID. Used only when `secret_vault_jwt_role` is empty |
@@ -81,7 +81,9 @@ For a repository still on AppRole, swap the last three inputs:
 
 The action is a no-op when `secret_vault_address` is empty, so forks, local runs and repositories that have not opted in are unaffected — no annotations, no failed steps.
 
-When `secret_vault_address` **is** set, the configuration must be complete: `ci_analytics_secret_path`, plus either `secret_vault_jwt_role` or both AppRole inputs. An incomplete set is a configuration mistake rather than an opt-out, and produces a warning naming what is missing. Treating it as "no credentials" instead would leave a repository believing it reports metrics when it does not.
+When `secret_vault_address` **is** set, the configuration must be complete: `ci_analytics_secret_path`, plus either both `secret_vault_jwt_path` and `secret_vault_jwt_role`, or both AppRole inputs. An incomplete set is a configuration mistake rather than an opt-out, and produces a warning naming what is missing. Treating it as "no credentials" instead would leave a repository believing it reports metrics when it does not.
+
+`secret_vault_jwt_audience` is deliberately outside that check: `vault-action` applies a working default and no existing caller in the organisation sets it. `secret_vault_jwt_path` is inside it because every existing JWT caller does pass it — relying on `vault-action`'s default mount silently instead would produce an authentication failure reported as a missing Vault policy.
 
 The build duration is derived from the mtime of `/tmp/_monitor-start.pid`, written by `start-build-monitor`. If that file is absent the action warns and omits `build_duration_millis` rather than falling back to a later anchor: an under-reported duration is worse than a missing one in a duration dashboard. Durations outside 0–72h are dropped the same way.
 

--- a/observe-build-status/README.md
+++ b/observe-build-status/README.md
@@ -1,0 +1,103 @@
+# observe-build-status
+
+This composite Github Action (GHA) reports a job's outcome, duration and runner resource usage to [CI Analytics](https://confluence.camunda.com/display/HAN/CI+Analytics).
+
+It wraps [`start-build-monitor`](../start-build-monitor) and [`submit-build-status`](../submit-build-status) together with the Vault plumbing that fetches the CI Analytics credentials, so a repository needs two workflow steps rather than a vendored copy of that plumbing.
+
+## Why this exists
+
+At the time of writing, eleven repositories in the organisation carry their own copy of this wrapper under `.github/actions/observe-build-status/`. They are all descended from the same original, and they have drifted:
+
+- seven of them anchor the build duration on `$GITHUB_ACTION_PATH` instead of the `start-build-monitor` timestamp file, so every duration they report excludes job setup, tool installation and image pulls — silently, with no warning
+- four reference `hashicorp/vault-action` by mutable tag, which is refused outright in repositories that enforce GitHub's *Require actions to be pinned to a full-length commit SHA* setting
+- `user_description` is documented as 200 characters in six copies and 1000 in the rest; [`submit-build-status`](../submit-build-status) accepts 1000
+- most fail the job they are supposed to observe if Vault or BigQuery has a bad day, unless the caller remembers `continue-on-error: true`
+
+Only the Vault secret path genuinely differs between them, so it is an input here.
+
+## Usage
+
+`start-build-monitor` must be the **first** step of the job, and this action the **last**:
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # only for JWT authentication
+    steps:
+    - uses: camunda/infra-global-github-actions/start-build-monitor@main
+
+    # ... the job's real steps ...
+
+    - name: Observe build status
+      if: always()
+      uses: camunda/infra-global-github-actions/observe-build-status@main
+      with:
+        ci_analytics_secret_path: secret/data/products/<product>/ci/ci-analytics
+        job_name: ${{ github.job }}
+        build_status: ${{ job.status }}
+        secret_vault_address: ${{ secrets.VAULT_ADDR }}
+        secret_vault_jwt_path: ${{ secrets.VAULT_JWT_PATH }}
+        secret_vault_jwt_role: ${{ secrets.VAULT_JWT_ROLE }}
+        secret_vault_jwt_audience: ${{ secrets.VAULT_JWT_AUDIENCE }}
+```
+
+`if: always()` is required so failed and cancelled jobs are reported. `continue-on-error: true` is **not** required: every step in this action is best-effort, so it cannot fail the job it measures.
+
+For a repository still on AppRole, swap the last three inputs:
+
+```yaml
+        secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+        secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+```
+
+### Matrix jobs
+
+`job_name` defaults to `$GITHUB_JOB`, which collapses every leg of a matrix into one row. Pass the matrix values explicitly, separated by `/` — matrix values routinely contain `-`, which makes the column unsplittable otherwise:
+
+```yaml
+        job_name: ${{ github.job }}/${{ matrix.runner }}/${{ matrix.version }}
+```
+
+### Inputs
+
+| Input name | Description |
+|---|---|
+| `build_status` | Outcome of the job, normally `${{ job.status }}`: one of `success`, `failure`, `cancelled` |
+| `job_name` | Optional. Value recorded in the `job_name` column; defaults to `$GITHUB_JOB` |
+| `user_reason` | Optional string (200 chars max) categorising why the job ended this way, e.g. `flaky-tests` |
+| `user_description` | Optional string (1000 chars max) detailing `user_reason`, e.g. the list of flaky tests |
+| `ci_analytics_secret_path` | Vault path holding the CI Analytics service-account key under `gcloud_sa_key`. By convention `secret/data/products/<product>/ci/ci-analytics` |
+| `secret_vault_address` | Vault server URL. The opt-in switch: leave empty to disable reporting entirely |
+| `secret_vault_jwt_path` | Vault JWT auth mount path |
+| `secret_vault_jwt_role` | Vault JWT auth role. Setting it selects JWT authentication |
+| `secret_vault_jwt_audience` | Vault JWT GitHub audience |
+| `secret_vault_roleId` | Vault AppRole role ID. Used only when `secret_vault_jwt_role` is empty |
+| `secret_vault_secretId` | Vault AppRole secret ID |
+
+### Behaviour
+
+The action is a no-op when `secret_vault_address` is empty, so forks, local runs and repositories that have not opted in are unaffected — no annotations, no failed steps.
+
+When `secret_vault_address` **is** set, the configuration must be complete: `ci_analytics_secret_path`, plus either `secret_vault_jwt_role` or both AppRole inputs. An incomplete set is a configuration mistake rather than an opt-out, and produces a warning naming what is missing. Treating it as "no credentials" instead would leave a repository believing it reports metrics when it does not.
+
+The build duration is derived from the mtime of `/tmp/_monitor-start.pid`, written by `start-build-monitor`. If that file is absent the action warns and omits `build_duration_millis` rather than falling back to a later anchor: an under-reported duration is worse than a missing one in a duration dashboard. Durations outside 0–72h are dropped the same way.
+
+Resource metrics (CPU, memory, network) are collected by `start-build-monitor` and picked up automatically by `submit-build-status`; this action passes nothing for them.
+
+### Authentication
+
+JWT/OIDC is preferred: it stores no long-lived credential as a repository secret. It requires `permissions: id-token: write` on the calling job. AppRole is supported so a repository can adopt this action before migrating, and is skipped as soon as `secret_vault_jwt_role` is set — both sets of inputs can coexist during a migration.
+
+Both AppRole inputs are required together. Authenticating with only one of them cannot succeed, and the resulting failure would be reported as "could not read the secret", pointing at the Vault policy — the one place the problem is not.
+
+## Migrating from a vendored copy
+
+Delete `.github/actions/observe-build-status/` and point the workflow at this action. Input names match the majority of existing copies; two changes are usually needed:
+
+- add `ci_analytics_secret_path`, carrying over the path that was hardcoded in the vendored copy
+- drop `continue-on-error: true` from the call site, now redundant
+
+Expect reported durations to **increase** after migrating if the vendored copy anchored on `$GITHUB_ACTION_PATH`: the previous numbers excluded everything before the checkout.

--- a/observe-build-status/action.yml
+++ b/observe-build-status/action.yml
@@ -48,16 +48,21 @@ inputs:
       reporting entirely.
     required: false
   secret_vault_jwt_path:
-    description: Vault JWT auth mount path. JWT/OIDC authentication, preferred over AppRole.
+    description: |
+      Vault JWT auth mount path. Together with secret_vault_jwt_role and secret_vault_address it
+      forms a complete JWT credential set. vault-action would fall back to its own default mount
+      if omitted, but every JWT caller in the organisation passes it explicitly, so an empty
+      value is treated as a configuration mistake rather than an implicit default.
     required: false
   secret_vault_jwt_role:
     description: |
-      Vault JWT auth role. Setting it selects JWT authentication, and together with
-      secret_vault_address it forms a complete credential set. The calling job needs
+      Vault JWT auth role. Setting it selects JWT authentication. The calling job needs
       `permissions: id-token: write` so GitHub mints the OIDC token.
     required: false
   secret_vault_jwt_audience:
-    description: Vault JWT GitHub audience.
+    description: |
+      Vault JWT GitHub audience. Optional and not part of the completeness check: vault-action
+      applies a working default, and no existing caller sets it.
     required: false
   secret_vault_roleId:
     description: |
@@ -79,7 +84,7 @@ runs:
   # fork PR without secrets must degrade to "no metrics", never fail the job being measured.
   - name: Import CI Analytics secret (JWT)
     id: secrets-jwt
-    if: ${{ inputs.secret_vault_address != '' && inputs.secret_vault_jwt_role != '' && inputs.ci_analytics_secret_path != '' }}
+    if: ${{ inputs.secret_vault_address != '' && inputs.secret_vault_jwt_role != '' && inputs.secret_vault_jwt_path != '' && inputs.ci_analytics_secret_path != '' }}
     continue-on-error: true
     uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
     with:
@@ -117,11 +122,11 @@ runs:
     if: >-
       ${{ inputs.secret_vault_address != ''
       && (inputs.ci_analytics_secret_path == ''
-      || (inputs.secret_vault_jwt_role == ''
-      && !(inputs.secret_vault_roleId != '' && inputs.secret_vault_secretId != ''))) }}
+      || !((inputs.secret_vault_jwt_role != '' && inputs.secret_vault_jwt_path != '')
+      || (inputs.secret_vault_roleId != '' && inputs.secret_vault_secretId != ''))) }}
     shell: bash
     run: |
-      echo "::warning::Not sending CI health metrics: secret_vault_address is set but the configuration is incomplete. Provide ci_analytics_secret_path, plus either secret_vault_jwt_role (JWT, preferred) or both secret_vault_roleId and secret_vault_secretId (AppRole). Leave secret_vault_address empty to disable reporting on purpose."
+      echo "::warning::Not sending CI health metrics: secret_vault_address is set but the configuration is incomplete. Provide ci_analytics_secret_path, plus either both secret_vault_jwt_path and secret_vault_jwt_role (JWT, preferred) or both secret_vault_roleId and secret_vault_secretId (AppRole). Leave secret_vault_address empty to disable reporting on purpose."
 
   # Only reachable once a complete configuration was supplied, so this always means a real
   # failure: a Vault outage, or a role without a policy on ci_analytics_secret_path.
@@ -129,7 +134,7 @@ runs:
     if: >-
       ${{ inputs.secret_vault_address != ''
       && inputs.ci_analytics_secret_path != ''
-      && (inputs.secret_vault_jwt_role != ''
+      && ((inputs.secret_vault_jwt_role != '' && inputs.secret_vault_jwt_path != '')
       || (inputs.secret_vault_roleId != '' && inputs.secret_vault_secretId != ''))
       && steps.secrets-jwt.outputs.gcloud_sa_key == ''
       && steps.secrets-approle.outputs.gcloud_sa_key == '' }}

--- a/observe-build-status/action.yml
+++ b/observe-build-status/action.yml
@@ -37,9 +37,11 @@ inputs:
   ci_analytics_secret_path:
     description: |
       Vault path holding the CI Analytics Google service-account key under the gcloud_sa_key key.
-      Per-team by convention: secret/data/products/<product>/ci/ci-analytics. Required whenever
-      secret_vault_address is set.
-    required: true
+      Per-team by convention: secret/data/products/<product>/ci/ci-analytics. Needed whenever
+      secret_vault_address is set; omitting it there is reported as a configuration mistake.
+      Not marked required, so a caller that leaves secret_vault_address empty to disable
+      reporting does not have to pass it.
+    required: false
   secret_vault_address:
     description: |
       Vault server URL. It is the opt-in switch for this action: leave it empty to disable

--- a/observe-build-status/action.yml
+++ b/observe-build-status/action.yml
@@ -1,0 +1,178 @@
+---
+name: Observe Build Status
+
+description: |
+  Reports a job's outcome, duration and runner resource usage to CI Analytics.
+
+  Wraps start-build-monitor and submit-build-status so a caller needs two steps instead of a
+  vendored copy of the Vault plumbing. start-build-monitor must still be the FIRST step of the
+  job: it starts the resource sampler and writes /tmp/_monitor-start.pid, whose mtime this
+  action uses as the job-start anchor. Call this action LAST, with `if: always()`, so failed
+  and cancelled jobs are reported too.
+
+  Every step is best-effort: a Vault outage, a BigQuery error or an uncomputable duration is
+  reported as a warning and never fails the job being measured.
+
+  Authenticate with either JWT/OIDC (preferred: no long-lived credential) or AppRole. Leave
+  secret_vault_address empty to disable reporting entirely, so forks and local runs are
+  unaffected.
+
+inputs:
+  build_status:
+    description: 'Outcome of the job, normally ${{ job.status }}: one of success, failure, cancelled.'
+    required: true
+  job_name:
+    description: |
+      Value recorded in the job_name column. Defaults to $GITHUB_JOB when omitted, which is
+      ambiguous for matrix jobs: pass `${{ github.job }}/${{ matrix.<key> }}` so each matrix leg
+      is distinguishable. Use `/` as the separator, since matrix values routinely contain `-`.
+    required: false
+  user_reason:
+    description: Optional string (200 chars max) categorising why the job ended this way, e.g. flaky-tests.
+    required: false
+  user_description:
+    description: Optional string (1000 chars max) detailing user_reason, e.g. the list of flaky tests.
+    required: false
+
+  ci_analytics_secret_path:
+    description: |
+      Vault path holding the CI Analytics Google service-account key under the gcloud_sa_key key.
+      Per-team by convention: secret/data/products/<product>/ci/ci-analytics. Required whenever
+      secret_vault_address is set.
+    required: true
+  secret_vault_address:
+    description: |
+      Vault server URL. It is the opt-in switch for this action: leave it empty to disable
+      reporting entirely.
+    required: false
+  secret_vault_jwt_path:
+    description: Vault JWT auth mount path. JWT/OIDC authentication, preferred over AppRole.
+    required: false
+  secret_vault_jwt_role:
+    description: |
+      Vault JWT auth role. Setting it selects JWT authentication, and together with
+      secret_vault_address it forms a complete credential set. The calling job needs
+      `permissions: id-token: write` so GitHub mints the OIDC token.
+    required: false
+  secret_vault_jwt_audience:
+    description: Vault JWT GitHub audience.
+    required: false
+  secret_vault_roleId:
+    description: |
+      Vault AppRole role ID. Used only when secret_vault_jwt_role is empty, and only together
+      with secret_vault_secretId. Prefer JWT, which stores no long-lived credential as a
+      repository secret.
+    required: false
+  secret_vault_secretId:
+    description: Vault AppRole secret ID. See secret_vault_roleId.
+    required: false
+
+runs:
+  using: composite
+  steps:
+  # Composite actions cannot read the `secrets` context, so callers pass the Vault configuration
+  # as inputs and it resolves here through `inputs.*`.
+  #
+  # `continue-on-error` on both auth steps is deliberate: a Vault outage, a missing policy or a
+  # fork PR without secrets must degrade to "no metrics", never fail the job being measured.
+  - name: Import CI Analytics secret (JWT)
+    id: secrets-jwt
+    if: ${{ inputs.secret_vault_address != '' && inputs.secret_vault_jwt_role != '' && inputs.ci_analytics_secret_path != '' }}
+    continue-on-error: true
+    uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+    with:
+      url: ${{ inputs.secret_vault_address }}
+      method: jwt
+      path: ${{ inputs.secret_vault_jwt_path }}
+      role: ${{ inputs.secret_vault_jwt_role }}
+      jwtGithubAudience: ${{ inputs.secret_vault_jwt_audience }}
+      exportEnv: false # step outputs are enough; keep the key out of the job environment
+      secrets: |
+        ${{ inputs.ci_analytics_secret_path }} gcloud_sa_key;
+
+  # AppRole is the migration path for repositories that have not moved to OIDC yet. It is
+  # skipped as soon as a JWT role is configured, so a repository can carry both sets of inputs
+  # while it migrates. Both AppRole inputs are required: authenticating with half a credential
+  # set only produces a failure and a misleading "Vault read failed" warning.
+  - name: Import CI Analytics secret (AppRole)
+    id: secrets-approle
+    if: ${{ inputs.secret_vault_address != '' && inputs.secret_vault_jwt_role == '' && inputs.secret_vault_roleId != '' && inputs.secret_vault_secretId != '' && inputs.ci_analytics_secret_path != '' }}
+    continue-on-error: true
+    uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+    with:
+      url: ${{ inputs.secret_vault_address }}
+      method: approle
+      roleId: ${{ inputs.secret_vault_roleId }}
+      secretId: ${{ inputs.secret_vault_secretId }}
+      exportEnv: false # step outputs are enough; keep the key out of the job environment
+      secrets: |
+        ${{ inputs.ci_analytics_secret_path }} gcloud_sa_key;
+
+  # secret_vault_address is the opt-in switch, so setting it without everything else needed is a
+  # configuration mistake rather than an opt-out. Say so explicitly: silently doing nothing here
+  # would leave a repository believing it reports metrics when it does not.
+  - name: Check CI Analytics configuration
+    if: >-
+      ${{ inputs.secret_vault_address != ''
+      && (inputs.ci_analytics_secret_path == ''
+      || (inputs.secret_vault_jwt_role == ''
+      && !(inputs.secret_vault_roleId != '' && inputs.secret_vault_secretId != ''))) }}
+    shell: bash
+    run: |
+      echo "::warning::Not sending CI health metrics: secret_vault_address is set but the configuration is incomplete. Provide ci_analytics_secret_path, plus either secret_vault_jwt_role (JWT, preferred) or both secret_vault_roleId and secret_vault_secretId (AppRole). Leave secret_vault_address empty to disable reporting on purpose."
+
+  # Only reachable once a complete configuration was supplied, so this always means a real
+  # failure: a Vault outage, or a role without a policy on ci_analytics_secret_path.
+  - name: Check CI Analytics secret availability
+    if: >-
+      ${{ inputs.secret_vault_address != ''
+      && inputs.ci_analytics_secret_path != ''
+      && (inputs.secret_vault_jwt_role != ''
+      || (inputs.secret_vault_roleId != '' && inputs.secret_vault_secretId != ''))
+      && steps.secrets-jwt.outputs.gcloud_sa_key == ''
+      && steps.secrets-approle.outputs.gcloud_sa_key == '' }}
+    shell: bash
+    run: |
+      echo "::warning::Not sending CI health metrics: could not read gcloud_sa_key from ${{ inputs.ci_analytics_secret_path }}. Check that the Vault role has a policy on that path."
+
+  - name: Get build duration in milliseconds
+    id: duration
+    if: ${{ steps.secrets-jwt.outputs.gcloud_sa_key != '' || steps.secrets-approle.outputs.gcloud_sa_key != '' }}
+    continue-on-error: true # a duration we cannot compute must not fail the job being measured
+    shell: bash
+    run: |
+      set -euo pipefail
+
+      # start-build-monitor writes this file as its first action, so its mtime is the closest
+      # available proxy for the job start. Anchoring on anything else -- $GITHUB_ACTION_PATH, the
+      # checkout -- silently under-reports by however long setup, tool installation and image
+      # pulls took, and a wrong duration is worse than a missing one in a duration dashboard.
+      if [ ! -f /tmp/_monitor-start.pid ]; then
+        echo "::warning::Not sending build duration: start-build-monitor did not create /tmp/_monitor-start.pid. Is it the first step of this job?"
+        echo "result=" >> "$GITHUB_OUTPUT"
+        exit 0
+      fi
+
+      start=$(date -r /tmp/_monitor-start.pid +'%s')
+      now=$(date +'%s')
+      duration=$(( now - start ))
+
+      # Only submit plausible durations, between 0 and 72 hours.
+      if (( duration >= 0 && duration <= 259200 )); then
+        echo "result=$(( duration * 1000 ))" >> "$GITHUB_OUTPUT"
+      else
+        echo "::warning::Not sending build duration: computed ${duration}s, outside the expected range."
+        echo "result=" >> "$GITHUB_OUTPUT"
+      fi
+
+  - name: Submit build status
+    if: ${{ always() && (steps.secrets-jwt.outputs.gcloud_sa_key != '' || steps.secrets-approle.outputs.gcloud_sa_key != '') }}
+    continue-on-error: true # BigQuery or network trouble must not fail the job being measured
+    uses: camunda/infra-global-github-actions/submit-build-status@main
+    with:
+      job_name_override: ${{ inputs.job_name }}
+      build_status: ${{ inputs.build_status }}
+      build_duration_millis: ${{ steps.duration.outputs.result }}
+      user_reason: ${{ inputs.user_reason }}
+      user_description: ${{ inputs.user_description }}
+      gcp_credentials_json: ${{ steps.secrets-jwt.outputs.gcloud_sa_key || steps.secrets-approle.outputs.gcloud_sa_key }}


### PR DESCRIPTION
## Why

Eleven repositories in the org carry their own copy of `.github/actions/observe-build-status/` — the wrapper that glues [`start-build-monitor`](../start-build-monitor) and [`submit-build-status`](../submit-build-status) together with the Vault plumbing that fetches the CI Analytics credentials. They all descend from one original and have drifted. The wrapper belongs next to the two actions it wraps.

I inventoried all 868 repos in the org. The 11 copies:

| Repo | Vault path | Auth | Duration anchor | `vault-action` pin |
|---|---|---|---|---|
| `camunda/camunda` | `.../zeebe/...` | approle | **`$GITHUB_ACTION_PATH`** | SHA |
| `camunda/camunda-hub` | `.../web-modeler/...` | approle | **`$GITHUB_ACTION_PATH`** | SHA |
| `camunda/c8-cross-component-e2e-tests` | `.../qa/...` | approle | **`$GITHUB_ACTION_PATH`** | SHA (v3.0.0) |
| `camunda/c8-cross-component-sm-testing` | `.../qa/...` | approle | **`$GITHUB_ACTION_PATH`** | SHA (v3.0.0) |
| `camunda/infra-core` | `.../infra/...` | jwt | pid + fallback | SHA |
| `camunda/camunda-platform-helm` | `.../distribution/...` | jwt | pid + fallback | SHA |
| `camunda/camunda-docs` | `.../camunda-docs/...` | jwt | pid + fallback | **tag** |
| `camunda/identity` | `.../identity/...` | jwt | pid + fallback | **tag** |
| `camunda/camunda-optimize` | `.../optimize/...` | jwt | pid + fallback | **tag** |
| `camunda/camunda-cloud-management-apps` | `.../console/...` | jwt | pid + fallback | **tag** |
| `camunda/infraex-common-config` | `.../infrastructure-experience/...` | jwt + approle | pid, strict | SHA |

Exactly one pair is byte-identical (the two `c8-cross-component` repos). Everything else is unique.

The drift is not cosmetic:

- **Seven copies report wrong durations.** They anchor on `$GITHUB_ACTION_PATH` — either exclusively, or as a fallback when the timestamp file is missing. That is roughly checkout time, so every duration silently excludes job setup, tool installation and image pulls. No warning; the number just looks plausible and is too small. This action anchors strictly on `/tmp/_monitor-start.pid` and omits the field with a warning when it is absent, because a missing duration is better than a wrong one in a duration dashboard.
- **Four reference `hashicorp/vault-action` by mutable tag**, which is refused at `Set up job` in consumers enforcing GitHub's *Require actions to be pinned to a full-length commit SHA* setting.
- **`user_description` is documented as 200 chars in six copies**, 1000 in the rest. [`submit-build-status` accepts 1000](https://github.com/camunda/infra-global-github-actions/blob/main/submit-build-status/action.yml#L17-L19).
- **Most fail the job they exist to observe** if Vault or BigQuery has a bad day, unless the caller remembers `continue-on-error: true`.

There is also a generator keeping this going: `camunda/infra-core/.claude/skills/onboard-on-workflow-build-status/reference/observe-build-status-action.yml` scaffolds a fresh copy into any repo that lacks one, with `vault-action@v4.0.0` unpinned and the `$GITHUB_ACTION_PATH` fallback baked in. It is the source of six of the copies above and will keep minting more until it is repointed at this action.

## Design decisions

**The Vault secret path is an input.** Ten distinct values, one per product, and the only genuine per-repo difference. `secret/data/products/<product>/ci/ci-analytics` is the convention but is not hardcoded.

**Input names follow the majority of existing copies, not my preference.** The JWT names (`secret_vault_address`, `secret_vault_jwt_path`, `secret_vault_jwt_role`, `secret_vault_jwt_audience`) come from the six-copy scheme; the AppRole names (`secret_vault_roleId`, `secret_vault_secretId`, camelCase) from the four-copy one. Migrating is then mostly deleting the vendored directory and adding `ci_analytics_secret_path`.

**Both auth methods are supported**, and AppRole is skipped as soon as a JWT role is set — so a repository can adopt this action *before* migrating off AppRole, rather than being blocked on it. Both AppRole inputs are required together: authenticating with half a set cannot succeed, and the resulting failure would be reported as "could not read the secret", pointing at the Vault policy, which is the one place the problem is not.

**Every step is `continue-on-error`.** For an action consumed org-wide, "analytics never fails your build" should not depend on each caller remembering a flag.

**An incomplete configuration warns instead of doing nothing.** Treating a half-configured caller as an opt-out would let a repository believe it reports metrics when it does not; the warning names the missing input.

`camunda/camunda`'s copy also submits per-test statuses and resolves failing-test owners via `submit-test-status` and a codeowners CLI. That is beyond this wrapper, so that repo can only migrate the build-status half.

## Validation

- `pre-commit run --all-files` clean: `actionlint`, `zizmor`, shellcheck, renovate config validator.
- **Gate confirmed to cover the new file**, rather than assumed: replacing the `vault-action` SHA with `@v4.0.0` makes `zizmor` fail on `observe-build-status/action.yml:82` and `:101` with `unpinned-uses`, and the file is clean again once restored.
- YAML parsed and every step condition evaluated for the five input combinations (no Vault, complete JWT, complete AppRole, partial AppRole, missing path) — partial configurations reach the configuration warning and never attempt authentication.
- The step sequence is the one already proven end-to-end in [camunda/keycloak run 31689628694](https://github.com/camunda/keycloak/actions/runs/31689628694): Vault read, `job_name` `build-image/26-hub`, `build_duration_milliseconds` `428000`, BigQuery `tableDataInsertAllResponse` with no `insertErrors`.
- Registered in `release-please-config.json` and the manifest, so it gets a version like every other action here.

## Disclosure

I released the same action in `camunda/infraex-common-config` earlier today ([2.3.0](https://github.com/camunda/infraex-common-config/releases/tag/2.3.0)), scoped to the InfraEx fleet where the Vault path is a constant. The org-wide inventory above then showed the fan-out is not InfraEx-specific and that the wrapper's two dependencies both live here, which makes this the better home. If this lands, that copy becomes a deprecation candidate and I will raise the follow-up to point InfraEx repositories here instead. No repository consumes it yet, so nothing breaks.

## Follow-ups (not in this PR)

- repoint or retire the `infra-core` scaffolding skill, otherwise new copies keep appearing
- migrate the eleven repositories, starting with the four whose durations are wrong
- deprecate the `infraex-common-config` copy
