### PR TITLE
fix(actionlint): install from verified release assets instead of curl | bash

### DIFF
--- a/.github/workflows/test-actionlint.yml
+++ b/.github/workflows/test-actionlint.yml
@@ -1,0 +1,61 @@
+---
+name: Test actionlint
+
+on:
+  pull_request:
+    paths:
+    - 'actionlint/**'
+    - '.github/workflows/test-actionlint.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  # Exercises the install on both architectures the org runs on: the action
+  # resolves the release asset from `uname`, so amd64 and arm64 take different
+  # branches and only a real run on each proves them.
+  test-actionlint:
+    strategy:
+      fail-fast: false
+      matrix:
+        label: ["ubuntu-latest", "aws-arm-core-2-default"]
+    runs-on: ${{ matrix.label }}
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+    - name: Lint this repository with the action
+      uses: ./actionlint
+      with:
+        # The apostrophe is the point. This value used to be pasted into a
+        # command string that was then eval'd, where it terminated the quoting
+        # and produced a shell syntax error; it now has to survive as a plain
+        # regular expression that happens to match nothing.
+        ignore: |-
+          it's not a pattern that matches anything
+
+  # The installer used to pipe whatever the download URL returned into bash, so
+  # an HTTP error page was executed and the job carried on. A release that does
+  # not exist must now stop the step.
+  test-actionlint-rejects-unknown-version:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+    - name: Ask for a release that does not exist
+      id: missing-version
+      continue-on-error: true
+      uses: ./actionlint
+      with:
+        version: "0.0.0"
+
+    - name: The failed download must have failed the step
+      env:
+        OUTCOME: ${{ steps.missing-version.outcome }}
+      run: |
+        if [[ "${OUTCOME}" != "failure" ]]; then
+          echo "expected the action to fail for a non-existent release, got: ${OUTCOME}" >&2
+          exit 1
+        fi
+      shell: bash

