### PR TITLE
feat(app-token): let callers narrow what the token may do

### DIFF
--- a/.github/workflows/test-generate-github-app-token-from-vault-secrets.yml
+++ b/.github/workflows/test-generate-github-app-token-from-vault-secrets.yml
@@ -1,0 +1,28 @@
+---
+name: Test generate-github-app-token-from-vault-secrets
+
+on:
+  pull_request:
+    paths:
+    - 'generate-github-app-token-from-vault-secrets/**'
+    - '.github/workflows/test-generate-github-app-token-from-vault-secrets.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  # Only the `permissions` validation is covered. The rest of the action needs
+  # Vault and a GitHub App, so it cannot run here — and driving the validation
+  # through the action would not test it either: a rejection and a later Vault
+  # failure both surface as "the step failed", so the assertion would stay green
+  # if the validation stopped rejecting anything.
+  test-permissions-validation:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+    - name: Validate the permissions input
+      run: |
+        ./generate-github-app-token-from-vault-secrets/validate-permissions_test.sh
+      shell: bash

--- a/generate-github-app-token-from-vault-secrets/README.md
+++ b/generate-github-app-token-from-vault-secrets/README.md
@@ -59,11 +59,12 @@ An unrecognised key is an error rather than a silent no-op, because a dropped sc
 leave the caller believing the token was narrowed when it was not:
 
 ```
-::error::Unknown permission scope(s): contnets
+::error::unknown permission scope(s): contnets
 ```
 
 Omitting the input entirely keeps the previous behaviour: the token inherits every
-permission the App holds.
+permission the App holds — and is also why `jq`, which the validation uses, is only
+required of callers that actually pass `permissions`.
 
 ### Workflow Example
 ```yaml

--- a/generate-github-app-token-from-vault-secrets/README.md
+++ b/generate-github-app-token-from-vault-secrets/README.md
@@ -23,6 +23,7 @@ This composite GHA can be used in any repository.
 | skip-token-revoke                   | If truthy, the token will not be revoked when the current job is complete (optional) |
 | owner                               | The owner of the GitHub App installation (defaults to current repository owner, optional). |
 | repositories                        | Comma or newline-separated list of repositories for which the GitHub app token will be valid for(defaults to current repository if owner is unset, optional). If you want to generate a token that has access to all repositories of the owner, set this to `!all` and explicitely set an `owner`. |
+| permissions                         | JSON object narrowing what the token may do, e.g. `{"contents": "read"}` (optional, defaults to every permission the App holds). See [Permissions](#permissions). |
 
 > (*) Supports both App Role (`vault-auth-method=approle`) and GitHub OIDC/JWT
 > (`vault-auth-method=jwt`) authentication. When using `jwt`, the calling job
@@ -34,6 +35,35 @@ This composite GHA can be used in any repository.
 | token            | The generated GitHub token        |
 | installation-id  | GitHub App installation ID        |
 | app-slug         | GitHub App slug                   |
+
+### Permissions
+
+`repositories` scopes **which repositories** the token reaches. `permissions` scopes
+**what it may do** to them. Without the second, a token minted for one narrow purpose
+still carries everything the App holds on those repositories.
+
+```yaml
+    - uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
+      with:
+        # ... vault inputs ...
+        repositories: infraex-common-config
+        permissions: '{"issues": "read", "actions": "write"}'
+```
+
+Keys are the scope names accepted by
+[`actions/create-github-app-token`](https://github.com/actions/create-github-app-token)
+with the `permission-` prefix removed, so `permission-pull-requests` is written
+`pull-requests`. Values are the usual `read`, `write` or `admin`, depending on the scope.
+
+An unrecognised key is an error rather than a silent no-op, because a dropped scope would
+leave the caller believing the token was narrowed when it was not:
+
+```
+::error::Unknown permission scope(s): contnets
+```
+
+Omitting the input entirely keeps the previous behaviour: the token inherits every
+permission the App holds.
 
 ### Workflow Example
 ```yaml

