### PR TITLE
fix(renovate): match the actual packageName for pre-commit automerge

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -84,7 +84,10 @@
         "kubernetes-sigs/gateway-api",
         "public.ecr.aws/gravitational/teleport-ent-distroless",
         "fossas/fossa-cli",
-        "pre-commit",
+        // the pre-commit tool itself (.tool-versions), resolved by Renovate's
+        // asdf manager via the github-tags datasource with this packageName,
+        // not the bare "pre-commit" string
+        "pre-commit/pre-commit",
       ],
       addLabels: ["automerge"],
       automerge: true,
@@ -92,7 +95,7 @@
     {
       matchUpdateTypes: ["minor"],
       matchPackageNames: [
-        "pre-commit",
+        "pre-commit/pre-commit",
       ],
       addLabels: ["automerge"],
       automerge: true,


### PR DESCRIPTION
## Summary

[PR #786](https://github.com/camunda/infra-global-github-actions/pull/786) (`pre-commit` 4.6.1 → 4.6.2, a patch update) was not automerged, even though `pre-commit` already appeared in the patch and minor automerge `packageRules`.

The root cause: Renovate's `asdf` manager resolves the `pre-commit` tool (tracked in `.tool-versions`) via the `github-tags` datasource with `packageName: "pre-commit/pre-commit"` — not the bare string `"pre-commit"` (verified against Renovate's [`upgradeable-tooling.ts`](https://github.com/renovatebot/renovate/blob/main/lib/modules/manager/asdf/upgradeable-tooling.ts)). `matchPackageNames` does exact-string matching unless the entry is wrapped in `/regex/` delimiters, so `"pre-commit"` never matched and every `pre-commit` tool-version bump required a manual merge.

This updates both the patch and minor `pre-commit` automerge rules to match on `"pre-commit/pre-commit"` instead.

## Test plan

- [x] Validated the config with `npx renovate-config-validator --strict .github/renovate.json5` (same tool the repo's `pre-commit` hook runs) — passes.
- [x] Cross-checked the expected `packageName` against Renovate's own asdf tooling registry.
- [ ] Confirm the next `pre-commit` tool-version PR automerges.


---
_Generated by [Claude Code](https://claude.ai/code/session_011vsLgaMBjpPwcbbPPUwep9)_