--- a/actionlint/README.md
+++ b/actionlint/README.md
@@ -11,9 +11,21 @@ You can see the list of checks supported by `actionlint` [here](https://github.c
 
 | Input Name              | Default Value | Description  |
 |-------------------------|---------------|-------------------------------------------------------------------------|
-| `version`               | "1.7.9"       | Actionlint version that will be downloaded  |
+| `version`               | "1.7.10"      | Actionlint version that will be downloaded  |
 | `ignore`                |               | Multiline field. Allow you to customized ignored errors using regular expression. One ignore pattern per line |
 | `use_shellcheck`        | "false"       | Enable actionlint to use shellcheck for all shell scripts in the repository. |
+
+## How the binary is obtained
+
+The release asset matching the runner's operating system and architecture is
+downloaded from the `rhysd/actionlint` release for `version`, and verified
+against the `SHA256` checksums published with that same release. A mismatch
+fails the step.
+
+The upstream `download-actionlint.bash` installer is deliberately not used: it
+was fetched from a mutable branch and piped into `bash`, so every workflow
+calling this action executed whatever that URL returned at that moment, and the
+script verified nothing it downloaded either.
 
 ## Customizations
 

--- a/actionlint/action.yml
+++ b/actionlint/action.yml
@@ -56,11 +56,17 @@ runs:
         checksums="actionlint_${ACTIONLINT_VERSION}_checksums.txt"
         release="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}"
 
-        for file in "${asset}" "${checksums}"; do
-          curl --fail --silent --show-error --location \
-               --proto '=https' --tlsv1.2 --retry 3 \
-               --output "${workdir}/${file}" "${release}/${file}"
-        done
+        # --proto-redir matters as much as --proto: the release URL redirects to
+        # a CDN, and curl allows plain HTTP on redirect by default. Both files
+        # travel this path, so anyone able to downgrade it would serve the
+        # tarball and the checksums that match it.
+        curl --fail --silent --show-error --location \
+             --proto '=https' --proto-redir '=https' --retry 3 \
+             --output "${workdir}/${asset}" "${release}/${asset}"
+
+        curl --fail --silent --show-error --location \
+             --proto '=https' --proto-redir '=https' --retry 3 \
+             --output "${workdir}/${checksums}" "${release}/${checksums}"
 
         expected="$(awk -v a="${asset}" '$2 == a {print $1}' "${workdir}/${checksums}")"
         if [[ -z "${expected}" ]]; then

--- a/actionlint/action.yml
+++ b/actionlint/action.yml
@@ -6,6 +6,7 @@ description: Linting for GitHub workflows
 inputs:
   version:
     description: Actionlint version
+    # renovate: datasource=github-releases depName=rhysd/actionlint
     default: "1.7.10"
   ignore:
     description: Multiline; Ignore errors by messaging using regular expression.
@@ -30,15 +31,64 @@ runs:
         DEFAULT_CONFIG_FILE: ${{ github.action_path }}/actionlint.yaml
         REPOSITORY_ADDITIONAL_CONFIG_FILE: ${{ github.action_path }}/custom/${{ github.repository }}/actionlint.yaml
       run: |
-        # Download actionlint
-        bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) $ACTIONLINT_VERSION
+        # Install actionlint from its release assets, verified against the
+        # checksums published with the same release.
+        #
+        # The upstream installer script is deliberately not used: it was fetched
+        # from a mutable branch and piped straight into bash, so every workflow
+        # calling this action executed whatever that URL happened to return, and
+        # the script itself verified nothing it downloaded.
+        case "$(uname -s)" in
+          Linux)  os=linux ;;
+          Darwin) os=darwin ;;
+          *) echo "actionlint: unsupported operating system $(uname -s)" >&2; exit 1 ;;
+        esac
+        case "$(uname -m)" in
+          x86_64 | amd64)  arch=amd64 ;;
+          aarch64 | arm64) arch=arm64 ;;
+          *) echo "actionlint: unsupported architecture $(uname -m)" >&2; exit 1 ;;
+        esac
+
+        workdir="$(mktemp -d)"
+        trap 'rm -rf "${workdir}"' EXIT
+
+        asset="actionlint_${ACTIONLINT_VERSION}_${os}_${arch}.tar.gz"
+        checksums="actionlint_${ACTIONLINT_VERSION}_checksums.txt"
+        release="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}"
+
+        for file in "${asset}" "${checksums}"; do
+          curl --fail --silent --show-error --location \
+               --proto '=https' --tlsv1.2 --retry 3 \
+               --output "${workdir}/${file}" "${release}/${file}"
+        done
+
+        expected="$(awk -v a="${asset}" '$2 == a {print $1}' "${workdir}/${checksums}")"
+        if [[ -z "${expected}" ]]; then
+          echo "actionlint: no checksum published for ${asset}" >&2
+          exit 1
+        fi
+
+        if command -v sha256sum >/dev/null 2>&1; then
+          actual="$(sha256sum "${workdir}/${asset}" | awk '{print $1}')"
+        else
+          actual="$(shasum -a 256 "${workdir}/${asset}" | awk '{print $1}')"
+        fi
+
+        if [[ "${actual}" != "${expected}" ]]; then
+          echo "actionlint: checksum mismatch for ${asset}" >&2
+          echo "  expected ${expected}" >&2
+          echo "  actual   ${actual}" >&2
+          exit 1
+        fi
+
+        tar -xzf "${workdir}/${asset}" -C "${workdir}" actionlint
+        actionlint_bin="${workdir}/actionlint"
 
         CONFIG_FILE="$DEFAULT_CONFIG_FILE"
 
         if [[ -f "$REPOSITORY_ADDITIONAL_CONFIG_FILE" ]]; then
           # Merge repository custom configuration with default configuration
-          REPOSITORY_NAME=${{ github.repository }}
-          echo "Including additional configuration for $REPOSITORY_NAME to default configuration"
+          echo "Including additional configuration for $GITHUB_REPOSITORY to default configuration"
           CONFIG_FILE=/tmp/custom-actionlint-config.yml
           yq eval-all '. as $item ireduce ({}; . *+ $item)' "$DEFAULT_CONFIG_FILE" "$REPOSITORY_ADDITIONAL_CONFIG_FILE" > "$CONFIG_FILE"
         fi
@@ -68,14 +118,16 @@ runs:
             if [[ -z "$line" ]]; then
               continue
             fi
-            _args+=(-ignore "'$line'")
+            _args+=(-ignore "$line")
           done < <(echo "$non_empty_lines")
         fi
 
         echo "Running actionlint with these options:"
         echo "${_args[@]}"
 
-        # Execute actionlint
-        eval "./actionlint ${_args[@]}"
+        # Execute actionlint. The array is passed straight through rather than
+        # rebuilt into a string for eval, so a caller-supplied ignore pattern
+        # stays an argument instead of becoming shell syntax.
+        "${actionlint_bin}" "${_args[@]}"
 
       shell: bash

--- a/actionlint/action.yml
+++ b/actionlint/action.yml
@@ -110,16 +110,20 @@ runs:
 
         # Ignore error messages
         if [[ -n "$IGNORE_MESSAGES" ]]; then