--- a/generate-github-app-token-from-vault-secrets/action.yml
+++ b/generate-github-app-token-from-vault-secrets/action.yml
@@ -65,6 +65,16 @@ inputs:
     description: "Comma or newline-separated list of repositories to install the GitHub App on (defaults to current repository if owner is unset). If you want to generate a token that has access to all repositories of the owner, set this to '!all' and explicitely set an `owner`."
     required: false
     type: string
+  permissions:
+    description: >
+      JSON object narrowing what the token may do, for example
+      '{"contents": "read", "issues": "read"}'. Keys are the scope names accepted by
+      actions/create-github-app-token without the `permission-` prefix, and unknown keys
+      are rejected rather than ignored. When omitted, the token inherits every permission
+      the App holds, which is the behaviour callers had before this input existed.
+    required: false
+    default: ""
+    type: string
 
 outputs:
   token:
@@ -122,6 +132,13 @@ runs:
         echo "::error::Conflicting input(s) for vault-auth-method='${VAULT_AUTH_METHOD}': ${conflicting[*]} must not be set (provide only the inputs for the selected auth method)"
         exit 1
       fi
+
+  - name: Validate the requested permissions
+    shell: bash
+    env:
+      PERMISSIONS: ${{ inputs.permissions }}
+    run: |
+      "${{ github.action_path }}/validate-permissions.sh" "${PERMISSIONS}"
 
   - name: Import the GitHub App ID from vault
     id: app-id
@@ -193,3 +210,57 @@ runs:
       skip-token-revoke: ${{ inputs.skip-token-revoke }}
       owner: ${{ inputs.owner }}
       repositories: ${{ env.repositories }}
+      permission-actions: ${{ fromJSON(inputs.permissions || '{}')['actions'] }}
+      permission-administration: ${{ fromJSON(inputs.permissions || '{}')['administration'] }}
+      permission-artifact-metadata: ${{ fromJSON(inputs.permissions || '{}')['artifact-metadata'] }}
+      permission-attestations: ${{ fromJSON(inputs.permissions || '{}')['attestations'] }}
+      permission-checks: ${{ fromJSON(inputs.permissions || '{}')['checks'] }}
+      permission-codespaces: ${{ fromJSON(inputs.permissions || '{}')['codespaces'] }}
+      permission-contents: ${{ fromJSON(inputs.permissions || '{}')['contents'] }}
+      permission-custom-properties-for-organizations: ${{ fromJSON(inputs.permissions || '{}')['custom-properties-for-organizations'] }}
+      permission-dependabot-secrets: ${{ fromJSON(inputs.permissions || '{}')['dependabot-secrets'] }}
+      permission-deployments: ${{ fromJSON(inputs.permissions || '{}')['deployments'] }}
+      permission-discussions: ${{ fromJSON(inputs.permissions || '{}')['discussions'] }}
+      permission-email-addresses: ${{ fromJSON(inputs.permissions || '{}')['email-addresses'] }}
+      permission-enterprise-custom-properties-for-organizations: ${{ fromJSON(inputs.permissions || '{}')['enterprise-custom-properties-for-organizations'] }}
+      permission-environments: ${{ fromJSON(inputs.permissions || '{}')['environments'] }}
+      permission-followers: ${{ fromJSON(inputs.permissions || '{}')['followers'] }}
+      permission-git-ssh-keys: ${{ fromJSON(inputs.permissions || '{}')['git-ssh-keys'] }}
+      permission-gpg-keys: ${{ fromJSON(inputs.permissions || '{}')['gpg-keys'] }}
+      permission-interaction-limits: ${{ fromJSON(inputs.permissions || '{}')['interaction-limits'] }}
+      permission-issues: ${{ fromJSON(inputs.permissions || '{}')['issues'] }}
+      permission-members: ${{ fromJSON(inputs.permissions || '{}')['members'] }}
+      permission-merge-queues: ${{ fromJSON(inputs.permissions || '{}')['merge-queues'] }}
+      permission-metadata: ${{ fromJSON(inputs.permissions || '{}')['metadata'] }}
+      permission-organization-administration: ${{ fromJSON(inputs.permissions || '{}')['organization-administration'] }}
+      permission-organization-announcement-banners: ${{ fromJSON(inputs.permissions || '{}')['organization-announcement-banners'] }}
+      permission-organization-copilot-seat-management: ${{ fromJSON(inputs.permissions || '{}')['organization-copilot-seat-management'] }}
+      permission-organization-custom-org-roles: ${{ fromJSON(inputs.permissions || '{}')['organization-custom-org-roles'] }}
+      permission-organization-custom-properties: ${{ fromJSON(inputs.permissions || '{}')['organization-custom-properties'] }}
+      permission-organization-custom-roles: ${{ fromJSON(inputs.permissions || '{}')['organization-custom-roles'] }}
+      permission-organization-events: ${{ fromJSON(inputs.permissions || '{}')['organization-events'] }}
+      permission-organization-hooks: ${{ fromJSON(inputs.permissions || '{}')['organization-hooks'] }}
+      permission-organization-packages: ${{ fromJSON(inputs.permissions || '{}')['organization-packages'] }}
+      permission-organization-personal-access-token-requests: ${{ fromJSON(inputs.permissions || '{}')['organization-personal-access-token-requests'] }}
+      permission-organization-personal-access-tokens: ${{ fromJSON(inputs.permissions || '{}')['organization-personal-access-tokens'] }}
+      permission-organization-plan: ${{ fromJSON(inputs.permissions || '{}')['organization-plan'] }}
+      permission-organization-projects: ${{ fromJSON(inputs.permissions || '{}')['organization-projects'] }}
+      permission-organization-secrets: ${{ fromJSON(inputs.permissions || '{}')['organization-secrets'] }}
+      permission-organization-self-hosted-runners: ${{ fromJSON(inputs.permissions || '{}')['organization-self-hosted-runners'] }}
+      permission-organization-user-blocking: ${{ fromJSON(inputs.permissions || '{}')['organization-user-blocking'] }}
+      permission-packages: ${{ fromJSON(inputs.permissions || '{}')['packages'] }}
+      permission-pages: ${{ fromJSON(inputs.permissions || '{}')['pages'] }}
+      permission-profile: ${{ fromJSON(inputs.permissions || '{}')['profile'] }}
+      permission-pull-requests: ${{ fromJSON(inputs.permissions || '{}')['pull-requests'] }}
+      permission-repository-custom-properties: ${{ fromJSON(inputs.permissions || '{}')['repository-custom-properties'] }}
+      permission-repository-hooks: ${{ fromJSON(inputs.permissions || '{}')['repository-hooks'] }}
+      permission-repository-projects: ${{ fromJSON(inputs.permissions || '{}')['repository-projects'] }}
+      permission-secret-scanning-alerts: ${{ fromJSON(inputs.permissions || '{}')['secret-scanning-alerts'] }}
+      permission-secrets: ${{ fromJSON(inputs.permissions || '{}')['secrets'] }}
+      permission-security-events: ${{ fromJSON(inputs.permissions || '{}')['security-events'] }}
+      permission-single-file: ${{ fromJSON(inputs.permissions || '{}')['single-file'] }}
+      permission-starring: ${{ fromJSON(inputs.permissions || '{}')['starring'] }}
+      permission-statuses: ${{ fromJSON(inputs.permissions || '{}')['statuses'] }}
+      permission-team-discussions: ${{ fromJSON(inputs.permissions || '{}')['team-discussions'] }}
+      permission-vulnerability-alerts: ${{ fromJSON(inputs.permissions || '{}')['vulnerability-alerts'] }}
+      permission-workflows: ${{ fromJSON(inputs.permissions || '{}')['workflows'] }}

--- a/generate-github-app-token-from-vault-secrets/validate-permissions.sh
+++ b/generate-github-app-token-from-vault-secrets/validate-permissions.sh
@@ -12,8 +12,17 @@ set -euo pipefail
 PERMISSIONS="${1:-}"
 
 # Nothing to check: the token inherits every permission the App holds, which is