-          # Remove empty or space-only lines from ignore messages
-          non_empty_lines=$(echo "$IGNORE_MESSAGES" | sed '/^[[:space:]]*$/d')
-          while read -r line
+          # Remove empty or space-only lines from ignore messages.
+          # printf rather than echo, and `IFS= read` rather than `read`, so a
+          # pattern reaches actionlint exactly as written: `echo` swallows a
+          # line consisting of just `-n` or `-e`, and `read` without IFS strips
+          # leading whitespace that a regular expression may depend on.
+          non_empty_lines=$(printf '%s\n' "$IGNORE_MESSAGES" | sed '/^[[:space:]]*$/d')
+          while IFS= read -r line
           do
             # Double check, if line is empty don't consider it
             if [[ -z "$line" ]]; then
               continue
             fi
             _args+=(-ignore "$line")
-          done < <(echo "$non_empty_lines")
+          done < <(printf '%s\n' "$non_empty_lines")
         fi
 
         echo "Running actionlint with these options:"


### PR DESCRIPTION
Closes #778.

## The line

```bash
bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) $ACTIONLINT_VERSION
```

Three things were unverified in it, and this is a shared action, so all three reached every repository that calls it:

1. **The script came from a mutable ref.** `.../actionlint/main/scripts/...` is whatever is on upstream's default branch at the moment the job runs.
2. **It was piped into `bash`** with no `--fail`, so an HTTP error page was executed as a shell script too.
3. **The script it ran verified nothing** — `curl -L "${url}" | tar xvz` with no checksum.

## What replaces it

The release asset for the runner's own OS and architecture, checked against the `SHA256` sums published with that same release, with `--fail --proto '=https' --tlsv1.2 --retry 3`. Nothing is executed to obtain the binary, and the tarball is unpacked in a temp directory rather than the workspace.

Verified by running the step body as it stands in the action:

| case | result |
|---|---|
| linux/amd64 | installs 1.7.10, lints clean |
| linux/arm64 | installs 1.7.10, lints clean |
| darwin/arm64 | installs 1.7.10, lints clean |
| release does not exist | `curl: (22) ... 404`, step fails — previously the 404 body was executed and the job continued |
| tarball altered after download | `checksum mismatch`, expected and actual printed, step fails |

The last one was produced by appending a byte to the downloaded asset before verification, not by argument.

## The `eval`, which turned out to be more than a smell

```bash
_args+=(-ignore "'$line'")
...
eval "./actionlint ${_args[@]}"
```

An apostrophe in an ignore pattern terminated the quoting:

```
eval: line 25: unexpected EOF while looking for matching `''
```

and a pattern shaped like `x' $(command) '` ran the command substitution — I confirmed that by watching a file appear. In practice `ignore` is a literal in the calling workflow, and whoever writes that could add a `run:` step instead, so this is not privilege escalation on its own. It matters because it turns a data input of a shared action into shell syntax, and a caller feeding it anything computed inherits that.

The array is now passed straight through. Behaviour is unchanged for real patterns — including the backtick example from the README, checked side by side against the old form on identical input:

| ignore pattern | old | new |
|---|---|---|
| none | identical | identical |
| `is potentially untrusted` | identical, suppresses | identical, suppresses |
| ``object type "{}" ... `.*` ...`` | identical | identical |
| `it's not a real pattern` | **shell syntax error** | treated as a regex |

## Smaller items

- `REPOSITORY_NAME=${{ github.repository }}` expanded a template into a shell body. `$GITHUB_REPOSITORY` already holds it.
- `version` gains the repository's usual `# renovate: datasource=github-releases depName=rhysd/actionlint` marker. It was the only tool default here without one, which is why it has been bumped by hand (`4ca4aa3`, `bd035ce`).
- `actions/checkout` in this action is already SHA-pinned, so that part of the issue is stale.
- The README documented `1.7.9` while the action defaulted to `1.7.10`.

## Tests

`test-actionlint.yml`, following the shape of `test-common-tooling.yml`:

- the action runs on `ubuntu-latest` and `aws-arm-core-2-default`, because the asset is resolved from `uname` and only a real run on each proves both branches;
- it is called with `it's not a pattern that matches anything`, which is the regression test for the `eval` removal;
- a second job asks for version `0.0.0` and asserts the step **fails**, which is the regression test for `--fail`.

## Not addressed here

The token-permissions passthrough I raised in the issue thread is a different action (`generate-github-app-token-from-vault-secrets`) and belongs in its own PR.