-# what callers got before this input existed.
+# what callers got before this input existed. Kept above the jq dependency
+# below, so a caller that does not use `permissions` needs nothing new.
 [[ -z "${PERMISSIONS}" ]] && exit 0
+
+# Without this, a missing jq surfaces as "not valid JSON" — the check below runs
+# `jq` and reads its non-zero exit as a verdict on the input rather than as the
+# command being absent.
+if ! command -v jq >/dev/null 2>&1; then
+  echo "::error::the 'permissions' input needs jq, which is not installed on this runner"
+  exit 1
+fi
 
 KNOWN_SCOPES=(
   actions

--- a/generate-github-app-token-from-vault-secrets/validate-permissions.sh
+++ b/generate-github-app-token-from-vault-secrets/validate-permissions.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Validates the `permissions` input of the composite action.
+#
+# Kept in a file rather than inline so it can be exercised directly. Through the
+# action, a rejection and a later Vault failure both surface as "the step
+# failed", so an end-to-end assertion cannot tell them apart and would go green
+# even if this stopped rejecting anything.
+#
+# Usage: validate-permissions.sh '<json>'
+set -euo pipefail
+
+PERMISSIONS="${1:-}"
+
+# Nothing to check: the token inherits every permission the App holds, which is
+# what callers got before this input existed.
+[[ -z "${PERMISSIONS}" ]] && exit 0
+
+KNOWN_SCOPES=(
+  actions
+  administration
+  artifact-metadata
+  attestations
+  checks
+  codespaces
+  contents
+  custom-properties-for-organizations
+  dependabot-secrets
+  deployments
+  discussions
+  email-addresses
+  enterprise-custom-properties-for-organizations
+  environments
+  followers
+  git-ssh-keys
+  gpg-keys
+  interaction-limits
+  issues
+  members
+  merge-queues
+  metadata
+  organization-administration
+  organization-announcement-banners
+  organization-copilot-seat-management
+  organization-custom-org-roles
+  organization-custom-properties
+  organization-custom-roles
+  organization-events
+  organization-hooks
+  organization-packages
+  organization-personal-access-token-requests
+  organization-personal-access-tokens
+  organization-plan
+  organization-projects
+  organization-secrets
+  organization-self-hosted-runners
+  organization-user-blocking
+  packages
+  pages
+  profile
+  pull-requests
+  repository-custom-properties
+  repository-hooks
+  repository-projects
+  secret-scanning-alerts
+  secrets
+  security-events
+  single-file
+  starring
+  statuses
+  team-discussions
+  vulnerability-alerts
+  workflows
+)
+
+if ! jq -e . >/dev/null 2>&1 <<<"${PERMISSIONS}"; then
+  echo "::error::the 'permissions' input is not valid JSON: ${PERMISSIONS}"
+  exit 1
+fi
+
+if [[ "$(jq -r 'type' <<<"${PERMISSIONS}")" != "object" ]]; then
+  echo "::error::the 'permissions' input must be a JSON object, for example {\"contents\": \"read\"}"
+  exit 1
+fi
+
+known_json="$(printf '%s\n' "${KNOWN_SCOPES[@]}" | jq -Rn '[inputs]')"
+
+# A scope this action does not forward would otherwise be dropped in silence,
+# and the caller would believe the token was narrowed when it was not.
+unknown="$(jq -r --argjson known "${known_json}" \
+  '[keys[] | select(. as $k | $known | index($k) | not)] | join(", ")' <<<"${PERMISSIONS}")"
+
+if [[ -n "${unknown}" ]]; then
+  echo "::error::unknown permission scope(s): ${unknown}"
+  printf 'Accepted scopes: %s\n' "${KNOWN_SCOPES[*]}" >&2
+  exit 1
+fi

--- a/generate-github-app-token-from-vault-secrets/validate-permissions_test.sh
+++ b/generate-github-app-token-from-vault-secrets/validate-permissions_test.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Exercises validate-permissions.sh.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="${SCRIPT:-$HERE/validate-permissions.sh}"
+PASS=0
+FAIL=0
+
+check() { # check <label> <expected-rc> <permissions> [expected substring]
+  local label="$1" want="$2" perms="$3" needle="${4:-}"
+  local out rc
+  out="$("$SCRIPT" "$perms" 2>&1)"
+  rc=$?
+
+  if [[ "$rc" != "$want" ]]; then
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label — expected rc=$want, got rc=$rc"
+    echo "        output: $out"
+    return
+  fi
+
+  if [[ -n "$needle" ]] && ! grep -qF "$needle" <<<"$out"; then
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label — expected output to contain: $needle"
+    echo "        output: $out"
+    return
+  fi
+
+  PASS=$((PASS + 1))
+}
+
+echo "bash $BASH_VERSION"
+
+# Omitted or empty: the token inherits the App's permissions, as before.
+check "empty input"            0 ""
+check "empty object"           0 '{}'
+
+# Accepted.
+check "one scope"              0 '{"contents": "read"}'
+check "several scopes"         0 '{"contents": "read", "issues": "read", "pull-requests": "write"}'
+check "a dashed scope"         0 '{"organization-secrets": "read"}'
+
+# Every scope the wrapper forwards must be accepted, or the list in the script
+# has drifted from the one in the action.
+all="$(jq -n --args '$ARGS.positional | map({(.): "read"}) | add' \
+  actions administration artifact-metadata attestations checks codespaces contents \
+  custom-properties-for-organizations dependabot-secrets deployments discussions \
+  email-addresses enterprise-custom-properties-for-organizations environments followers \
+  git-ssh-keys gpg-keys interaction-limits issues members merge-queues metadata \
+  organization-administration organization-announcement-banners \
+  organization-copilot-seat-management organization-custom-org-roles \
+  organization-custom-properties organization-custom-roles organization-events \
+  organization-hooks organization-packages organization-personal-access-token-requests \
+  organization-personal-access-tokens organization-plan organization-projects \
+  organization-secrets organization-self-hosted-runners organization-user-blocking \
+  packages pages profile pull-requests repository-custom-properties repository-hooks \
+  repository-projects secret-scanning-alerts secrets security-events single-file \
+  starring statuses team-discussions vulnerability-alerts workflows)"
+check "all 54 scopes"          0 "$all"
+
+# Rejected. The typo case is the reason this validation exists: the wrapper
+# cannot forward a scope it does not know, so without this it would be dropped
+# and the caller would think the token was narrowed.
+check "a misspelled scope"     1 '{"contnets": "read"}'          "unknown permission scope(s): contnets"
+check "underscores not dashes" 1 '{"pull_requests": "write"}'    "unknown permission scope(s): pull_requests"
+check "one good one bad"       1 '{"contents": "read", "nope": "read"}' "unknown permission scope(s): nope"
+check "not JSON at all"        1 'contents=read'                 "not valid JSON"
+check "a JSON array"           1 '["contents"]'                  "must be a JSON object"
+check "a JSON string"          1 '"contents"'                    "must be a JSON object"
+
+echo
+echo "passed=$PASS failed=$FAIL"
+[[ "$FAIL" == "0" ]]

--- a/generate-github-app-token-from-vault-secrets/validate-permissions_test.sh
+++ b/generate-github-app-token-from-vault-secrets/validate-permissions_test.sh
@@ -30,6 +30,29 @@ check() { # check <label> <expected-rc> <permissions> [expected substring]
   PASS=$((PASS + 1))
 }
 
+check_without_jq() { # check_without_jq <label> <expected-rc> <permissions> [substring]
+  local label="$1" want="$2" perms="$3" needle="${4:-}"
+  local out rc
+  out="$(PATH="" "$SCRIPT" "$perms" 2>&1)"
+  rc=$?
+
+  if [[ "$rc" != "$want" ]]; then
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label — expected rc=$want, got rc=$rc"
+    echo "        output: $out"
+    return
+  fi
+
+  if [[ -n "$needle" ]] && ! grep -qF "$needle" <<<"$out"; then
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label — expected output to contain: $needle"
+    echo "        output: $out"
+    return
+  fi
+
+  PASS=$((PASS + 1))
+}
+
 echo "bash $BASH_VERSION"
 
 # Omitted or empty: the token inherits the App's permissions, as before.
@@ -68,6 +91,12 @@ check "one good one bad"       1 '{"contents": "read", "nope": "read"}' "unknown
 check "not JSON at all"        1 'contents=read'                 "not valid JSON"
 check "a JSON array"           1 '["contents"]'                  "must be a JSON object"
 check "a JSON string"          1 '"contents"'                    "must be a JSON object"
+
+# jq is only reached once the input is non-empty, so a caller that does not use
+# `permissions` needs nothing new. One that does, on a runner without jq, must
+# be told that rather than that its JSON is malformed.
+check_without_jq "no jq, input given"   1 '{"contents": "read"}' "needs jq"
+check_without_jq "no jq, input omitted" 0 ''                     ""
 
 echo
 echo "passed=$PASS failed=$FAIL"


### PR DESCRIPTION
Follow-up to the point I raised in #778 and deliberately kept out of #789.

## The gap

`repositories` scopes **which repositories** a token reaches. Nothing scoped **what it may do** to them, so a token minted for one narrow purpose carried every permission the shared App holds.

The concrete case: in `camunda/infraex-common-config`'s `report-failure-on-slack`, the token has exactly two consumers — `gh issue list` needs `issues: read` and `gh workflow run` needs `actions: write`. It receives whatever the App has on those repositories.

```yaml
    - uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
      with:
        # ... vault inputs ...
        repositories: infraex-common-config
        permissions: '{"issues": "read", "actions": "write"}'
```

## Correcting what I said in #778

I quoted a generic `permissions` input on `actions/create-github-app-token`, described as taking "a YAML or JSON object", and called this a passthrough. **There is no such input** — not at the pinned SHA, not at latest (both v3.2.0). It exposes **54 individual `permission-<scope>` inputs**. So the object has to be spread across all 54 in `with:`, which is where most of this diff goes.

## Existing callers are unaffected

Checked in upstream's `lib/get-permissions-from-inputs.js` rather than assumed:

```js
if (!key.startsWith("INPUT_PERMISSION-")) return permissions;
if (!value) return permissions;
// Inherit app permissions if no permissions inputs are set
```

Empty inputs are skipped, and if none are set the permission set stays `undefined`, so the token inherits the App's own permissions. Omitting `permissions` therefore behaves exactly as before.

## Unknown scopes are an error

A wrapper that cannot forward a scope would otherwise drop it in silence, and the caller would believe the token was narrowed when it was not — the failure mode being fixed here, reintroduced one level up.

```
::error::unknown permission scope(s): contnets
```

Keys are the upstream scope names without the `permission-` prefix, so `permission-pull-requests` is written `pull-requests`. `pull_requests` is rejected rather than ignored, which is worth having given the API itself uses underscores.

## Tests

The validation is a script rather than inline so it can be exercised directly. Through the action it could not be: a rejection and a later Vault failure both surface as "the step failed", so an end-to-end assertion would stay green even if the validation stopped rejecting anything. The workflow comment says so, to stop someone "simplifying" it later.

Twelve cases, green on bash 5.2 and on macOS bash 3.2:

| case | expected |
|---|---|
| omitted / `{}` | accepted, App permissions inherited |
| one scope, several scopes, a dashed scope | accepted |
| all 54 scopes | accepted |
| `contnets` | rejected, names the typo |
| `pull_requests` | rejected |
| one good key and one bad | rejected, names only the bad one |
| not JSON / a JSON array / a JSON string | rejected |

The "all 54 scopes" case is the drift detector between the script's list and the `with:` block. Verified by deleting `merge-queues` from the script: `passed=11 failed=1`.

## Not covered

Everything downstream of the validation needs Vault and a GitHub App, so it cannot run on a pull request. The `with:` block is mechanical and generated from upstream's `action.yml`, but it is unexercised here — the first real use of a narrowed token will be its first execution.
